### PR TITLE
fix: preserve traversal stack visualization

### DIFF
--- a/src/features/code-execution/external-algorithms-use-cases.test.tsx
+++ b/src/features/code-execution/external-algorithms-use-cases.test.tsx
@@ -303,6 +303,22 @@ const wordBreakCode = loadAlgorithm('dynamic-programming/word-break.ts')
 const numIslandsCode = loadAlgorithm('graphs/number-of-islands.ts')
 const floodFillCode = loadAlgorithm('matrix/flood-fill.ts')
 const maxDepthCode = loadAlgorithm('tree/max-depth.ts')
+const kthSmallestCode = `
+function kthSmallest(root: TreeNode | null, k: number): number {
+  const arr: number[] = []
+
+  function dfs(node: TreeNode | null) {
+    if (!node) return
+
+    dfs(node.left)
+    arr.push(node.val)
+    dfs(node.right)
+  }
+
+  dfs(root)
+  return arr[k - 1]
+}
+`
 const invertTreeCode = loadAlgorithm('binary-search-tree/invert-binary-tree.ts')
 const reverseListCode = loadAlgorithm('linked-list/reverse-list.ts')
 const mergeTwoListsCode = loadAlgorithm('linked-list/merge-two-lists.ts')
@@ -391,11 +407,15 @@ function completeAtStep(
   }
 }
 
-function renderVisualizer(executionState: ExecutionState) {
+function renderVisualizer(
+  executionState: ExecutionState,
+  autoOpenPrimaryVisualization = false
+) {
   render(
     <Visualizer
       executionState={executionState}
       isRunning={false}
+      autoOpenPrimaryVisualization={autoOpenPrimaryVisualization}
       onPause={noop}
       onRunAll={noop}
       onReset={noop}
@@ -755,6 +775,36 @@ describe('external algorithms use cases', () => {
     renderVisualizer(completeAtStep(state, currentStep))
 
     expect(screen.getByText('Tree Graph')).toBeInTheDocument()
+  })
+
+  it('shows a derived inorder array as the primary Stack View', () => {
+    const parameters: FunctionParameter[] = [
+      { name: 'root', type: 'tree-node', optional: false },
+      { name: 'k', type: 'number', optional: false },
+    ]
+    const inputs = convertInputValues(parameters, {
+      root: '[2,1,3]',
+      k: '2',
+    })
+    const state = executeCode(kthSmallestCode, inputs, 'kthSmallest')
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(2)
+
+    const currentStep = findVisualizationStep(
+      state,
+      (variables) => Array.isArray(variables.arr) && variables.arr.length === 3
+    )
+    renderVisualizer(
+      {
+        ...state,
+        currentStep,
+        isComplete: false,
+      },
+      true
+    )
+
+    expect(screen.getByText('Stack Visualization: arr')).toBeInTheDocument()
   })
 
   it('runs invert tree and exposes the tree graph view', () => {

--- a/src/features/visualization/lib/execution-step-search.test.ts
+++ b/src/features/visualization/lib/execution-step-search.test.ts
@@ -33,4 +33,15 @@ describe('getExecutionStepSearchOrder', () => {
       })
     ).toEqual([2, 1, 0, 3, 4])
   })
+
+  it('can exclude future steps while preserving an explicit target', () => {
+    expect(
+      getExecutionStepSearchOrder({
+        executionState,
+        targetStepIndex: 4,
+        preferPastSteps: true,
+        includeFutureSteps: false,
+      })
+    ).toEqual([2, 4, 1, 0])
+  })
 })

--- a/src/features/visualization/lib/execution-step-search.ts
+++ b/src/features/visualization/lib/execution-step-search.ts
@@ -6,6 +6,7 @@ export function getExecutionStepSearchOrder({
   executionState,
   targetStepIndex,
   preferPastSteps = false,
+  includeFutureSteps = true,
 }: {
   /** Execution state whose steps should be searched. */
   executionState: ExecutionState
@@ -13,12 +14,16 @@ export function getExecutionStepSearchOrder({
   targetStepIndex?: number
   /** Whether past steps should be searched before future steps. */
   preferPastSteps?: boolean
+  /** Whether surrounding steps after the current step should be searched. */
+  includeFutureSteps?: boolean
 }): number[] {
   const { currentStep, steps } = executionState
-  const futureStepIndexes = Array.from(
-    { length: Math.max(0, steps.length - currentStep - 1) },
-    (_, index) => currentStep + index + 1
-  )
+  const futureStepIndexes = includeFutureSteps
+    ? Array.from(
+        { length: Math.max(0, steps.length - currentStep - 1) },
+        (_, index) => currentStep + index + 1
+      )
+    : []
   const pastStepIndexes = Array.from(
     { length: Math.max(0, currentStep) },
     (_, index) => currentStep - index - 1

--- a/src/features/visualization/model/visualization-detection/array-candidates.ts
+++ b/src/features/visualization/model/visualization-detection/array-candidates.ts
@@ -10,6 +10,7 @@ import { isDpVariableName } from '../../lib/dp-view'
 import {
   isResultLikeName,
   isResultVariableName,
+  isTraversalWorklistName,
   isWorkingPathName,
 } from './variables'
 import type { VariableEntries } from './types'
@@ -56,6 +57,23 @@ export function getPrimaryStackName(
       (!isNumericArray(value) ||
         (options.includeNumericResultArrays &&
           options.mutatedNumericArrayNames?.has(name)))
+  )?.[0]
+}
+
+export function getPrimaryTraversalResultArrayName(
+  variableEntries: VariableEntries,
+  initialVariableNames: Set<string>,
+  mutatedNumericArrayNames: Set<string>
+): string | undefined {
+  return variableEntries.find(
+    ([name, value]) =>
+      !initialVariableNames.has(name) &&
+      !isWorkingPathName(name) &&
+      !isTraversalWorklistName(name) &&
+      !isDpVariableName(name.toLowerCase()) &&
+      isNumericArray(value) &&
+      value.length > 0 &&
+      mutatedNumericArrayNames.has(name)
   )?.[0]
 }
 

--- a/src/features/visualization/model/visualization-detection/detect-visualization-state.test.ts
+++ b/src/features/visualization/model/visualization-detection/detect-visualization-state.test.ts
@@ -117,6 +117,25 @@ describe('detectVisualizationState', () => {
     expect(detectVisualizationState(state).primaryStackName).toBe('answer')
   })
 
+  it('selects a derived traversal array regardless of its variable name', () => {
+    const root = {
+      val: 2,
+      left: { val: 1, left: null, right: null },
+      right: { val: 3, left: null, right: null },
+    }
+    const state = createExecutionState([
+      createStep(0, 'Function called', { root, k: 2 }),
+      createStep(1, 'const arr = []', { root, k: 2, arr: [] }),
+      createStep(2, 'arr.push(node.val)', {
+        root,
+        k: 2,
+        arr: [1, 2, 3],
+      }),
+    ])
+
+    expect(detectVisualizationState(state).primaryStackName).toBe('arr')
+  })
+
   it('selects height for a trapping-rain-water area view', () => {
     const state = createExecutionState([
       createStep(0, 'Function called', {

--- a/src/features/visualization/model/visualization-detection/detect-visualization-state.ts
+++ b/src/features/visualization/model/visualization-detection/detect-visualization-state.ts
@@ -7,6 +7,7 @@ import {
   getPrimaryDpArrayName,
   getPrimaryGraphName,
   getPrimaryStackName,
+  getPrimaryTraversalResultArrayName,
   hasInitialTreeNodeVariable,
 } from './array-candidates'
 import {
@@ -51,8 +52,12 @@ export function detectVisualizationState(
     getInitialVariableContext(executionState)
   const metadata = collectVisualizationMutationMetadata(executionState)
   const hasSort = hasSortTrace(executionState)
+  const hasInitialTreeNode = hasInitialTreeNodeVariable(
+    variableEntries,
+    initialVariableNames
+  )
   const prefersResultStack =
-    hasInitialTreeNodeVariable(variableEntries, initialVariableNames) &&
+    hasInitialTreeNode &&
     variableEntries.some(
       ([name, value]) => isResultLikeName(name) && isNumericArray(value)
     )
@@ -62,10 +67,18 @@ export function detectVisualizationState(
     metadata.mutatedNumericArrayNames,
     { excludeResultLikeArrays: prefersResultStack }
   )
-  const primaryStackName = getPrimaryStackName(variableEntries, {
-    includeNumericResultArrays: prefersResultStack || !hasSort,
-    mutatedNumericArrayNames: metadata.mutatedNumericArrayNames,
-  })
+  const primaryStackName =
+    getPrimaryStackName(variableEntries, {
+      includeNumericResultArrays: prefersResultStack || !hasSort,
+      mutatedNumericArrayNames: metadata.mutatedNumericArrayNames,
+    }) ??
+    (hasInitialTreeNode
+      ? getPrimaryTraversalResultArrayName(
+          variableEntries,
+          initialVariableNames,
+          metadata.mutatedNumericArrayNames
+        )
+      : undefined)
   const primaryBinarySearchCandidate = getPrimaryBinarySearchCandidate(
     executionState,
     initialVariableNames

--- a/src/features/visualization/ui/visualization-modal-content.tsx
+++ b/src/features/visualization/ui/visualization-modal-content.tsx
@@ -100,6 +100,7 @@ function findArrayStep({
     executionState,
     targetStepIndex,
     preferPastSteps: true,
+    includeFutureSteps: false,
   })
 
   for (const index of orderedIndexes) {

--- a/src/features/visualization/ui/visualization-modal-content.tsx
+++ b/src/features/visualization/ui/visualization-modal-content.tsx
@@ -84,6 +84,35 @@ function findNumericArrayStep({
   return undefined
 }
 
+function findArrayStep({
+  executionState,
+  variableName,
+  targetStepIndex,
+}: {
+  /** Execution state whose steps should be searched. */
+  executionState: ExecutionState
+  /** Array variable name to find. */
+  variableName: string
+  /** Preferred step index to check before surrounding steps. */
+  targetStepIndex?: number
+}): ExecutionStepSnapshot | undefined {
+  const orderedIndexes = getExecutionStepSearchOrder({
+    executionState,
+    targetStepIndex,
+    preferPastSteps: true,
+  })
+
+  for (const index of orderedIndexes) {
+    const step = executionState.steps[index]
+
+    if (step && isArray(step.variables[variableName])) {
+      return step
+    }
+  }
+
+  return undefined
+}
+
 function findTreeNodeStep({
   executionState,
   variableName,
@@ -149,7 +178,11 @@ export function VisualizationModalContent({
 
   switch (type) {
     case 'stack': {
-      const data = getCurrentStepVariable(targetVariable)
+      const data = findArrayStep({
+        executionState,
+        variableName: targetVariable,
+        targetStepIndex,
+      })?.variables[targetVariable]
 
       return isArray(data) ? (
         <StackVisualizer data={data} name={targetVariable} />

--- a/src/features/visualization/ui/visualizer.test.tsx
+++ b/src/features/visualization/ui/visualizer.test.tsx
@@ -2210,6 +2210,95 @@ describe('Visualizer return value display', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('keeps a derived traversal stack visible after the variable leaves scope', async () => {
+    const root = {
+      val: 2,
+      left: { val: 1, left: null, right: null },
+      right: { val: 3, left: null, right: null },
+    }
+    const steps: ExecutionState['steps'] = [
+      {
+        stepNumber: 0,
+        type: 'function-entry',
+        line: 1,
+        description: 'Entering function: kthSmallest',
+        variables: { root, k: 2 },
+        timestamp: Date.now(),
+        callStack: ['root', 'kthSmallest'],
+      },
+      {
+        stepNumber: 1,
+        type: 'variable-declaration',
+        line: 2,
+        description: 'const arr = []',
+        variables: { root, k: 2, arr: [] },
+        timestamp: Date.now(),
+        callStack: ['root', 'kthSmallest'],
+      },
+      {
+        stepNumber: 2,
+        type: 'array-mutation',
+        line: 10,
+        description: 'arr.push(node.val)',
+        variables: { root, k: 2, arr: [1, 2, 3] },
+        timestamp: Date.now(),
+        callStack: ['root', 'kthSmallest', 'dfs'],
+      },
+      {
+        stepNumber: 3,
+        type: 'return',
+        line: 15,
+        description: 'return arr[k - 1]',
+        variables: { root, k: 2 },
+        timestamp: Date.now(),
+        callStack: ['root'],
+      },
+    ]
+    const initialState: ExecutionState = {
+      currentStep: 2,
+      totalSteps: steps.length,
+      steps,
+      isComplete: false,
+    }
+    const visualizerProps = {
+      isRunning: false,
+      autoOpenPrimaryVisualization: true,
+      onPause: noop,
+      onRunAll: noop,
+      onReset: noop,
+      onStepForward: noop,
+      onStepBackward: noop,
+      onSkipToEnd: noop,
+      onJumpToStep: noop,
+    }
+    const { rerender } = render(
+      <Visualizer executionState={initialState} {...visualizerProps} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Stack Visualization: arr')).toBeInTheDocument()
+    })
+
+    rerender(
+      <Visualizer
+        executionState={{
+          ...initialState,
+          currentStep: 3,
+          isComplete: true,
+          returnValue: 2,
+        }}
+        {...visualizerProps}
+      />
+    )
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).queryByText('Variable is not an array')).toBeNull()
+    expect(within(dialog).getByText('Return Value')).toBeInTheDocument()
+    expect(within(dialog).getByText('1')).toBeInTheDocument()
+    expect(within(dialog).getAllByText('2')).toHaveLength(2)
+    expect(within(dialog).getByText('3')).toBeInTheDocument()
+  })
+
   it('prefers result arrays over path arrays for the primary sort bar chart', () => {
     const steps: ExecutionState['steps'] = [
       {

--- a/src/features/visualization/ui/visualizer.test.tsx
+++ b/src/features/visualization/ui/visualizer.test.tsx
@@ -2283,6 +2283,22 @@ describe('Visualizer return value display', () => {
       <Visualizer
         executionState={{
           ...initialState,
+          currentStep: 0,
+        }}
+        {...visualizerProps}
+      />
+    )
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Variable is not an array')).toBeVisible()
+    expect(within(dialog).queryByText('1')).not.toBeInTheDocument()
+    expect(within(dialog).queryByText('2')).not.toBeInTheDocument()
+    expect(within(dialog).queryByText('3')).not.toBeInTheDocument()
+
+    rerender(
+      <Visualizer
+        executionState={{
+          ...initialState,
           currentStep: 3,
           isComplete: true,
           returnValue: 2,
@@ -2291,7 +2307,6 @@ describe('Visualizer return value display', () => {
       />
     )
 
-    const dialog = screen.getByRole('dialog')
     expect(within(dialog).queryByText('Variable is not an array')).toBeNull()
     expect(within(dialog).getByText('Return Value')).toBeInTheDocument()
     expect(within(dialog).getByText('1')).toBeInTheDocument()


### PR DESCRIPTION
## Summary

Preserve traversal stack visualization.

<!-- A brief summary of the changes -->

## Description

- Detect derived TreeNode traversal arrays regardless of variable name
- Show arrays such as `arr` as the primary Stack View
- Exclude working arrays such as `path`, `stack`, `queue`, and `dp`

<!-- A detailed explanation of the changes, including why they are needed -->
