### PR TITLE
feat: add built-in min and max heaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ to _view_ why the answer changes.
   Arrays become bars, matrices become grids, trees become node graphs, linked lists become chains, and two-pointer area problems get their own visual view.
 
 - 🌳 **DSA-friendly inputs out of the box**<br />
-  `TreeNode`, `ListNode`, nested arrays, matrices, strings, numbers, and class
-  style inputs are supported without ceremony.
+  `TreeNode`, `ListNode`, `MinHeap`, `MaxHeap`, `PriorityQueue`, nested arrays,
+  matrices, strings, numbers, and class-style inputs are supported without
+  ceremony.
 
 - 🔎 **39 built-in examples**<br />
   Search by name, browse by category, and jump into classics like Two Sum,

--- a/src/entities/code/index.ts
+++ b/src/entities/code/index.ts
@@ -26,3 +26,4 @@ export {
   isParamTypeStringMatrix,
   isParamTypeTreeNode,
 } from './model/parameter-type'
+export { isPreparedTypeScriptClassName } from './model/prepared-class-name'

--- a/src/entities/code/lib/prepared-typescript-classes.ts
+++ b/src/entities/code/lib/prepared-typescript-classes.ts
@@ -254,6 +254,152 @@ class PriorityQueue<T> {
 }`,
   },
   {
+    name: 'MinHeap',
+    source: `
+class MinHeap {
+  private values: number[] = []
+
+  size(): number {
+    return this.values.length
+  }
+
+  isEmpty(): boolean {
+    return this.values.length === 0
+  }
+
+  peek(): number {
+    if (this.values.length === 0) throw new Error('Cannot peek an empty MinHeap')
+    return this.values[0]
+  }
+
+  push(value: number): void {
+    this.values.push(value)
+    this.bubbleUp(this.values.length - 1)
+  }
+
+  pop(): number {
+    if (this.values.length === 0) throw new Error('Cannot pop an empty MinHeap')
+    const top = this.values[0]
+    const last = this.values.pop()!
+
+    if (this.values.length > 0) {
+      this.values[0] = last
+      this.bubbleDown(0)
+    }
+
+    return top
+  }
+
+  private bubbleUp(index: number): void {
+    while (index > 0) {
+      const parent = Math.floor((index - 1) / 2)
+      if (this.values[parent] <= this.values[index]) break
+      ;[this.values[parent], this.values[index]] = [this.values[index], this.values[parent]]
+      index = parent
+    }
+  }
+
+  private bubbleDown(index: number): void {
+    while (true) {
+      const left = index * 2 + 1
+      const right = index * 2 + 2
+      let smallest = index
+
+      if (
+        left < this.values.length &&
+        this.values[left] < this.values[smallest]
+      ) {
+        smallest = left
+      }
+
+      if (
+        right < this.values.length &&
+        this.values[right] < this.values[smallest]
+      ) {
+        smallest = right
+      }
+
+      if (smallest === index) break
+      ;[this.values[index], this.values[smallest]] = [this.values[smallest], this.values[index]]
+      index = smallest
+    }
+  }
+}`,
+  },
+  {
+    name: 'MaxHeap',
+    source: `
+class MaxHeap {
+  private values: number[] = []
+
+  size(): number {
+    return this.values.length
+  }
+
+  isEmpty(): boolean {
+    return this.values.length === 0
+  }
+
+  peek(): number {
+    if (this.values.length === 0) throw new Error('Cannot peek an empty MaxHeap')
+    return this.values[0]
+  }
+
+  push(value: number): void {
+    this.values.push(value)
+    this.bubbleUp(this.values.length - 1)
+  }
+
+  pop(): number {
+    if (this.values.length === 0) throw new Error('Cannot pop an empty MaxHeap')
+    const top = this.values[0]
+    const last = this.values.pop()!
+
+    if (this.values.length > 0) {
+      this.values[0] = last
+      this.bubbleDown(0)
+    }
+
+    return top
+  }
+
+  private bubbleUp(index: number): void {
+    while (index > 0) {
+      const parent = Math.floor((index - 1) / 2)
+      if (this.values[parent] >= this.values[index]) break
+      ;[this.values[parent], this.values[index]] = [this.values[index], this.values[parent]]
+      index = parent
+    }
+  }
+
+  private bubbleDown(index: number): void {
+    while (true) {
+      const left = index * 2 + 1
+      const right = index * 2 + 2
+      let largest = index
+
+      if (
+        left < this.values.length &&
+        this.values[left] > this.values[largest]
+      ) {
+        largest = left
+      }
+
+      if (
+        right < this.values.length &&
+        this.values[right] > this.values[largest]
+      ) {
+        largest = right
+      }
+
+      if (largest === index) break
+      ;[this.values[index], this.values[largest]] = [this.values[largest], this.values[index]]
+      index = largest
+    }
+  }
+}`,
+  },
+  {
     name: 'Deque',
     source: `
 class Deque<T> {

--- a/src/entities/code/lib/prepared-typescript-classes.ts
+++ b/src/entities/code/lib/prepared-typescript-classes.ts
@@ -1,4 +1,5 @@
 import { parse } from '@babel/parser'
+import { isPreparedTypeScriptClassName } from '../model/prepared-class-name'
 
 /**
  * Built-in class definition injected when user code references a common DSA type.
@@ -610,10 +611,6 @@ class Counter<T> {
   },
 ]
 
-const PREPARED_CLASS_NAMES = new Set(
-  PREPARED_CLASSES.map((definition) => definition.name)
-)
-
 const PARSER_OPTIONS = {
   sourceType: 'module' as const,
   plugins: ['typescript' as const],
@@ -684,11 +681,11 @@ function stripPreparedClassImports(code: string): string {
       .forEach((node) => {
         const importsPreparedClass = node.specifiers.some((specifier) => {
           if (specifier.type === 'ImportDefaultSpecifier') {
-            return PREPARED_CLASS_NAMES.has(specifier.local.name)
+            return isPreparedTypeScriptClassName(specifier.local.name)
           }
 
           if (specifier.type === 'ImportSpecifier') {
-            return PREPARED_CLASS_NAMES.has(specifier.local.name)
+            return isPreparedTypeScriptClassName(specifier.local.name)
           }
 
           return false

--- a/src/entities/code/model/prepared-class-name.ts
+++ b/src/entities/code/model/prepared-class-name.ts
@@ -1,0 +1,21 @@
+import { oneOfValues } from '@/shared/lib/guards'
+
+/** Recognizes built-in DSA class names that usually act as solution helpers. */
+export const isPreparedTypeScriptClassName = oneOfValues(
+  'TreeNode',
+  'ListNode',
+  'TrieNode',
+  '_Node',
+  'GraphNode',
+  'NaryNode',
+  'RandomListNode',
+  'DoublyListNode',
+  'Node',
+  'PriorityQueue',
+  'MinHeap',
+  'MaxHeap',
+  'Deque',
+  'UnionFind',
+  'DSU',
+  'Counter'
+)

--- a/src/features/code-editing/lib/parser.test.ts
+++ b/src/features/code-editing/lib/parser.test.ts
@@ -179,6 +179,42 @@ class MinHeap {
     })
   })
 
+  it('prefers a later design class over an earlier behavioral helper', () => {
+    const signature = extractFunctionSignature(`
+class DoublyLinkedList {
+  add(value: number): void {}
+  remove(value: number): void {}
+}
+
+class LRUCache {
+  get(key: number): number { return -1 }
+  put(key: number, value: number): void {}
+  has(key: number): boolean { return false }
+}
+`)
+
+    expect(signature).toMatchObject({
+      kind: 'class',
+      name: 'LRUCache',
+      methods: [{ name: 'get' }, { name: 'put' }, { name: 'has' }],
+    })
+  })
+
+  it('uses a lone prepared class override as the design target', () => {
+    const signature = extractFunctionSignature(`
+class MinHeap {
+  push(value: number): void {}
+  pop(): number { return 0 }
+}
+`)
+
+    expect(signature).toMatchObject({
+      kind: 'class',
+      name: 'MinHeap',
+      methods: [{ name: 'push' }, { name: 'pop' }],
+    })
+  })
+
   it('detects returned function parameters for LeetCode factory solutions', () => {
     const signature = extractFunctionSignature(`
 function isBadVersion(n: number): boolean {

--- a/src/features/code-editing/lib/parser.test.ts
+++ b/src/features/code-editing/lib/parser.test.ts
@@ -157,6 +157,28 @@ class LRUCache {
     })
   })
 
+  it('keeps the first design class ahead of later behavioral helpers', () => {
+    const signature = extractFunctionSignature(`
+class MedianFinder {
+  addNum(num: number): void {}
+  findMedian(): number { return 0 }
+}
+
+class MinHeap {
+  size(): number { return 0 }
+  peek(): number | undefined { return undefined }
+  push(value: number): void {}
+  pop(): number | undefined { return undefined }
+}
+`)
+
+    expect(signature).toMatchObject({
+      kind: 'class',
+      name: 'MedianFinder',
+      methods: [{ name: 'addNum' }, { name: 'findMedian' }],
+    })
+  })
+
   it('detects returned function parameters for LeetCode factory solutions', () => {
     const signature = extractFunctionSignature(`
 function isBadVersion(n: number): boolean {

--- a/src/features/code-editing/lib/typescript-parser.ts
+++ b/src/features/code-editing/lib/typescript-parser.ts
@@ -288,7 +288,9 @@ function shouldPreferClassSignature(
 ): boolean {
   if (!current) return true
 
-  return (candidate.methods?.length ?? 0) > (current.methods?.length ?? 0)
+  return (
+    (current.methods?.length ?? 0) === 0 && (candidate.methods?.length ?? 0) > 0
+  )
 }
 
 /**

--- a/src/features/code-editing/lib/typescript-parser.ts
+++ b/src/features/code-editing/lib/typescript-parser.ts
@@ -12,10 +12,11 @@ import type {
   TypeAnnotation,
 } from '@babel/types'
 
-import type {
-  ClassMethodSignature,
-  FunctionSignature,
-  FunctionParameter,
+import {
+  isPreparedTypeScriptClassName,
+  type ClassMethodSignature,
+  type FunctionParameter,
+  type FunctionSignature,
 } from '@/entities/code'
 import { define, hasKey, isObject, oneOfValues } from '@/shared/lib/guards'
 import {
@@ -288,9 +289,14 @@ function shouldPreferClassSignature(
 ): boolean {
   if (!current) return true
 
-  return (
-    (current.methods?.length ?? 0) === 0 && (candidate.methods?.length ?? 0) > 0
-  )
+  const candidateIsPrepared = isPreparedTypeScriptClassName(candidate.name)
+  const currentIsPrepared = isPreparedTypeScriptClassName(current.name)
+
+  if (candidateIsPrepared !== currentIsPrepared) {
+    return currentIsPrepared
+  }
+
+  return (candidate.methods?.length ?? 0) > (current.methods?.length ?? 0)
 }
 
 /**

--- a/src/features/code-execution/lib/prepared-typescript-classes.integration.test.ts
+++ b/src/features/code-execution/lib/prepared-typescript-classes.integration.test.ts
@@ -4,6 +4,7 @@ import {
   compileTypeScriptCode,
   getPreparedTypeScriptEditorClassSource,
 } from '@/entities/code/lib'
+import { createClassDesignInput } from './class-design-input'
 import { executeCode } from './runner'
 
 describe('prepared classes', () => {
@@ -89,6 +90,18 @@ function reverseList(head: ListNode | null): ListNode | null {
 `)
 
     expect(source).toContain('class ListNode')
+  })
+
+  it('provides editor declarations for MinHeap and MaxHeap', () => {
+    const source = getPreparedTypeScriptEditorClassSource(`
+class MedianFinder {
+  private minHeap = new MinHeap()
+  private maxHeap = new MaxHeap()
+}
+`)
+
+    expect(source).toContain('class MinHeap')
+    expect(source).toContain('class MaxHeap')
   })
 
   it('provides editor declarations for _Node in clone-graph code', () => {
@@ -233,6 +246,53 @@ function topTwo(): number[] {
 
     expect(state.error).toBeUndefined()
     expect(state.returnValue).toEqual([5, 3])
+  })
+
+  it('executes MedianFinder with prepared MinHeap and MaxHeap', () => {
+    const code = `
+class MedianFinder {
+  private minHeap
+  private maxHeap
+
+  constructor() {
+    this.minHeap = new MinHeap()
+    this.maxHeap = new MaxHeap()
+  }
+
+  addNum(num: number): void {
+    this.maxHeap.push(num)
+    this.minHeap.push(this.maxHeap.pop())
+
+    if (this.minHeap.size() > this.maxHeap.size()) {
+      this.maxHeap.push(this.minHeap.pop())
+    }
+  }
+
+  findMedian(): number {
+    if (this.maxHeap.size() > this.minHeap.size()) {
+      return this.maxHeap.peek()
+    }
+
+    return (this.maxHeap.peek() + this.minHeap.peek()) / 2
+  }
+}
+`
+    const inputs = createClassDesignInput(
+      'MedianFinder',
+      [
+        'MedianFinder',
+        'addNum',
+        'addNum',
+        'findMedian',
+        'addNum',
+        'findMedian',
+      ],
+      [[], [1], [2], [], [3], []]
+    )
+    const state = executeCode(code, inputs, 'MedianFinder')
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([null, null, null, 1.5, null, 2])
   })
 
   it('executes sliding-window style code with prepared Deque', () => {

--- a/src/widgets/control-panel/ui/editor-tab-content.test.tsx
+++ b/src/widgets/control-panel/ui/editor-tab-content.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+import { EditorTabContent } from './editor-tab-content'
+
+const baseProps = {
+  algorithmExamples: [{ id: 'two-sum', label: 'Two Sum' }],
+  selectedExampleId: 'two-sum',
+  compilationResult: null,
+  onExampleChange: vi.fn(),
+  onCompile: vi.fn(),
+}
+
+describe('EditorTabContent', () => {
+  it('allows compilation with warnings but blocks errors', () => {
+    const { rerender } = render(
+      <EditorTabContent
+        {...baseProps}
+        lintErrors={[
+          {
+            line: 2,
+            column: 11,
+            message: "Member 'minHeap' implicitly has an 'any' type",
+            severity: 'warning',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Compile Code' })).toBeEnabled()
+
+    rerender(
+      <EditorTabContent
+        {...baseProps}
+        lintErrors={[
+          {
+            line: 10,
+            column: 5,
+            message: 'This expression is not callable',
+            severity: 'error',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Compile Code' })).toBeDisabled()
+  })
+})

--- a/src/widgets/control-panel/ui/editor-tab-content.tsx
+++ b/src/widgets/control-panel/ui/editor-tab-content.tsx
@@ -11,6 +11,10 @@ export function EditorTabContent({
   onExampleChange,
   onCompile,
 }: EditorTabContentProps) {
+  const hasLintErrors = lintErrors.some(
+    (lintError) => lintError.severity === 'error'
+  )
+
   return (
     <div className="flex h-auto flex-col p-6 lg:h-full">
       <div className="flex-none mb-6 space-y-4">
@@ -26,7 +30,7 @@ export function EditorTabContent({
         </Stack>
         <Button
           onClick={onCompile}
-          disabled={lintErrors.length > 0}
+          disabled={hasLintErrors}
           className="w-full shadow-lg hover:shadow-xl transition-all h-11 text-base font-semibold"
         >
           Compile Code


### PR DESCRIPTION
## Summary

Add built-in min and max heaps.

<!-- A brief summary of the changes -->

## Description

- Add built-in numeric `MinHeap` and `MaxHeap` classes
- Support `size()`, `isEmpty()`, `peek()`, `push()`, and `pop()`
- Make the classes available to Monaco and the runtime without user definitions
- Keep the first design class as the execution target when helper classes follow it

<!-- A detailed explanation of the changes, including why they are needed -->
