### PR TITLE
chore: configure oxfmt and simplify is-kit guards

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,9 @@
+{
+  "singleQuote": true,
+  "jsxSingleQuote": false,
+  "semi": false,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "printWidth": 80,
+  "ignorePatterns": ["dist/**"]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["oxc.oxc-vscode"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,72 @@ No coverage threshold is configured today, so contributors should at minimum add
 Recent history uses short subjects such as `update` and `re-architecture`. Keep commit titles short and imperative, but make them more specific than `update` when possible, for example `fix execution step highlighting`.
 
 PRs should include a concise description, testing notes (`pnpm lint`, `pnpm test`), and screenshots or recordings for UI changes. Link related issues when applicable.
+
+<!-- is-kit-agent-rules:start -->
+# is-kit Agent Rules
+
+Use these rules when generating or reviewing code that uses `is-kit`.
+
+Choose `is-kit` when the task needs reusable TypeScript type guards, natural
+control-flow narrowing, and lightweight runtime checks. Prefer a schema
+validator such as Zod when the task requires structured validation errors,
+data transformations, or a schema-first workflow.
+
+## Usage Rules
+
+- Build reusable custom guards with `define<T>(...)` instead of writing
+  standalone type-predicate functions by hand.
+- Prefer `is-kit` combinators over hand-written boolean composition when
+  combining existing guards.
+- Use `or(isA, isB)` instead of `(value) => isA(value) || isB(value)` when the
+  result should be a reusable guard.
+- Use `and(baseGuard, refinement)` or `andAll(...)` instead of hand-written
+  `&&` checks when narrowing should be preserved.
+- Use `not(guard)` for reusable negated guards.
+- Use `nullable(guard)`, `optional(guard)`, or `nullish(guard)` when widening an
+  existing guard to accept `null` and/or `undefined`.
+- Use `isNil(value)` when checking a value directly for `null | undefined`.
+- Use `optionalKey(guard)` for optional object keys inside `struct`.
+
+## Preferred Examples
+
+```ts
+import {
+  and,
+  define,
+  isNil,
+  isNumber,
+  isString,
+  nullish,
+  or,
+  predicateToRefine
+} from 'is-kit';
+
+const isId = or(isString, isNumber);
+const isMaybeName = nullish(isString);
+const isSlug = define<string>(
+  (value) => isString(value) && /^[a-z0-9-]+$/.test(value)
+);
+const isPositiveNumber = and(
+  isNumber,
+  predicateToRefine<number>((value) => value > 0)
+);
+
+declare const value: unknown;
+
+if (isNil(value)) {
+  return;
+}
+```
+
+## Avoid
+
+```ts
+declare const value: unknown;
+
+const isId = (value: unknown) => isString(value) || isNumber(value);
+const isMaybeName = (value: unknown) => value == null || isString(value);
+const isSlug = (value: unknown): value is string =>
+  isString(value) && /^[a-z0-9-]+$/.test(value);
+```
+<!-- is-kit-agent-rules:end -->

--- a/src/features/code-execution/worker/worker-transfer.test.ts
+++ b/src/features/code-execution/worker/worker-transfer.test.ts
@@ -16,6 +16,20 @@ describe('createWorkerTransferValue', () => {
     expect(Number.isNaN(clonedByBrowser.invalidDate.getTime())).toBe(true)
   })
 
+  it.each(['Map', 'Set', 'RegExp'])(
+    'does not treat a spoofed %s tag as a built-in instance',
+    (tag) => {
+      const taggedObject = {
+        [Symbol.toStringTag]: tag,
+        callback() {},
+      }
+
+      expect(createWorkerTransferValue(taggedObject)).toEqual({
+        callback: '[Function callback]',
+      })
+    }
+  )
+
   it('preserves cyclic graphs while replacing local functions', () => {
     const first: {
       val: number

--- a/src/features/code-execution/worker/worker-transfer.test.ts
+++ b/src/features/code-execution/worker/worker-transfer.test.ts
@@ -4,6 +4,18 @@ import { executeCode } from '../lib/runner'
 import { createWorkerTransferValue } from './worker-transfer'
 
 describe('createWorkerTransferValue', () => {
+  it('preserves invalid Date instances', () => {
+    const invalidDate = new Date('invalid')
+
+    const transferred = createWorkerTransferValue({ invalidDate })
+    const clonedByBrowser = structuredClone(transferred)
+
+    expect(transferred.invalidDate).toBeInstanceOf(Date)
+    expect(Number.isNaN(transferred.invalidDate.getTime())).toBe(true)
+    expect(clonedByBrowser.invalidDate).toBeInstanceOf(Date)
+    expect(Number.isNaN(clonedByBrowser.invalidDate.getTime())).toBe(true)
+  })
+
   it('preserves cyclic graphs while replacing local functions', () => {
     const first: {
       val: number

--- a/src/shared/lib/guards.test.ts
+++ b/src/shared/lib/guards.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { isDate, isMap, isRegExp, isSet } from './guards'
+
+describe('built-in instance guards', () => {
+  it('accepts genuine built-in instances, including invalid Dates', () => {
+    expect(isDate(new Date('invalid'))).toBe(true)
+    expect(isMap(new Map())).toBe(true)
+    expect(isSet(new Set())).toBe(true)
+    expect(isRegExp(/value/)).toBe(true)
+  })
+
+  it('rejects plain objects with spoofed built-in tags', () => {
+    expect(isMap({ [Symbol.toStringTag]: 'Map' })).toBe(false)
+    expect(isSet({ [Symbol.toStringTag]: 'Set' })).toBe(false)
+    expect(isRegExp({ [Symbol.toStringTag]: 'RegExp' })).toBe(false)
+    expect(isDate({ [Symbol.toStringTag]: 'Date', getTime: () => 0 })).toBe(
+      false
+    )
+  })
+})

--- a/src/shared/lib/guards.ts
+++ b/src/shared/lib/guards.ts
@@ -28,7 +28,6 @@ export {
   isInfiniteNumber,
   isInstanceOf,
   isInteger,
-  isMap,
   isNaN,
   isNil,
   isNull,
@@ -37,8 +36,6 @@ export {
   isObject,
   isPlainObject,
   isPrimitive,
-  isRegExp,
-  isSet,
   isSymbol,
   isString,
   isUndefined,
@@ -97,3 +94,16 @@ export const isGraphSource = or(isArray, isObject)
 
 /** Matches Date instances, including invalid dates whose timestamp is NaN. */
 export const isDate = isInstanceOf(Date)
+
+/** Matches genuine Map instances without trusting Symbol.toStringTag. */
+export const isMap = isInstanceOf(Map)
+
+/** Matches genuine Set instances without trusting Symbol.toStringTag. */
+export const isSet = isInstanceOf(
+  Set as unknown as abstract new (...args: unknown[]) => Set<unknown>
+)
+
+/** Matches genuine RegExp instances without trusting Symbol.toStringTag. */
+export const isRegExp = isInstanceOf(
+  RegExp as unknown as abstract new (...args: unknown[]) => RegExp
+)

--- a/src/shared/lib/guards.ts
+++ b/src/shared/lib/guards.ts
@@ -4,6 +4,7 @@ import {
   define,
   isBoolean,
   isArray,
+  isInstanceOf,
   isNumber,
   isObject,
   isString,
@@ -27,7 +28,6 @@ export {
   isInfiniteNumber,
   isInstanceOf,
   isInteger,
-  isDate,
   isMap,
   isNaN,
   isNil,
@@ -94,3 +94,6 @@ export const isAdjacencyList = define<MatrixValue>((value) => {
 })
 
 export const isGraphSource = or(isArray, isObject)
+
+/** Matches Date instances, including invalid dates whose timestamp is NaN. */
+export const isDate = isInstanceOf(Date)

--- a/src/shared/lib/guards.ts
+++ b/src/shared/lib/guards.ts
@@ -4,7 +4,6 @@ import {
   define,
   isBoolean,
   isArray,
-  isInstanceOf,
   isNumber,
   isObject,
   isString,
@@ -28,6 +27,8 @@ export {
   isInfiniteNumber,
   isInstanceOf,
   isInteger,
+  isDate,
+  isMap,
   isNaN,
   isNil,
   isNull,
@@ -36,6 +37,8 @@ export {
   isObject,
   isPlainObject,
   isPrimitive,
+  isRegExp,
+  isSet,
   isSymbol,
   isString,
   isUndefined,
@@ -91,15 +94,3 @@ export const isAdjacencyList = define<MatrixValue>((value) => {
 })
 
 export const isGraphSource = or(isArray, isObject)
-
-export const isMap = isInstanceOf(Map)
-
-export const isSet = isInstanceOf(
-  Set as unknown as abstract new (...args: unknown[]) => Set<unknown>
-)
-
-export const isDate = isInstanceOf(Date)
-
-export const isRegExp = isInstanceOf(
-  RegExp as unknown as abstract new (...args: unknown[]) => RegExp
-)


### PR DESCRIPTION
## Summary

Configure oxfmt and simplify `is-kit` guards.

<!-- A brief summary of the changes -->

## Description

- add the shared `Oxfmt` configuration
- recommend the `Oxc` `VS Code` extension
- add generated is-kit usage guidance to `AGENTS.md`

<!-- A detailed explanation of the changes, including why they are needed -->
