### PR TITLE
chore: add changelog automation

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,33 @@
+name: Update Changelog
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Update changelog
+        uses: nyaomaru/changelog-bot@v0.6.5
+        with:
+          changelog-path: CHANGELOG.md
+          base-branch: main
+          provider: openai
+          npm-version: 0.6.5
+          release-tag: ${{ github.event.release.tag_name }}
+          release-name: ${{ github.event.release.tag_name }}
+          release-body: ${{ github.event.release.body }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]


### PR DESCRIPTION
## Summary

Add changelog-bot automation.

<!-- A brief summary of the changes -->

## Description

- Add an initial Keep a Changelog-compatible `CHANGELOG.md`
- Run changelog-bot when a GitHub Release is published
- Generate a pull request containing the release changelog update

<!-- A detailed explanation of the changes, including why they are needed -->
