### PR TITLE
fix: mobile visualization scroll cache

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- A brief summary of the issue -->
+
+## Description
+
+<!-- A detailed description of the issue, including any relevant context -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- A brief summary of the changes -->
+
+## Description
+
+<!-- A detailed explanation of the changes, including why they are needed -->

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -177,6 +177,26 @@ test('visualizes array and rolling DP examples', async ({ page, isMobile }) => {
 
     await expect(dpDialog).toBeVisible()
     await expect(dpDialog.getByText(example.table)).toBeVisible()
+
+    if (isMobile) {
+      const scrollContainer = dpDialog.locator('[data-tree-scroll-container]')
+      const layout = await scrollContainer.evaluate((element) => {
+        const containerTop = element.getBoundingClientRect().top
+        const firstChildTop =
+          element.firstElementChild?.getBoundingClientRect().top
+
+        return {
+          containerTop,
+          firstChildTop,
+          scrollTop: element.scrollTop,
+        }
+      })
+
+      expect(layout.scrollTop).toBe(0)
+      expect(layout.firstChildTop).toBeGreaterThanOrEqual(
+        layout.containerTop - 1
+      )
+    }
   }
 })
 

--- a/src/features/visualization/ui/visualization-modal.tsx
+++ b/src/features/visualization/ui/visualization-modal.tsx
@@ -184,19 +184,19 @@ export function VisualizationModal({
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="top-4 h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] translate-y-0 flex flex-col bg-background sm:top-[50%] sm:h-[min(80vh,calc(100dvh-2rem))] sm:max-w-3xl sm:translate-y-[-50%]">
-        <DialogHeader>
+        <DialogHeader className="shrink-0">
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
         <div
           className={cn(
-            'py-4 flex-1 min-h-0 overflow-y-auto',
+            'py-4 flex-1 min-h-0 overflow-y-auto overscroll-contain',
             (type === 'matrix' ||
               type === 'list-graph' ||
               type === 'dp' ||
               type === 'map') &&
-              'flex items-center justify-center'
+              'flex items-start justify-center sm:items-center'
           )}
           data-tree-scroll-container
         >
@@ -205,12 +205,14 @@ export function VisualizationModal({
 
         {executionState.isComplete &&
           !isUndefined(executionState.returnValue) && (
-            <ReturnValueCard
-              returnValue={executionState.returnValue}
-              isExpanded={isReturnValueExpanded}
-              returnValueRef={returnValueRef}
-              onExpandedChange={setIsReturnValueExpanded}
-            />
+            <div className="shrink-0">
+              <ReturnValueCard
+                returnValue={executionState.returnValue}
+                isExpanded={isReturnValueExpanded}
+                returnValueRef={returnValueRef}
+                onExpandedChange={setIsReturnValueExpanded}
+              />
+            </div>
           )}
 
         <PlaybackControls
@@ -222,7 +224,7 @@ export function VisualizationModal({
           onStepForward={onStepForward}
           onStepBackward={onStepBackward}
           onSkipToEnd={onSkipToEnd}
-          className="justify-center gap-2 pt-4 border-t mt-auto"
+          className="shrink-0 justify-center gap-2 pt-4 border-t mt-auto"
         />
       </DialogContent>
     </Dialog>

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,15 @@
   "framework": "vite",
   "headers": [
     {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## Summary

Fix mobile visualization scroll cache.

## Descripition

- Align visualization content to the top on mobile
- Keep modal headers, return values, and playback controls fixed
- Limit scrolling to the visualization area