### PR TITLE
feat: visualize abbreviated sliding windows

### DIFF
--- a/src/features/code-execution/external-algorithms-use-cases.test.tsx
+++ b/src/features/code-execution/external-algorithms-use-cases.test.tsx
@@ -298,6 +298,47 @@ function maxArea(height: number[]): number {
   return best
 }
 `
+const minWindowCode = `
+function minWindow(s: string, t: string): string {
+  if (t.length === 0 || s.length === 0) return ''
+
+  const need = new Map<string, number>()
+  for (const char of t) {
+    need.set(char, (need.get(char) || 0) + 1)
+  }
+
+  const have = new Map<string, number>()
+  const required = need.size
+  let formed = 0
+  let l = 0
+  let bestLen = Infinity
+  let bestL = 0
+
+  for (let r = 0; r < s.length; r++) {
+    const char = s[r]
+    have.set(char, (have.get(char) || 0) + 1)
+
+    if (need.has(char) && have.get(char) === need.get(char)) formed++
+
+    while (l <= r && formed === required) {
+      const windowLen = r - l + 1
+      if (windowLen < bestLen) {
+        bestLen = windowLen
+        bestL = l
+      }
+
+      const leftChar = s[l]
+      have.set(leftChar, have.get(leftChar)! - 1)
+      if (need.has(leftChar) && have.get(leftChar)! < need.get(leftChar)) {
+        formed--
+      }
+      l++
+    }
+  }
+
+  return bestLen === Infinity ? '' : s.slice(bestL, bestL + bestLen)
+}
+`
 const mySqrtCode = loadAlgorithm('math/my-sqrt.ts')
 const wordBreakCode = loadAlgorithm('dynamic-programming/word-break.ts')
 const numIslandsCode = loadAlgorithm('graphs/number-of-islands.ts')
@@ -598,6 +639,45 @@ describe('external algorithms use cases', () => {
 
     expectNoStructureView()
     expect(screen.getByText('Return Value')).toBeInTheDocument()
+  })
+
+  it('runs minimum window substring and exposes the sliding window view', () => {
+    const parameters: FunctionParameter[] = [
+      { name: 's', type: 'string', optional: false },
+      { name: 't', type: 'string', optional: false },
+    ]
+    const inputs = convertInputValues(parameters, {
+      s: 'ADOBECODEBANC',
+      t: 'ABC',
+    })
+    const state = executeCode(minWindowCode, inputs, 'minWindow')
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe('BANC')
+
+    const currentStep = findVisualizationStep(state, (variables) => {
+      const left = variables.l
+      const right = variables.r
+
+      return (
+        Number.isInteger(left) &&
+        Number.isInteger(right) &&
+        Number(left) <= Number(right)
+      )
+    })
+    renderVisualizer(
+      {
+        ...state,
+        currentStep,
+        isComplete: false,
+      },
+      true
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Sliding Window View: s' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('pattern: ABC')).toBeInTheDocument()
   })
 
   it('runs trapping rain water and exposes the area view', () => {

--- a/src/features/visualization/lib/sliding-window-view.test.ts
+++ b/src/features/visualization/lib/sliding-window-view.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { getSlidingWindowState } from './sliding-window-view'
+
+describe('getSlidingWindowState', () => {
+  it('recognizes abbreviated boundaries and a t pattern', () => {
+    expect(
+      getSlidingWindowState('ADOBECODEBANC', {
+        s: 'ADOBECODEBANC',
+        t: 'ABC',
+        l: 0,
+        r: 5,
+      })
+    ).toEqual({
+      left: 0,
+      right: 5,
+      pattern: 'ABC',
+    })
+  })
+})

--- a/src/features/visualization/lib/sliding-window-view.ts
+++ b/src/features/visualization/lib/sliding-window-view.ts
@@ -2,7 +2,7 @@ import type { ExecutionState, ExecutionStep } from '@/entities/execution'
 import { isInteger, isNull, isString } from '@/shared/lib/guards'
 
 const STRING_SOURCE_NAMES = new Set(['s', 'str', 'text'])
-const PATTERN_SOURCE_NAMES = ['p', 'pattern', 'word'] as const
+const PATTERN_SOURCE_NAMES = ['p', 'pattern', 't', 'word'] as const
 
 /** Window boundaries and optional pattern metadata for one execution step. */
 export type SlidingWindowState = {
@@ -57,8 +57,8 @@ export function getSlidingWindowState(
 ): SlidingWindowState | null {
   if (!isString(value) || value.length === 0) return null
 
-  const left = variables.left
-  const right = variables.right
+  const left = variables.left ?? variables.l
+  const right = variables.right ?? variables.r
 
   if (!isInteger(left) || !isInteger(right)) {
     return null


### PR DESCRIPTION
## Summary

Visualize abbreviated sliding windows.

<!-- A brief summary of the changes -->

## Description

 - Recognize `l` and `r` as sliding-window boundary aliases

<!-- A detailed explanation of the changes, including why they are needed -->
