### PR TITLE
feat: improve step playback discoverability

### DIFF
--- a/src/features/visualization/ui/return-value-card.tsx
+++ b/src/features/visualization/ui/return-value-card.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown, ChevronLeft, ChevronUp } from 'lucide-react'
 import { Button, Card, CardContent, CardHeader, CardTitle } from '@/shared/ui'
 import { isInlineReturnValue, stringifyValue } from '../lib/value-formatting'
 import type { RefObject } from 'react'
@@ -15,6 +15,8 @@ type ReturnValueCardProps = {
   returnValueRef: RefObject<HTMLDivElement | null>
   /** Callback when the detail expansion state changes. */
   onExpandedChange: (isExpanded: boolean) => void
+  /** Moves playback to the previous step when step review is available. */
+  onStepBackward?: () => void
 }
 
 export function ReturnValueCard({
@@ -22,6 +24,7 @@ export function ReturnValueCard({
   isExpanded,
   returnValueRef,
   onExpandedChange,
+  onStepBackward,
 }: ReturnValueCardProps) {
   const shouldInlineReturnValue = isInlineReturnValue(returnValue)
 
@@ -45,19 +48,42 @@ export function ReturnValueCard({
           </Button>
         )}
       </CardHeader>
-      <CardContent>
-        {shouldInlineReturnValue ? (
-          <code className="font-mono text-sm">
-            {stringifyValue(returnValue)}
-          </code>
-        ) : isExpanded ? (
-          <code className="font-mono text-sm">
-            {stringifyValue(returnValue)}
-          </code>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            Return value hidden. Open details to inspect it.
-          </p>
+      <CardContent className="space-y-4">
+        <div>
+          {shouldInlineReturnValue ? (
+            <code className="font-mono text-sm">
+              {stringifyValue(returnValue)}
+            </code>
+          ) : isExpanded ? (
+            <code className="font-mono text-sm">
+              {stringifyValue(returnValue)}
+            </code>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Return value hidden. Open details to inspect it.
+            </p>
+          )}
+        </div>
+        {onStepBackward && (
+          <div className="flex flex-col gap-3 rounded-md border border-primary/25 bg-primary/5 p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">
+                Want to see how this result was reached?
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Use Step Backward to review the execution one step at a time.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="shrink-0 gap-1"
+              onClick={onStepBackward}
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Step Backward
+            </Button>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/features/visualization/ui/visualization-modal.tsx
+++ b/src/features/visualization/ui/visualization-modal.tsx
@@ -221,6 +221,9 @@ export function VisualizationModal({
                 isExpanded={isReturnValueExpanded}
                 returnValueRef={returnValueRef}
                 onExpandedChange={setIsReturnValueExpanded}
+                onStepBackward={
+                  executionState.totalSteps > 1 ? onStepBackward : undefined
+                }
               />
             </div>
           )}

--- a/src/features/visualization/ui/visualizer.test.tsx
+++ b/src/features/visualization/ui/visualizer.test.tsx
@@ -5,7 +5,7 @@ import {
   waitFor,
   within,
 } from '@testing-library/react'
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it, vi } from 'vite-plus/test'
 
 import type { ExecutionState } from '@/entities/execution'
 
@@ -156,6 +156,70 @@ describe('Visualizer return value display', () => {
         'Return value hidden. Open details to inspect it.'
       )
     ).not.toBeInTheDocument()
+    expect(
+      within(returnCard as HTMLElement).queryByText(
+        'Want to see how this result was reached?'
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  it('offers step-by-step review after a multi-step execution completes', () => {
+    const onStepBackward = vi.fn()
+    const steps: ExecutionState['steps'] = [
+      {
+        stepNumber: 0,
+        type: 'function-call',
+        line: 1,
+        description: 'Entering function: add',
+        variables: { total: 0 },
+        timestamp: Date.now(),
+        callStack: ['root', 'add'],
+      },
+      {
+        stepNumber: 1,
+        type: 'return',
+        line: 2,
+        description: 'Returned',
+        variables: { total: 3 },
+        timestamp: Date.now(),
+        callStack: ['root'],
+      },
+    ]
+
+    render(
+      <Visualizer
+        executionState={{
+          ...createExecutionStateWithSteps(steps),
+          returnValue: 3,
+        }}
+        isRunning={false}
+        onPause={noop}
+        onRunAll={noop}
+        onReset={noop}
+        onStepForward={noop}
+        onStepBackward={onStepBackward}
+        onSkipToEnd={noop}
+        onJumpToStep={noop}
+      />
+    )
+
+    const returnCard = screen
+      .getByText('Return Value')
+      .closest('.border-primary')
+
+    expect(
+      within(returnCard as HTMLElement).getByText(
+        'Want to see how this result was reached?'
+      )
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      within(returnCard as HTMLElement).getByRole('button', {
+        name: 'Step Backward',
+      })
+    )
+
+    expect(onStepBackward).toHaveBeenCalledOnce()
   })
 
   it('shows the final return value inside an open visualization modal', () => {
@@ -207,6 +271,11 @@ describe('Visualizer return value display', () => {
     expect(returnCard).not.toBeNull()
     expect(
       within(returnCard as HTMLElement).getByText('42')
+    ).toBeInTheDocument()
+    expect(
+      within(returnCard as HTMLElement).getByText(
+        'Want to see how this result was reached?'
+      )
     ).toBeInTheDocument()
   })
 

--- a/src/features/visualization/ui/visualizer.tsx
+++ b/src/features/visualization/ui/visualizer.tsx
@@ -266,6 +266,9 @@ export function Visualizer({
             isExpanded={isReturnValueExpanded}
             returnValueRef={returnValueRef}
             onExpandedChange={setIsReturnValueExpanded}
+            onStepBackward={
+              executionState.totalSteps > 1 ? onStepBackward : undefined
+            }
           />
         )}
       <VisualizationModal


### PR DESCRIPTION
## Summary

Improve step playback discoverability.

<!-- A brief summary of the changes -->

## Description

This PR addresses [feedback from Hacker News](https://news.ycombinator.com/item?id=48947766) that step-by-step execution was difficult to discover.

- show contextual guidance after a multi-step execution completes
- provide a clickable Step Backward action below the return value
- display the guidance in both the Runtime view and visualization modal

<!-- A detailed explanation of the changes, including why they are needed -->
