### PR TITLE
feat: add recursive call frame inspector

### DIFF
--- a/src/entities/execution/index.ts
+++ b/src/entities/execution/index.ts
@@ -1,5 +1,6 @@
 export {
   FUNCTION_ARGUMENTS_LABEL,
+  FUNCTION_NAME_LABEL,
   CLASS_RECEIVER_LABEL,
   RETURN_LOCATION_LABEL,
   RETURN_VALUE_LABEL,
@@ -8,6 +9,8 @@ export {
 export type {
   ExecutionState,
   ExecutionStep,
+  CallFramePhase,
+  CallFrameStepMetadata,
   HeapKind,
   HeapSnapshot,
   HeapTraceSnapshot,

--- a/src/entities/execution/model/constants.ts
+++ b/src/entities/execution/model/constants.ts
@@ -2,6 +2,7 @@ export const FUNCTION_ARGUMENTS_LABEL = 'function arguments'
 export const RETURN_VALUE_LABEL = 'return value'
 export const RETURN_LOCATION_LABEL = 'return location'
 export const CLASS_RECEIVER_LABEL = '__algorithmVisualizerClassReceiver'
+export const FUNCTION_NAME_LABEL = '__algorithmVisualizerFunctionName'
 
 export const STEP_TYPES = {
   FUNCTION_CALL: 'function-call',

--- a/src/entities/execution/model/types.ts
+++ b/src/entities/execution/model/types.ts
@@ -18,6 +18,22 @@ export type HeapTraceSnapshot = {
   heaps: HeapSnapshot[]
 }
 
+export type CallFramePhase = 'enter' | 'update' | 'return'
+
+/** Runtime identity and visible binding names for one logical call frame. */
+export type CallFrameStepMetadata = {
+  /** Stable identifier assigned to one function invocation. */
+  frameId: number
+  /** Parent invocation identifier, when this is a nested call. */
+  parentFrameId?: number
+  /** Function or method name displayed by the frame inspector. */
+  functionName: string
+  /** Frame lifecycle event represented by this execution step. */
+  phase: CallFramePhase
+  /** Variable names visible while this frame recorded the step. */
+  visibleVariableNames: string[]
+}
+
 /** Map of user-provided values for function parameters. */
 export type InputValues = Record<string, unknown>
 
@@ -51,6 +67,8 @@ export type ExecutionStep = {
     functionName?: string
     /** Normalized state for prepared MinHeap and MaxHeap instances. */
     heapTrace?: HeapTraceSnapshot
+    /** Logical call-frame event associated with this step. */
+    callFrame?: CallFrameStepMetadata
   }
 }
 

--- a/src/features/code-execution/lib/instrumentation/context.ts
+++ b/src/features/code-execution/lib/instrumentation/context.ts
@@ -3,6 +3,7 @@ import * as t from '@babel/types'
 import {
   CLASS_RECEIVER_LABEL,
   FUNCTION_ARGUMENTS_LABEL,
+  FUNCTION_NAME_LABEL,
   STEP_TYPES,
 } from '@/entities/execution'
 import { getUniqueNames } from './binding-names'
@@ -79,6 +80,10 @@ export class InstrumentationContext {
         line,
         description,
         this.createScopeProperties([
+          t.objectProperty(
+            t.stringLiteral(FUNCTION_NAME_LABEL),
+            t.stringLiteral(functionName)
+          ),
           t.objectProperty(
             t.stringLiteral(FUNCTION_ARGUMENTS_LABEL),
             t.objectExpression(

--- a/src/features/code-execution/lib/instrumentation/context.ts
+++ b/src/features/code-execution/lib/instrumentation/context.ts
@@ -28,8 +28,12 @@ export class InstrumentationContext {
     this.scopeStack.push([...getUniqueNames(names)])
   }
 
-  popScope(): void {
-    this.scopeStack.pop()
+  popScope(preserveVariablesInParent = false): void {
+    const variables = this.scopeStack.pop()
+
+    if (preserveVariablesInParent && variables) {
+      this.addVariablesToCurrentScope(variables)
+    }
   }
 
   addVariablesToCurrentScope(names: string[]): void {

--- a/src/features/code-execution/lib/instrumentation/function-visitors.ts
+++ b/src/features/code-execution/lib/instrumentation/function-visitors.ts
@@ -2,12 +2,45 @@ import { type NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
 
 import {
+  RETURN_LOCATION_LABEL,
+  RETURN_VALUE_LABEL,
+  STEP_TYPES,
+} from '@/entities/execution'
+import {
   isSkippedArrayCallback,
   skipArrayCallbackTraversal,
 } from './array-methods'
 import { getLineNumber } from './ast-utils'
 import { getParameterNames } from './binding-names'
 import { InstrumentationContext } from './context'
+import { createRecordStepStatement } from './step-factory'
+
+const addImplicitReturnStep = (
+  context: InstrumentationContext,
+  body: t.BlockStatement,
+  functionName: string,
+  line: number
+): void => {
+  const returnLocation = `${functionName} line ${line}`
+
+  body.body.push(
+    createRecordStepStatement(
+      STEP_TYPES.RETURN,
+      line,
+      `implicit return from ${returnLocation}: undefined`,
+      context.createScopeProperties([
+        t.objectProperty(
+          t.stringLiteral(RETURN_VALUE_LABEL),
+          t.identifier('undefined')
+        ),
+        t.objectProperty(
+          t.stringLiteral(RETURN_LOCATION_LABEL),
+          t.stringLiteral(returnLocation)
+        ),
+      ])
+    )
+  )
+}
 
 export const createFunctionVisitors = (context: InstrumentationContext) => ({
   FunctionDeclaration: {
@@ -21,7 +54,14 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
         getParameterNames(path.node.params)
       )
     },
-    exit() {
+    exit(path: NodePath<t.FunctionDeclaration>) {
+      const functionName = path.node.id?.name ?? 'anonymous'
+      addImplicitReturnStep(
+        context,
+        path.node.body,
+        functionName,
+        path.node.loc?.end.line ?? getLineNumber(path.node)
+      )
       context.exitFunction()
     },
   },
@@ -46,6 +86,12 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
       if (context.isInstrumented(path.node) || isSkippedArrayCallback(path)) {
         return
       }
+      addImplicitReturnStep(
+        context,
+        path.node.body,
+        'anonymous function',
+        path.node.loc?.end.line ?? getLineNumber(path.node)
+      )
       context.exitFunction()
     },
   },
@@ -75,6 +121,12 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
       if (context.isInstrumented(path.node) || isSkippedArrayCallback(path)) {
         return
       }
+      addImplicitReturnStep(
+        context,
+        path.node.body as t.BlockStatement,
+        'arrow function',
+        path.node.loc?.end.line ?? getLineNumber(path.node)
+      )
       context.exitFunction()
     },
   },
@@ -100,7 +152,16 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
         !isDerivedConstructor
       )
     },
-    exit() {
+    exit(path: NodePath<t.ClassMethod>) {
+      const methodName = t.isIdentifier(path.node.key)
+        ? path.node.key.name
+        : 'method'
+      addImplicitReturnStep(
+        context,
+        path.node.body,
+        methodName,
+        path.node.loc?.end.line ?? getLineNumber(path.node)
+      )
       context.exitFunction()
     },
   },

--- a/src/features/code-execution/lib/instrumentation/function-visitors.ts
+++ b/src/features/code-execution/lib/instrumentation/function-visitors.ts
@@ -15,6 +15,9 @@ import { getParameterNames } from './binding-names'
 import { InstrumentationContext } from './context'
 import { createRecordStepStatement } from './step-factory'
 
+const getMethodName = (method: t.ClassMethod | t.ObjectMethod): string =>
+  t.isIdentifier(method.key) ? method.key.name : 'method'
+
 const addImplicitReturnStep = (
   context: InstrumentationContext,
   body: t.BlockStatement,
@@ -131,11 +134,32 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
     },
   },
 
+  ObjectMethod: {
+    enter(path: NodePath<t.ObjectMethod>) {
+      const methodName = getMethodName(path.node)
+      context.enterFunction(
+        path.node.body,
+        methodName,
+        getLineNumber(path.node),
+        `Entering method: ${methodName}`,
+        getParameterNames(path.node.params)
+      )
+    },
+    exit(path: NodePath<t.ObjectMethod>) {
+      const methodName = getMethodName(path.node)
+      addImplicitReturnStep(
+        context,
+        path.node.body,
+        methodName,
+        path.node.loc?.end.line ?? getLineNumber(path.node)
+      )
+      context.exitFunction()
+    },
+  },
+
   ClassMethod: {
     enter(path: NodePath<t.ClassMethod>) {
-      const methodName = t.isIdentifier(path.node.key)
-        ? path.node.key.name
-        : 'method'
+      const methodName = getMethodName(path.node)
       const classNode = path.parentPath.parentPath?.node
       const isDerivedConstructor =
         path.node.kind === 'constructor' &&
@@ -153,9 +177,7 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
       )
     },
     exit(path: NodePath<t.ClassMethod>) {
-      const methodName = t.isIdentifier(path.node.key)
-        ? path.node.key.name
-        : 'method'
+      const methodName = getMethodName(path.node)
       addImplicitReturnStep(
         context,
         path.node.body,

--- a/src/features/code-execution/lib/instrumentation/loop-visitors.ts
+++ b/src/features/code-execution/lib/instrumentation/loop-visitors.ts
@@ -47,6 +47,7 @@ const isInstrumentedFunctionBody = (
   path.parentPath.isFunctionDeclaration() ||
   path.parentPath.isFunctionExpression() ||
   path.parentPath.isArrowFunctionExpression() ||
+  path.parentPath.isObjectMethod() ||
   path.parentPath.isClassMethod()
 
 export const createLoopVisitors = (context: InstrumentationContext) => ({

--- a/src/features/code-execution/lib/instrumentation/loop-visitors.ts
+++ b/src/features/code-execution/lib/instrumentation/loop-visitors.ts
@@ -41,6 +41,14 @@ const addDeclarationBindings = (
   )
 }
 
+const isInstrumentedFunctionBody = (
+  path: NodePath<t.BlockStatement>
+): boolean =>
+  path.parentPath.isFunctionDeclaration() ||
+  path.parentPath.isFunctionExpression() ||
+  path.parentPath.isArrowFunctionExpression() ||
+  path.parentPath.isClassMethod()
+
 export const createLoopVisitors = (context: InstrumentationContext) => ({
   WhileStatement: {
     enter(path: NodePath<t.WhileStatement>) {
@@ -130,8 +138,8 @@ export const createLoopVisitors = (context: InstrumentationContext) => ({
     enter() {
       context.pushScope()
     },
-    exit() {
-      context.popScope()
+    exit(path: NodePath<t.BlockStatement>) {
+      context.popScope(isInstrumentedFunctionBody(path))
     },
   },
 })

--- a/src/features/code-execution/lib/runner.recursion-frames.test.ts
+++ b/src/features/code-execution/lib/runner.recursion-frames.test.ts
@@ -11,7 +11,8 @@ function solve(depth: number): number[] {
 
   function dfs(current: number): void {
     if (current > 0) dfs(current - 1);
-    visits.push(current);
+    const total = current * 2;
+    visits.push(total);
   }
 
   dfs(depth);
@@ -23,7 +24,7 @@ function solve(depth: number): number[] {
     const state = executeCode(code, { depth: 2 }, 'solve')
 
     expect(state.error).toBeUndefined()
-    expect(state.returnValue).toEqual([0, 1, 2, 99])
+    expect(state.returnValue).toEqual([0, 2, 4, 99])
 
     const dfsEntries = state.steps.filter(
       (step) =>
@@ -46,6 +47,29 @@ function solve(depth: number): number[] {
     expect(
       dfsReturns.every((step) => step.metadata?.callFrame?.phase === 'return')
     ).toBe(true)
+    expect(
+      dfsReturns.map((step) => ({
+        current: step.variables.current,
+        total: step.variables.total,
+        visibleVariableNames: step.metadata?.callFrame?.visibleVariableNames,
+      }))
+    ).toEqual([
+      {
+        current: 0,
+        total: 0,
+        visibleVariableNames: expect.arrayContaining(['current', 'total']),
+      },
+      {
+        current: 1,
+        total: 2,
+        visibleVariableNames: expect.arrayContaining(['current', 'total']),
+      },
+      {
+        current: 2,
+        total: 4,
+        visibleVariableNames: expect.arrayContaining(['current', 'total']),
+      },
+    ])
 
     const mutationFrames = state.steps
       .filter((step) => step.description.startsWith('visits.push('))

--- a/src/features/code-execution/lib/runner.recursion-frames.test.ts
+++ b/src/features/code-execution/lib/runner.recursion-frames.test.ts
@@ -58,6 +58,44 @@ function solve(root: TreeNode | null): number {
       { node: null, depth: 2 },
     ])
 
+    const solveFrameId = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'solve'
+    )?.metadata?.callFrame?.frameId
+    const dfsFrames = dfsEntries.map((step) => step.metadata?.callFrame)
+    const dfsFrameIds = dfsFrames.map((frame) => frame?.frameId)
+
+    expect(solveFrameId).toBeDefined()
+    expect(new Set(dfsFrameIds).size).toBe(dfsEntries.length)
+    expect(dfsFrames).toEqual([
+      expect.objectContaining({
+        parentFrameId: solveFrameId,
+        functionName: 'dfs',
+        phase: 'enter',
+        visibleVariableNames: expect.arrayContaining([
+          FUNCTION_ARGUMENTS_LABEL,
+          'node',
+          'depth',
+        ]),
+      }),
+      expect.objectContaining({ parentFrameId: dfsFrameIds[0] }),
+      expect.objectContaining({ parentFrameId: dfsFrameIds[1] }),
+      expect.objectContaining({ parentFrameId: dfsFrameIds[1] }),
+      expect.objectContaining({ parentFrameId: dfsFrameIds[0] }),
+      expect.objectContaining({ parentFrameId: dfsFrameIds[4] }),
+      expect.objectContaining({ parentFrameId: dfsFrameIds[4] }),
+    ])
+
+    const returnedDfsFrameIds = state.steps.flatMap((step) => {
+      const frame = step.metadata?.callFrame
+      return frame?.functionName === 'dfs' && frame.phase === 'return'
+        ? [frame.frameId]
+        : []
+    })
+
+    expect(new Set(returnedDfsFrameIds)).toEqual(new Set(dfsFrameIds))
+
     const resumedSteps = state.steps.filter(
       (step) =>
         step.type === 'variable-declaration' &&

--- a/src/features/code-execution/lib/runner.recursion-frames.test.ts
+++ b/src/features/code-execution/lib/runner.recursion-frames.test.ts
@@ -4,6 +4,70 @@ import { FUNCTION_ARGUMENTS_LABEL } from '@/entities/execution'
 import { executeCode } from './runner'
 
 describe('runner - recursive frame snapshots', () => {
+  it('tracks object-method returns without completing the caller frame', () => {
+    const code = `
+function solve(): number {
+  const helper = {
+    getValue() {
+      const value = 1;
+      return value;
+    },
+  };
+  const result = helper.getValue();
+  const after = result + 1;
+  return after;
+}
+`
+
+    const state = executeCode(code, {}, 'solve')
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(2)
+
+    const solveEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'solve'
+    )
+    const methodEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'getValue'
+    )
+    const methodReturn = state.steps.find(
+      (step) =>
+        step.type === 'return' &&
+        step.metadata?.callFrame?.functionName === 'getValue'
+    )
+
+    expect(methodEntry?.metadata?.callFrame).toEqual(
+      expect.objectContaining({
+        parentFrameId: solveEntry?.metadata?.callFrame?.frameId,
+        phase: 'enter',
+      })
+    )
+    expect(methodReturn?.metadata?.callFrame).toEqual(
+      expect.objectContaining({
+        frameId: methodEntry?.metadata?.callFrame?.frameId,
+        phase: 'return',
+      })
+    )
+
+    const callerStepsAfterMethod = state.steps.filter(
+      (step) =>
+        step.type === 'variable-declaration' &&
+        (step.description.startsWith('const result =') ||
+          step.description.startsWith('const after ='))
+    )
+
+    expect(
+      callerStepsAfterMethod.map((step) => step.metadata?.callFrame?.frameId)
+    ).toEqual([
+      solveEntry?.metadata?.callFrame?.frameId,
+      solveEntry?.metadata?.callFrame?.frameId,
+    ])
+  })
+
   it('unwinds recursive frames when helpers return by falling through', () => {
     const code = `
 function solve(depth: number): number[] {

--- a/src/features/code-execution/lib/runner.recursion-frames.test.ts
+++ b/src/features/code-execution/lib/runner.recursion-frames.test.ts
@@ -4,6 +4,61 @@ import { FUNCTION_ARGUMENTS_LABEL } from '@/entities/execution'
 import { executeCode } from './runner'
 
 describe('runner - recursive frame snapshots', () => {
+  it('unwinds recursive frames when helpers return by falling through', () => {
+    const code = `
+function solve(depth: number): number[] {
+  const visits: number[] = [];
+
+  function dfs(current: number): void {
+    if (current > 0) dfs(current - 1);
+    visits.push(current);
+  }
+
+  dfs(depth);
+  visits.push(99);
+  return visits;
+}
+`
+
+    const state = executeCode(code, { depth: 2 }, 'solve')
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([0, 1, 2, 99])
+
+    const dfsEntries = state.steps.filter(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'dfs'
+    )
+    const dfsFrameIds = dfsEntries.map(
+      (step) => step.metadata?.callFrame?.frameId
+    )
+    const dfsReturns = state.steps.filter(
+      (step) =>
+        step.type === 'return' &&
+        step.metadata?.callFrame?.functionName === 'dfs'
+    )
+
+    expect(dfsReturns).toHaveLength(dfsEntries.length)
+    expect(dfsReturns.map((step) => step.metadata?.callFrame?.frameId)).toEqual(
+      [...dfsFrameIds].reverse()
+    )
+    expect(
+      dfsReturns.every((step) => step.metadata?.callFrame?.phase === 'return')
+    ).toBe(true)
+
+    const mutationFrames = state.steps
+      .filter((step) => step.description.startsWith('visits.push('))
+      .map((step) => step.metadata?.callFrame)
+
+    expect(mutationFrames.map((frame) => frame?.frameId)).toEqual([
+      dfsFrameIds[2],
+      dfsFrameIds[1],
+      dfsFrameIds[0],
+      dfsEntries[0]?.metadata?.callFrame?.parentFrameId,
+    ])
+  })
+
   it('keeps DFS arguments and resumed locals isolated for each invocation', () => {
     const code = `
 type TreeNode = {

--- a/src/features/code-execution/lib/step-recorder.ts
+++ b/src/features/code-execution/lib/step-recorder.ts
@@ -1,5 +1,7 @@
 import {
   CLASS_RECEIVER_LABEL,
+  FUNCTION_NAME_LABEL,
+  type CallFrameStepMetadata,
   type ExecutionStep,
   type HeapKind,
   type HeapTraceSnapshot,
@@ -12,6 +14,7 @@ import {
   isFunction,
   isNonArrayObject,
   isNumber,
+  isString,
   isUndefined,
   oneOfValues,
 } from '@/shared/lib/guards'
@@ -100,6 +103,14 @@ export type ExecutionContext = {
   steps: ExecutionStep[]
   /** Current logical call stack. */
   callStack: string[]
+  /** Next stable identifier assigned to a function invocation. */
+  nextFrameId: number
+  /** Active runtime invocations ordered from caller to callee. */
+  frameStack: Array<{
+    frameId: number
+    functionName: string
+    parentFrameId?: number
+  }>
 }
 
 export function createExecutionContext(inputs: InputValues): ExecutionContext {
@@ -110,6 +121,45 @@ export function createExecutionContext(inputs: InputValues): ExecutionContext {
     variableSnapshotCache: [],
     steps: [],
     callStack: ['root'],
+    nextFrameId: 1,
+    frameStack: [],
+  }
+}
+
+function getCallFrameMetadata({
+  context,
+  type,
+  functionName,
+  visibleVariableNames,
+}: {
+  context: ExecutionContext
+  type: ExecutionStep['type']
+  functionName: unknown
+  visibleVariableNames: string[]
+}): CallFrameStepMetadata | undefined {
+  if (type === 'function-entry') {
+    const parentFrame = context.frameStack[context.frameStack.length - 1]
+    const frame = {
+      frameId: context.nextFrameId++,
+      functionName: isString(functionName) ? functionName : 'anonymous',
+      parentFrameId: parentFrame?.frameId,
+    }
+    context.frameStack.push(frame)
+
+    return {
+      ...frame,
+      phase: 'enter',
+      visibleVariableNames,
+    }
+  }
+
+  const frame = context.frameStack[context.frameStack.length - 1]
+  if (!frame) return undefined
+
+  return {
+    ...frame,
+    phase: type === 'return' ? 'return' : 'update',
+    visibleVariableNames,
   }
 }
 
@@ -174,6 +224,14 @@ export function recordExecutionStep(
   const heapTrace = getHeapTraceSnapshot(stepVariables[CLASS_RECEIVER_LABEL])
   const visibleStepVariables = { ...stepVariables }
   delete visibleStepVariables[CLASS_RECEIVER_LABEL]
+  const functionName = visibleStepVariables[FUNCTION_NAME_LABEL]
+  delete visibleStepVariables[FUNCTION_NAME_LABEL]
+  const callFrame = getCallFrameMetadata({
+    context,
+    type,
+    functionName,
+    visibleVariableNames: Object.keys(visibleStepVariables),
+  })
 
   Object.assign(context.variables, visibleStepVariables)
   const variablesForStep =
@@ -181,11 +239,10 @@ export function recordExecutionStep(
   const variableDelta = deepClone(variablesForStep)
 
   if (type === 'function-entry') {
-    const functionName =
-      description.match(/Entering function: (\w+)/)?.[1] || 'anonymous'
-    context.callStack.push(functionName)
+    context.callStack.push(callFrame?.functionName ?? 'anonymous')
   } else if (type === 'return' && context.callStack.length > 1) {
     context.callStack.pop()
+    context.frameStack.pop()
   }
 
   const stepIndex = context.stepNumber++
@@ -199,7 +256,13 @@ export function recordExecutionStep(
       description,
       timestamp: Date.now(),
       callStack: [...context.callStack],
-      metadata: heapTrace ? { heapTrace: deepClone(heapTrace) } : undefined,
+      metadata:
+        heapTrace || callFrame
+          ? {
+              ...(heapTrace ? { heapTrace: deepClone(heapTrace) } : {}),
+              ...(callFrame ? { callFrame } : {}),
+            }
+          : undefined,
     },
     context.variableDeltas,
     context.variableSnapshotCache,

--- a/src/features/visualization/lib/call-frame-inspector.test.ts
+++ b/src/features/visualization/lib/call-frame-inspector.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   getCallFrameDetails,
   getCallFrameInspectorState,
+  getCallerFrameContext,
   hasCallFrameMetadata,
 } from './call-frame-inspector'
 
@@ -127,6 +128,19 @@ const steps: ExecutionState['steps'] = [
       childOnly: 'left frame',
     },
     visibleVariableNames: ['node', 'depth', 'total'],
+  }),
+  createStep({
+    frameId: 3,
+    parentFrameId: 1,
+    functionName: 'dfs',
+    phase: 'enter',
+    variables: {
+      [FUNCTION_ARGUMENTS_LABEL]: { node: 'right', depth: 1 },
+      node: 'right',
+      depth: 1,
+      total: 1,
+    },
+    visibleVariableNames: [FUNCTION_ARGUMENTS_LABEL, 'node', 'depth'],
   }),
 ]
 
@@ -251,6 +265,21 @@ describe('call-frame inspector', () => {
 
     expect(state.frames.map((frame) => frame.id)).toEqual([1])
     expect(state.currentFrameId).toBe(1)
+  })
+
+  it('reconstructs caller variables from immediately before each child call', () => {
+    const executionState = createState(6)
+    const state = getCallFrameInspectorState(executionState)
+    const firstChild = state.frames.find((frame) => frame.id === 2)
+    const secondChild = state.frames.find((frame) => frame.id === 3)
+
+    const firstCaller = getCallerFrameContext(executionState, firstChild!)
+    const secondCaller = getCallerFrameContext(executionState, secondChild!)
+
+    expect(firstCaller?.frame.id).toBe(1)
+    expect(firstCaller?.details.locals).toEqual({ total: 0 })
+    expect(secondCaller?.frame.id).toBe(1)
+    expect(secondCaller?.details.locals).toEqual({ total: 1 })
   })
 
   it('leaves legacy traces available to the recursion-tree fallback', () => {

--- a/src/features/visualization/lib/call-frame-inspector.test.ts
+++ b/src/features/visualization/lib/call-frame-inspector.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import {
+  FUNCTION_ARGUMENTS_LABEL,
+  RETURN_LOCATION_LABEL,
+  RETURN_VALUE_LABEL,
+  type CallFramePhase,
+  type ExecutionState,
+} from '@/entities/execution'
+import {
+  getCallFrameDetails,
+  getCallFrameInspectorState,
+  hasCallFrameMetadata,
+} from './call-frame-inspector'
+
+function createStep({
+  frameId,
+  parentFrameId,
+  functionName,
+  phase,
+  variables,
+  visibleVariableNames = Object.keys(variables),
+}: {
+  frameId: number
+  parentFrameId?: number
+  functionName: string
+  phase: CallFramePhase
+  variables: Record<string, unknown>
+  visibleVariableNames?: string[]
+}): ExecutionState['steps'][number] {
+  return {
+    stepNumber: 1,
+    type:
+      phase === 'enter'
+        ? 'function-entry'
+        : phase === 'return'
+          ? 'return'
+          : 'assignment',
+    line: 1,
+    description: `${functionName} ${phase}`,
+    variables,
+    timestamp: 0,
+    metadata: {
+      callFrame: {
+        frameId,
+        parentFrameId,
+        functionName,
+        phase,
+        visibleVariableNames,
+      },
+    },
+  }
+}
+
+const steps: ExecutionState['steps'] = [
+  createStep({
+    frameId: 1,
+    functionName: 'dfs',
+    phase: 'enter',
+    variables: {
+      [FUNCTION_ARGUMENTS_LABEL]: { node: 'root', depth: 0 },
+      node: 'root',
+      depth: 0,
+    },
+  }),
+  createStep({
+    frameId: 1,
+    functionName: 'dfs',
+    phase: 'update',
+    variables: { node: 'root', depth: 0, total: 0 },
+  }),
+  createStep({
+    frameId: 2,
+    parentFrameId: 1,
+    functionName: 'dfs',
+    phase: 'enter',
+    variables: {
+      [FUNCTION_ARGUMENTS_LABEL]: { node: 'left', depth: 1 },
+      node: 'left',
+      depth: 1,
+      total: 0,
+    },
+    visibleVariableNames: [FUNCTION_ARGUMENTS_LABEL, 'node', 'depth'],
+  }),
+  createStep({
+    frameId: 2,
+    parentFrameId: 1,
+    functionName: 'dfs',
+    phase: 'update',
+    variables: {
+      node: 'left',
+      depth: 1,
+      total: 0,
+      childOnly: 'left frame',
+    },
+    visibleVariableNames: ['node', 'depth', 'childOnly'],
+  }),
+  createStep({
+    frameId: 2,
+    parentFrameId: 1,
+    functionName: 'dfs',
+    phase: 'return',
+    variables: {
+      node: 'left',
+      depth: 1,
+      total: 0,
+      childOnly: 'left frame',
+      [RETURN_VALUE_LABEL]: 1,
+      [RETURN_LOCATION_LABEL]: { line: 8 },
+    },
+    visibleVariableNames: [
+      'node',
+      'depth',
+      'childOnly',
+      RETURN_VALUE_LABEL,
+      RETURN_LOCATION_LABEL,
+    ],
+  }),
+  createStep({
+    frameId: 1,
+    functionName: 'dfs',
+    phase: 'update',
+    variables: {
+      node: 'root',
+      depth: 0,
+      total: 1,
+      childOnly: 'left frame',
+    },
+    visibleVariableNames: ['node', 'depth', 'total'],
+  }),
+]
+
+function createState(currentStep: number): ExecutionState {
+  return {
+    currentStep,
+    totalSteps: steps.length,
+    steps,
+    isComplete: false,
+  }
+}
+
+describe('call-frame inspector', () => {
+  it('keeps suspended caller locals separate from the current invocation', () => {
+    const state = getCallFrameInspectorState(createState(3))
+
+    expect(state.activeFrameIds).toEqual([1, 2])
+    expect(state.currentFrameId).toBe(2)
+    expect(state.frames).toEqual([
+      expect.objectContaining({ id: 1, status: 'suspended' }),
+      expect.objectContaining({ id: 2, parentId: 1, status: 'current' }),
+    ])
+
+    const parentFrame = state.frames[0]!
+    const childFrame = state.frames[1]!
+    const parentDetails = getCallFrameDetails(createState(3), parentFrame)
+    const childDetails = getCallFrameDetails(createState(3), childFrame)
+
+    expect(parentDetails).toEqual(
+      expect.objectContaining({
+        parameters: { node: 'root', depth: 0 },
+        locals: { total: 0 },
+      })
+    )
+    expect(childDetails).toEqual(
+      expect.objectContaining({
+        parameters: { node: 'left', depth: 1 },
+        locals: { childOnly: 'left frame' },
+      })
+    )
+    expect(parentDetails.locals).not.toHaveProperty('childOnly')
+  })
+
+  it('shows a frame as returning with its captured return value', () => {
+    const state = getCallFrameInspectorState(createState(4))
+    const childFrame = state.frames.find((frame) => frame.id === 2)
+
+    expect(state.currentFrameId).toBe(2)
+    expect(childFrame).toEqual(
+      expect.objectContaining({
+        status: 'returning',
+        hasReturnValue: true,
+      })
+    )
+    expect(getCallFrameDetails(createState(4), childFrame!)).toEqual(
+      expect.objectContaining({
+        returnValue: 1,
+        returnLocation: { line: 8 },
+      })
+    )
+  })
+
+  it('shows a parameter value from the frame latest observed step', () => {
+    const changedParameterSteps = [
+      createStep({
+        frameId: 1,
+        functionName: 'walk',
+        phase: 'enter',
+        variables: {
+          [FUNCTION_ARGUMENTS_LABEL]: { index: 0 },
+          index: 0,
+        },
+      }),
+      createStep({
+        frameId: 1,
+        functionName: 'walk',
+        phase: 'update',
+        variables: { index: 1 },
+      }),
+    ]
+    const state = getCallFrameInspectorState({
+      currentStep: 1,
+      totalSteps: changedParameterSteps.length,
+      steps: changedParameterSteps,
+      isComplete: false,
+    })
+
+    const frameDetails = getCallFrameDetails(
+      {
+        currentStep: 1,
+        totalSteps: changedParameterSteps.length,
+        steps: changedParameterSteps,
+        isComplete: false,
+      },
+      state.frames[0]!
+    )
+
+    expect(frameDetails.parameters).toEqual({ index: 1 })
+    expect(frameDetails.locals).toEqual({})
+  })
+
+  it('restores the caller and retains the completed child after returning', () => {
+    const state = getCallFrameInspectorState(createState(5))
+    const parentFrame = state.frames.find((frame) => frame.id === 1)
+    const childFrame = state.frames.find((frame) => frame.id === 2)
+
+    expect(state.activeFrameIds).toEqual([1])
+    expect(parentFrame).toEqual(
+      expect.objectContaining({ status: 'current' })
+    )
+    expect(childFrame).toEqual(
+      expect.objectContaining({ status: 'completed' })
+    )
+    expect(getCallFrameDetails(createState(5), parentFrame!).locals).toEqual({
+      total: 1,
+    })
+    expect(getCallFrameDetails(createState(5), childFrame!).returnValue).toBe(1)
+  })
+
+  it('reconstructs only frames that exist at an earlier timeline step', () => {
+    const state = getCallFrameInspectorState(createState(1))
+
+    expect(state.frames.map((frame) => frame.id)).toEqual([1])
+    expect(state.currentFrameId).toBe(1)
+  })
+
+  it('leaves legacy traces available to the recursion-tree fallback', () => {
+    const state: ExecutionState = {
+      currentStep: 0,
+      totalSteps: 1,
+      steps: [
+        {
+          stepNumber: 1,
+          type: 'function-entry',
+          line: 1,
+          description: 'Entering function: dfs',
+          variables: {},
+          timestamp: 0,
+        },
+      ],
+      isComplete: false,
+    }
+
+    expect(hasCallFrameMetadata(state)).toBe(false)
+    expect(getCallFrameInspectorState(state)).toEqual({
+      frames: [],
+      activeFrameIds: [],
+      currentFrameId: undefined,
+    })
+  })
+})

--- a/src/features/visualization/lib/call-frame-inspector.ts
+++ b/src/features/visualization/lib/call-frame-inspector.ts
@@ -66,6 +66,24 @@ const SPECIAL_VARIABLE_NAMES = new Set([
   RETURN_VALUE_LABEL,
 ])
 
+function getCallFrameStatus({
+  frameId,
+  returningFrameId,
+  currentFrameId,
+  activeFrameIds,
+}: {
+  frameId: number
+  returningFrameId?: number
+  currentFrameId?: number
+  activeFrameIds: number[]
+}): CallFrameStatus {
+  if (frameId === returningFrameId) return 'returning'
+  if (frameId === currentFrameId) return 'current'
+  if (activeFrameIds.includes(frameId)) return 'suspended'
+
+  return 'completed'
+}
+
 function getParameters(
   executionState: ExecutionState,
   frame: MutableCallFrame
@@ -79,14 +97,17 @@ function getParameters(
   const latestVariables =
     executionState.steps[frame.lastObservedStepIndex]?.variables ?? {}
 
-  return Object.fromEntries(
-    Object.entries(entryParameters).map(([name, entryValue]) => [
-      name,
-      Object.hasOwn(latestVariables, name)
+  const latestParameterEntries = Object.entries(entryParameters).map(
+    ([name, entryValue]) => {
+      const latestValue = Object.hasOwn(latestVariables, name)
         ? latestVariables[name]
-        : entryValue,
-    ])
+        : entryValue
+
+      return [name, latestValue]
+    }
   )
+
+  return Object.fromEntries(latestParameterEntries)
 }
 
 function getLocals(
@@ -96,16 +117,19 @@ function getLocals(
 ): Record<string, unknown> {
   const variables =
     executionState.steps[frame.lastObservedStepIndex]?.variables ?? {}
+  const localVariables: Record<string, unknown> = {}
 
-  return Object.fromEntries(
-    frame.visibleVariableNames.flatMap((name) => {
-      if (SPECIAL_VARIABLE_NAMES.has(name) || parameterNames.has(name)) {
-        return []
-      }
+  for (const name of frame.visibleVariableNames) {
+    const isParameter = parameterNames.has(name)
+    const isInternalVariable = SPECIAL_VARIABLE_NAMES.has(name)
 
-      return Object.hasOwn(variables, name) ? [[name, variables[name]]] : []
-    })
-  )
+    if (isParameter || isInternalVariable) continue
+    if (!Object.hasOwn(variables, name)) continue
+
+    localVariables[name] = variables[name]
+  }
+
+  return localVariables
 }
 
 /** Whether an execution contains stable call-frame metadata. */
@@ -186,15 +210,12 @@ export function getCallFrameInspectorState(
     activeFrameIds,
     currentFrameId,
     frames: [...frames.values()].map((frame) => {
-      const isActive = activeFrameIds.includes(frame.id)
-      const status: CallFrameStatus =
-        frame.id === returningFrameId
-          ? 'returning'
-          : frame.id === currentFrameId
-            ? 'current'
-            : isActive
-              ? 'suspended'
-              : 'completed'
+      const status = getCallFrameStatus({
+        frameId: frame.id,
+        returningFrameId,
+        currentFrameId,
+        activeFrameIds,
+      })
 
       return {
         id: frame.id,

--- a/src/features/visualization/lib/call-frame-inspector.ts
+++ b/src/features/visualization/lib/call-frame-inspector.ts
@@ -1,0 +1,213 @@
+import {
+  FUNCTION_ARGUMENTS_LABEL,
+  RETURN_LOCATION_LABEL,
+  RETURN_VALUE_LABEL,
+  type ExecutionState,
+} from '@/entities/execution'
+import { isNonArrayObject, isUndefined } from '@/shared/lib/guards'
+
+export type CallFrameStatus =
+  | 'current'
+  | 'suspended'
+  | 'returning'
+  | 'completed'
+
+export type InspectedCallFrame = {
+  /** Stable runtime invocation identifier. */
+  id: number
+  /** Parent invocation identifier. */
+  parentId?: number
+  /** Function or method name. */
+  functionName: string
+  /** Zero-based call depth. */
+  depth: number
+  /** Frame status at the selected execution step. */
+  status: CallFrameStatus
+  /** Step index where the invocation started. */
+  startStepIndex: number
+  /** Last step index observed for this invocation. */
+  lastObservedStepIndex: number
+  /** Binding names visible at the frame's last observed step. */
+  visibleVariableNames: string[]
+  /** Step index where the invocation returned. */
+  endStepIndex?: number
+  /** Whether a return event has been recorded. */
+  hasReturnValue: boolean
+}
+
+export type CallFrameDetails = {
+  /** Parameter values last observed while this frame executed. */
+  parameters: Record<string, unknown>
+  /** Local and captured variables last observed while this frame executed. */
+  locals: Record<string, unknown>
+  /** Value captured by the return event, including undefined. */
+  returnValue?: unknown
+  /** Source location associated with the return event. */
+  returnLocation?: unknown
+}
+
+export type CallFrameInspectorState = {
+  /** All invocations that have started by the selected step. */
+  frames: InspectedCallFrame[]
+  /** Active invocation identifiers ordered from caller to callee. */
+  activeFrameIds: number[]
+  /** Currently executing or returning invocation identifier. */
+  currentFrameId?: number
+}
+
+type MutableCallFrame = Omit<
+  InspectedCallFrame,
+  'status' | 'hasReturnValue'
+>
+
+const SPECIAL_VARIABLE_NAMES = new Set([
+  FUNCTION_ARGUMENTS_LABEL,
+  RETURN_LOCATION_LABEL,
+  RETURN_VALUE_LABEL,
+])
+
+function getParameters(
+  executionState: ExecutionState,
+  frame: MutableCallFrame
+): Record<string, unknown> {
+  const entryParameters =
+    executionState.steps[frame.startStepIndex]?.variables[
+      FUNCTION_ARGUMENTS_LABEL
+    ]
+  if (!isNonArrayObject(entryParameters)) return {}
+
+  const latestVariables =
+    executionState.steps[frame.lastObservedStepIndex]?.variables ?? {}
+
+  return Object.fromEntries(
+    Object.entries(entryParameters).map(([name, entryValue]) => [
+      name,
+      Object.hasOwn(latestVariables, name)
+        ? latestVariables[name]
+        : entryValue,
+    ])
+  )
+}
+
+function getLocals(
+  executionState: ExecutionState,
+  frame: MutableCallFrame,
+  parameterNames: Set<string>
+): Record<string, unknown> {
+  const variables =
+    executionState.steps[frame.lastObservedStepIndex]?.variables ?? {}
+
+  return Object.fromEntries(
+    frame.visibleVariableNames.flatMap((name) => {
+      if (SPECIAL_VARIABLE_NAMES.has(name) || parameterNames.has(name)) {
+        return []
+      }
+
+      return Object.hasOwn(variables, name) ? [[name, variables[name]]] : []
+    })
+  )
+}
+
+/** Whether an execution contains stable call-frame metadata. */
+export function hasCallFrameMetadata(executionState: ExecutionState): boolean {
+  return executionState.steps.some((step) => step.metadata?.callFrame)
+}
+
+/** Reads variable values only for the frame a user chooses to inspect. */
+export function getCallFrameDetails(
+  executionState: ExecutionState,
+  frame: InspectedCallFrame
+): CallFrameDetails {
+  const parameters = getParameters(executionState, frame)
+  const returnVariables = !isUndefined(frame.endStepIndex)
+    ? executionState.steps[frame.endStepIndex]?.variables
+    : undefined
+
+  return {
+    parameters,
+    locals: getLocals(
+      executionState,
+      frame,
+      new Set(Object.keys(parameters))
+    ),
+    returnValue: returnVariables?.[RETURN_VALUE_LABEL],
+    returnLocation: returnVariables?.[RETURN_LOCATION_LABEL],
+  }
+}
+
+/** Reconstructs call-frame state at the currently selected execution step. */
+export function getCallFrameInspectorState(
+  executionState: ExecutionState
+): CallFrameInspectorState {
+  const frames = new Map<number, MutableCallFrame>()
+  const activeFrameIds: number[] = []
+  let returningFrameId: number | undefined
+  const lastStepIndex = Math.min(
+    executionState.currentStep,
+    executionState.steps.length - 1
+  )
+
+  for (let stepIndex = 0; stepIndex <= lastStepIndex; stepIndex += 1) {
+    const step = executionState.steps[stepIndex]
+    const callFrame = step?.metadata?.callFrame
+    if (!step || !callFrame) continue
+
+    if (callFrame.phase === 'enter') {
+      frames.set(callFrame.frameId, {
+        id: callFrame.frameId,
+        parentId: callFrame.parentFrameId,
+        functionName: callFrame.functionName,
+        depth: activeFrameIds.length,
+        startStepIndex: stepIndex,
+        lastObservedStepIndex: stepIndex,
+        visibleVariableNames: callFrame.visibleVariableNames,
+      })
+      activeFrameIds.push(callFrame.frameId)
+      continue
+    }
+
+    const frame = frames.get(callFrame.frameId)
+    if (!frame) continue
+    frame.lastObservedStepIndex = stepIndex
+    frame.visibleVariableNames = callFrame.visibleVariableNames
+
+    if (callFrame.phase !== 'return') continue
+
+    frame.endStepIndex = stepIndex
+    const activeIndex = activeFrameIds.lastIndexOf(callFrame.frameId)
+    if (activeIndex >= 0) activeFrameIds.splice(activeIndex, 1)
+    if (stepIndex === lastStepIndex) returningFrameId = callFrame.frameId
+  }
+
+  const currentFrameId =
+    returningFrameId ?? activeFrameIds[activeFrameIds.length - 1]
+
+  return {
+    activeFrameIds,
+    currentFrameId,
+    frames: [...frames.values()].map((frame) => {
+      const isActive = activeFrameIds.includes(frame.id)
+      const status: CallFrameStatus =
+        frame.id === returningFrameId
+          ? 'returning'
+          : frame.id === currentFrameId
+            ? 'current'
+            : isActive
+              ? 'suspended'
+              : 'completed'
+
+      return {
+        id: frame.id,
+        parentId: frame.parentId,
+        functionName: frame.functionName,
+        depth: frame.depth,
+        status,
+        startStepIndex: frame.startStepIndex,
+        lastObservedStepIndex: frame.lastObservedStepIndex,
+        visibleVariableNames: frame.visibleVariableNames,
+        endStepIndex: frame.endStepIndex,
+        hasReturnValue: !isUndefined(frame.endStepIndex),
+      }
+    }),
+  }
+}

--- a/src/features/visualization/lib/call-frame-inspector.ts
+++ b/src/features/visualization/lib/call-frame-inspector.ts
@@ -46,6 +46,13 @@ export type CallFrameDetails = {
   returnLocation?: unknown
 }
 
+export type CallerFrameContext = {
+  /** Caller frame reconstructed immediately before the selected call started. */
+  frame: InspectedCallFrame
+  /** Caller values from that point in the timeline. */
+  details: CallFrameDetails
+}
+
 export type CallFrameInspectorState = {
   /** All invocations that have started by the selected step. */
   frames: InspectedCallFrame[]
@@ -156,6 +163,32 @@ export function getCallFrameDetails(
     ),
     returnValue: returnVariables?.[RETURN_VALUE_LABEL],
     returnLocation: returnVariables?.[RETURN_LOCATION_LABEL],
+  }
+}
+
+/** Reconstructs the parent frame immediately before a child invocation starts. */
+export function getCallerFrameContext(
+  executionState: ExecutionState,
+  frame: InspectedCallFrame
+): CallerFrameContext | undefined {
+  if (isUndefined(frame.parentId) || frame.startStepIndex === 0) {
+    return undefined
+  }
+
+  const stateBeforeCall: ExecutionState = {
+    ...executionState,
+    currentStep: frame.startStepIndex - 1,
+    isComplete: false,
+  }
+  const callerFrame = getCallFrameInspectorState(
+    stateBeforeCall
+  ).frames.find((candidate) => candidate.id === frame.parentId)
+
+  if (!callerFrame) return undefined
+
+  return {
+    frame: callerFrame,
+    details: getCallFrameDetails(executionState, callerFrame),
   }
 }
 

--- a/src/features/visualization/ui/call-frame-inspector.test.tsx
+++ b/src/features/visualization/ui/call-frame-inspector.test.tsx
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vite-plus/test'
+
+import {
+  FUNCTION_ARGUMENTS_LABEL,
+  RETURN_VALUE_LABEL,
+  type CallFramePhase,
+  type ExecutionState,
+  type ExecutionStep,
+} from '@/entities/execution'
+import { CallFrameInspector } from './call-frame-inspector'
+
+function createStep({
+  frameId,
+  parentFrameId,
+  phase,
+  variables,
+  visibleVariableNames = Object.keys(variables),
+}: {
+  frameId: number
+  parentFrameId?: number
+  phase: CallFramePhase
+  variables: Record<string, unknown>
+  visibleVariableNames?: string[]
+}): ExecutionStep {
+  return {
+    stepNumber: 1,
+    type:
+      phase === 'enter'
+        ? 'function-entry'
+        : phase === 'return'
+          ? 'return'
+          : 'assignment',
+    line: 1,
+    description: `dfs ${phase}`,
+    variables,
+    timestamp: 0,
+    metadata: {
+      callFrame: {
+        frameId,
+        parentFrameId,
+        functionName: 'dfs',
+        phase,
+        visibleVariableNames,
+      },
+    },
+  }
+}
+
+const steps = [
+  createStep({
+    frameId: 1,
+    phase: 'enter',
+    variables: {
+      [FUNCTION_ARGUMENTS_LABEL]: { node: 'root', depth: 0 },
+      node: 'root',
+      depth: 0,
+    },
+  }),
+  createStep({
+    frameId: 1,
+    phase: 'update',
+    variables: { node: 'root', depth: 0, total: 0 },
+  }),
+  createStep({
+    frameId: 2,
+    parentFrameId: 1,
+    phase: 'enter',
+    variables: {
+      [FUNCTION_ARGUMENTS_LABEL]: { node: 'left', depth: 1 },
+      node: 'left',
+      depth: 1,
+      total: 0,
+    },
+    visibleVariableNames: [FUNCTION_ARGUMENTS_LABEL, 'node', 'depth'],
+  }),
+  createStep({
+    frameId: 2,
+    parentFrameId: 1,
+    phase: 'update',
+    variables: {
+      node: 'left',
+      depth: 1,
+      total: 0,
+      childOnly: 'left frame',
+    },
+    visibleVariableNames: ['node', 'depth', 'childOnly'],
+  }),
+  createStep({
+    frameId: 2,
+    parentFrameId: 1,
+    phase: 'return',
+    variables: {
+      node: 'left',
+      depth: 1,
+      total: 0,
+      childOnly: 'left frame',
+      [RETURN_VALUE_LABEL]: 1,
+    },
+    visibleVariableNames: ['node', 'depth', 'childOnly', RETURN_VALUE_LABEL],
+  }),
+]
+
+function createState(currentStep: number): ExecutionState {
+  return {
+    currentStep,
+    totalSteps: steps.length,
+    steps,
+    isComplete: false,
+  }
+}
+
+describe('CallFrameInspector', () => {
+  it('selects a suspended caller without mixing its locals with the child', () => {
+    render(<CallFrameInspector executionState={createState(3)} />)
+
+    const childButton = screen.getByRole('button', { name: /dfs #2/i })
+    const parentButton = screen.getByRole('button', { name: /dfs #1/i })
+
+    expect(childButton).toHaveAttribute('aria-current', 'true')
+    expect(childButton).toHaveAttribute('aria-pressed', 'true')
+    expect(parentButton).toHaveTextContent('Suspended')
+
+    fireEvent.click(parentButton)
+
+    const parentDetails = screen.getByRole('region', {
+      name: 'dfs #1 frame details',
+    })
+    expect(parentDetails).toHaveTextContent('root')
+    expect(parentDetails).toHaveTextContent('total')
+    expect(parentDetails).not.toHaveTextContent('childOnly')
+    expect(parentDetails).toHaveTextContent(
+      'Showing the last state observed before this frame was suspended.'
+    )
+  })
+
+  it('synchronizes selection when moving before a selected frame existed', () => {
+    const { rerender } = render(
+      <CallFrameInspector executionState={createState(3)} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /dfs #2/i }))
+    rerender(<CallFrameInspector executionState={createState(1)} />)
+
+    expect(
+      screen.queryByRole('button', { name: /dfs #2/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('region', { name: 'dfs #1 frame details' })
+    ).toBeInTheDocument()
+  })
+
+  it('follows the current invocation until a frame is selected explicitly', () => {
+    const { rerender } = render(
+      <CallFrameInspector executionState={createState(1)} />
+    )
+
+    expect(
+      screen.getByRole('region', { name: 'dfs #1 frame details' })
+    ).toBeInTheDocument()
+
+    rerender(<CallFrameInspector executionState={createState(3)} />)
+
+    expect(
+      screen.getByRole('region', { name: 'dfs #2 frame details' })
+    ).toBeInTheDocument()
+  })
+
+  it('shows the returning frame and its return value', () => {
+    render(<CallFrameInspector executionState={createState(4)} />)
+
+    const returningButton = screen.getByRole('button', { name: /dfs #2/i })
+    const details = screen.getByRole('region', {
+      name: 'dfs #2 frame details',
+    })
+
+    expect(returningButton).toHaveAttribute('aria-current', 'true')
+    expect(returningButton).toHaveTextContent('Returning')
+    const returnSection = within(details)
+      .getByText('Return value')
+      .closest('section')
+    expect(returnSection).not.toBeNull()
+    expect(within(returnSection!).getByText('1')).toBeInTheDocument()
+  })
+})

--- a/src/features/visualization/ui/call-frame-inspector.test.tsx
+++ b/src/features/visualization/ui/call-frame-inspector.test.tsx
@@ -216,9 +216,7 @@ describe('CallFrameInspector', () => {
   it('keeps completed calls without repeating the Completed label', () => {
     render(<CallFrameInspector executionState={createState(6)} />)
 
-    const guidance = screen.getByText('No active calls at this step.').closest(
-      'div'
-    )
+    const guidance = screen.getByLabelText('No active calls')
 
     expect(guidance).toHaveClass('border-primary/25', 'bg-primary/5')
     expect(guidance).toHaveTextContent(

--- a/src/features/visualization/ui/call-frame-inspector.test.tsx
+++ b/src/features/visualization/ui/call-frame-inspector.test.tsx
@@ -47,7 +47,7 @@ function createStep({
   }
 }
 
-const steps = [
+const steps: ExecutionState['steps'] = [
   createStep({
     frameId: 1,
     phase: 'enter',
@@ -99,6 +99,25 @@ const steps = [
     },
     visibleVariableNames: ['node', 'depth', 'childOnly', RETURN_VALUE_LABEL],
   }),
+  createStep({
+    frameId: 1,
+    phase: 'return',
+    variables: {
+      node: 'root',
+      depth: 0,
+      total: 1,
+      [RETURN_VALUE_LABEL]: 1,
+    },
+    visibleVariableNames: ['node', 'depth', 'total', RETURN_VALUE_LABEL],
+  }),
+  {
+    stepNumber: 6,
+    type: 'return',
+    line: 0,
+    description: 'Returned: 1',
+    variables: { result: 1 },
+    timestamp: 0,
+  },
 ]
 
 function createState(currentStep: number): ExecutionState {
@@ -132,6 +151,17 @@ describe('CallFrameInspector', () => {
     expect(parentDetails).toHaveTextContent(
       'Showing the last state observed before this frame was suspended.'
     )
+
+    fireEvent.click(childButton)
+
+    const callerContext = screen.getByRole('region', {
+      name: 'Caller context',
+    })
+    expect(callerContext).toHaveTextContent(
+      'State from dfs #1 immediately before this call.'
+    )
+    expect(callerContext).toHaveTextContent('total')
+    expect(callerContext).toHaveTextContent('0')
   })
 
   it('synchronizes selection when moving before a selected frame existed', () => {
@@ -181,5 +211,31 @@ describe('CallFrameInspector', () => {
       .closest('section')
     expect(returnSection).not.toBeNull()
     expect(within(returnSection!).getByText('1')).toBeInTheDocument()
+  })
+
+  it('keeps completed calls without repeating the Completed label', () => {
+    render(<CallFrameInspector executionState={createState(6)} />)
+
+    const guidance = screen.getByText('No active calls at this step.').closest(
+      'div'
+    )
+
+    expect(guidance).toHaveClass('border-primary/25', 'bg-primary/5')
+    expect(guidance).toHaveTextContent(
+      'Step backward to inspect an earlier call frame.'
+    )
+    expect(screen.getByText('Completed calls')).toBeInTheDocument()
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /dfs #1/i })).toHaveClass(
+      'cursor-pointer'
+    )
+
+    const completedSection = screen
+      .getByText('Completed calls')
+      .closest('section')
+    const completedList = completedSection?.querySelector('.overflow-y-auto')
+
+    expect(completedSection).toHaveClass('lg:min-h-0', 'lg:flex-1')
+    expect(completedList).toHaveClass('lg:min-h-0', 'lg:flex-1')
   })
 })

--- a/src/features/visualization/ui/call-frame-inspector.tsx
+++ b/src/features/visualization/ui/call-frame-inspector.tsx
@@ -145,12 +145,15 @@ export function CallFrameInspector({
 
   if (!selectedFrame || !selectedFrameDetails) {
     return (
-      <div className="w-full rounded-md border border-primary/25 bg-primary/5 p-3">
+      <section
+        aria-label="Call frame guidance"
+        className="w-full rounded-md border border-primary/25 bg-primary/5 p-3"
+      >
         <p className="text-sm font-medium">No active calls at this step.</p>
         <p className="text-xs text-muted-foreground">
           Step backward to inspect an earlier call frame.
         </p>
-      </div>
+      </section>
     )
   }
 
@@ -171,12 +174,12 @@ export function CallFrameInspector({
         aria-label="Call frames"
       >
         <section className="space-y-2 lg:shrink-0">
-          <div>
+          <header>
             <h3 className="text-sm font-semibold">Active stack</h3>
             <p className="text-xs text-muted-foreground">
               Current call first, followed by its callers.
             </p>
-          </div>
+          </header>
           {activeFrames.length > 0 ? (
             <div className="space-y-2">
               {activeFrames.map((frame) => (
@@ -189,14 +192,17 @@ export function CallFrameInspector({
               ))}
             </div>
           ) : (
-            <div className="rounded-md border border-primary/25 bg-primary/5 p-3">
-              <p className="text-sm font-medium">
+            <p
+              aria-label="No active calls"
+              className="rounded-md border border-primary/25 bg-primary/5 p-3"
+            >
+              <span className="block text-sm font-medium">
                 No active calls at this step.
-              </p>
-              <p className="text-xs text-muted-foreground">
+              </span>
+              <span className="block text-xs text-muted-foreground">
                 Step backward to inspect an earlier call frame.
-              </p>
-            </div>
+              </span>
+            </p>
           )}
         </section>
 
@@ -221,7 +227,7 @@ export function CallFrameInspector({
         className="min-w-0 space-y-4 rounded-md border bg-card p-4 lg:min-h-0 lg:overflow-y-auto"
         aria-label={`${selectedFrame.functionName} #${selectedFrame.id} frame details`}
       >
-        <div className="flex flex-wrap items-center justify-between gap-2">
+        <header className="flex flex-wrap items-center justify-between gap-2">
           <div>
             <h3 className="font-mono text-base font-semibold">
               {selectedFrame.functionName} #{selectedFrame.id}
@@ -243,7 +249,7 @@ export function CallFrameInspector({
               {STATUS_LABELS[selectedFrame.status]}
             </Badge>
           )}
-        </div>
+        </header>
 
         {selectedFrame.status === 'suspended' && (
           <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
@@ -256,7 +262,7 @@ export function CallFrameInspector({
             className="space-y-2 rounded-md border p-3"
             aria-label="Caller context"
           >
-            <div>
+            <header>
               <h4 className="text-sm font-semibold">Caller context</h4>
               <p className="text-xs text-muted-foreground">
                 State from{' '}
@@ -265,7 +271,7 @@ export function CallFrameInspector({
                 </code>{' '}
                 immediately before this call.
               </p>
-            </div>
+            </header>
             <ValueRows
               values={{
                 ...callerContext.details.parameters,

--- a/src/features/visualization/ui/call-frame-inspector.tsx
+++ b/src/features/visualization/ui/call-frame-inspector.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/shared/lib/class-names'
 import {
   getCallFrameDetails,
   getCallFrameInspectorState,
+  getCallerFrameContext,
   type CallFrameStatus,
   type InspectedCallFrame,
 } from '../lib/call-frame-inspector'
@@ -41,7 +42,7 @@ function FrameButton({
       aria-pressed={isSelected}
       onClick={onSelect}
       className={cn(
-        'w-full rounded-md border px-3 py-2 text-left transition-colors',
+        'w-full cursor-pointer rounded-md border px-3 py-2 text-left transition-colors',
         'hover:border-primary/50 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         isSelected ? 'border-primary bg-primary/10' : 'border-border bg-card'
       )}
@@ -51,12 +52,14 @@ function FrameButton({
           {frame.functionName}
           <span className="ml-1 text-muted-foreground">#{frame.id}</span>
         </span>
-        <Badge
-          variant={isExecuting ? 'default' : 'outline'}
-          className="shrink-0"
-        >
-          {STATUS_LABELS[frame.status]}
-        </Badge>
+        {frame.status !== 'completed' && (
+          <Badge
+            variant={isExecuting ? 'default' : 'outline'}
+            className="shrink-0"
+          >
+            {STATUS_LABELS[frame.status]}
+          </Badge>
+        )}
       </span>
       <span className="mt-1 block text-xs text-muted-foreground">
         Depth {frame.depth} · last observed at step{' '}
@@ -126,6 +129,13 @@ export function CallFrameInspector({
         : undefined,
     [executionState, selectedFrame]
   )
+  const callerContext = useMemo(
+    () =>
+      selectedFrame
+        ? getCallerFrameContext(executionState, selectedFrame)
+        : undefined,
+    [executionState, selectedFrame]
+  )
 
   useEffect(() => {
     if (selectedFrameId !== undefined && !selectedFrameStillExists) {
@@ -135,9 +145,12 @@ export function CallFrameInspector({
 
   if (!selectedFrame || !selectedFrameDetails) {
     return (
-      <p className="text-sm text-muted-foreground">
-        Call-frame state is not available at this step.
-      </p>
+      <div className="w-full rounded-md border border-primary/25 bg-primary/5 p-3">
+        <p className="text-sm font-medium">No active calls at this step.</p>
+        <p className="text-xs text-muted-foreground">
+          Step backward to inspect an earlier call frame.
+        </p>
+      </div>
     )
   }
 
@@ -152,31 +165,45 @@ export function CallFrameInspector({
     .reverse()
 
   return (
-    <div className="grid w-full gap-4 lg:grid-cols-[minmax(13rem,0.4fr)_minmax(0,1fr)]">
-      <aside className="space-y-4" aria-label="Call frames">
-        <section className="space-y-2">
+    <div className="grid w-full gap-4 lg:h-full lg:min-h-0 lg:grid-cols-[minmax(13rem,0.4fr)_minmax(0,1fr)]">
+      <aside
+        className="space-y-4 lg:flex lg:min-h-0 lg:flex-col lg:gap-4 lg:space-y-0 lg:overflow-hidden"
+        aria-label="Call frames"
+      >
+        <section className="space-y-2 lg:shrink-0">
           <div>
             <h3 className="text-sm font-semibold">Active stack</h3>
             <p className="text-xs text-muted-foreground">
               Current call first, followed by its callers.
             </p>
           </div>
-          <div className="space-y-2">
-            {activeFrames.map((frame) => (
-              <FrameButton
-                key={frame.id}
-                frame={frame}
-                isSelected={frame.id === effectiveSelectedFrameId}
-                onSelect={() => setSelectedFrameId(frame.id)}
-              />
-            ))}
-          </div>
+          {activeFrames.length > 0 ? (
+            <div className="space-y-2">
+              {activeFrames.map((frame) => (
+                <FrameButton
+                  key={frame.id}
+                  frame={frame}
+                  isSelected={frame.id === effectiveSelectedFrameId}
+                  onSelect={() => setSelectedFrameId(frame.id)}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-md border border-primary/25 bg-primary/5 p-3">
+              <p className="text-sm font-medium">
+                No active calls at this step.
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Step backward to inspect an earlier call frame.
+              </p>
+            </div>
+          )}
         </section>
 
         {completedFrames.length > 0 && (
-          <section className="space-y-2">
+          <section className="space-y-2 lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:gap-2 lg:space-y-0">
             <h3 className="text-sm font-semibold">Completed calls</h3>
-            <div className="max-h-52 space-y-2 overflow-y-auto pr-1">
+            <div className="space-y-2 overflow-y-auto pr-1 lg:min-h-0 lg:flex-1">
               {completedFrames.map((frame) => (
                 <FrameButton
                   key={frame.id}
@@ -191,7 +218,7 @@ export function CallFrameInspector({
       </aside>
 
       <section
-        className="min-w-0 space-y-4 rounded-md border bg-card p-4"
+        className="min-w-0 space-y-4 rounded-md border bg-card p-4 lg:min-h-0 lg:overflow-y-auto"
         aria-label={`${selectedFrame.functionName} #${selectedFrame.id} frame details`}
       >
         <div className="flex flex-wrap items-center justify-between gap-2">
@@ -204,22 +231,49 @@ export function CallFrameInspector({
               {selectedFrame.startStepIndex + 1}
             </p>
           </div>
-          <Badge
-            variant={
-              selectedFrame.status === 'current' ||
-              selectedFrame.status === 'returning'
-                ? 'default'
-                : 'outline'
-            }
-          >
-            {STATUS_LABELS[selectedFrame.status]}
-          </Badge>
+          {selectedFrame.status !== 'completed' && (
+            <Badge
+              variant={
+                selectedFrame.status === 'current' ||
+                selectedFrame.status === 'returning'
+                  ? 'default'
+                  : 'outline'
+              }
+            >
+              {STATUS_LABELS[selectedFrame.status]}
+            </Badge>
+          )}
         </div>
 
         {selectedFrame.status === 'suspended' && (
           <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
             Showing the last state observed before this frame was suspended.
           </p>
+        )}
+
+        {callerContext && (
+          <section
+            className="space-y-2 rounded-md border p-3"
+            aria-label="Caller context"
+          >
+            <div>
+              <h4 className="text-sm font-semibold">Caller context</h4>
+              <p className="text-xs text-muted-foreground">
+                State from{' '}
+                <code className="font-mono">
+                  {callerContext.frame.functionName} #{callerContext.frame.id}
+                </code>{' '}
+                immediately before this call.
+              </p>
+            </div>
+            <ValueRows
+              values={{
+                ...callerContext.details.parameters,
+                ...callerContext.details.locals,
+              }}
+              emptyMessage="No caller variables were observed."
+            />
+          </section>
         )}
 
         <section className="space-y-2">

--- a/src/features/visualization/ui/call-frame-inspector.tsx
+++ b/src/features/visualization/ui/call-frame-inspector.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { ExecutionState } from '@/entities/execution'
+import { Badge } from '@/shared/ui'
+import { cn } from '@/shared/lib/class-names'
+import {
+  getCallFrameDetails,
+  getCallFrameInspectorState,
+  type CallFrameStatus,
+  type InspectedCallFrame,
+} from '../lib/call-frame-inspector'
+import { stringifyValuePreview } from '../lib/value-formatting'
+
+type CallFrameInspectorProps = {
+  /** Execution trace at the currently selected timeline step. */
+  executionState: ExecutionState
+}
+
+const STATUS_LABELS: Record<CallFrameStatus, string> = {
+  current: 'Current',
+  suspended: 'Suspended',
+  returning: 'Returning',
+  completed: 'Completed',
+}
+
+function FrameButton({
+  frame,
+  isSelected,
+  onSelect,
+}: {
+  frame: InspectedCallFrame
+  isSelected: boolean
+  onSelect: () => void
+}) {
+  const isExecuting = frame.status === 'current' || frame.status === 'returning'
+
+  return (
+    <button
+      type="button"
+      aria-label={`${frame.functionName} #${frame.id}, ${STATUS_LABELS[frame.status]}`}
+      aria-current={isExecuting ? 'true' : undefined}
+      aria-pressed={isSelected}
+      onClick={onSelect}
+      className={cn(
+        'w-full rounded-md border px-3 py-2 text-left transition-colors',
+        'hover:border-primary/50 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        isSelected ? 'border-primary bg-primary/10' : 'border-border bg-card'
+      )}
+    >
+      <span className="flex items-center justify-between gap-2">
+        <span className="min-w-0 truncate font-mono text-sm font-medium">
+          {frame.functionName}
+          <span className="ml-1 text-muted-foreground">#{frame.id}</span>
+        </span>
+        <Badge
+          variant={isExecuting ? 'default' : 'outline'}
+          className="shrink-0"
+        >
+          {STATUS_LABELS[frame.status]}
+        </Badge>
+      </span>
+      <span className="mt-1 block text-xs text-muted-foreground">
+        Depth {frame.depth} · last observed at step{' '}
+        {frame.lastObservedStepIndex + 1}
+      </span>
+    </button>
+  )
+}
+
+function ValueRows({
+  values,
+  emptyMessage,
+}: {
+  values: Record<string, unknown>
+  emptyMessage: string
+}) {
+  const entries = Object.entries(values)
+
+  if (entries.length === 0) {
+    return <p className="text-xs text-muted-foreground">{emptyMessage}</p>
+  }
+
+  return (
+    <dl className="divide-y rounded-md border bg-muted/20">
+      {entries.map(([name, value]) => (
+        <div
+          key={name}
+          className="grid grid-cols-[minmax(5rem,0.35fr)_minmax(0,1fr)] gap-3 px-3 py-2 text-sm"
+        >
+          <dt className="truncate font-mono font-medium">{name}</dt>
+          <dd
+            className="break-all text-right font-mono text-muted-foreground"
+            title={stringifyValuePreview(value)}
+          >
+            {stringifyValuePreview(value)}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+export function CallFrameInspector({
+  executionState,
+}: CallFrameInspectorProps) {
+  const inspectorState = useMemo(
+    () => getCallFrameInspectorState(executionState),
+    [executionState]
+  )
+  const [selectedFrameId, setSelectedFrameId] = useState<number>()
+  const selectedFrameStillExists =
+    selectedFrameId !== undefined &&
+    inspectorState.frames.some((frame) => frame.id === selectedFrameId)
+  const fallbackFrameId =
+    inspectorState.currentFrameId ??
+    inspectorState.frames[inspectorState.frames.length - 1]?.id
+  const effectiveSelectedFrameId = selectedFrameStillExists
+    ? selectedFrameId
+    : fallbackFrameId
+  const selectedFrame = inspectorState.frames.find(
+    (frame) => frame.id === effectiveSelectedFrameId
+  )
+  const selectedFrameDetails = useMemo(
+    () =>
+      selectedFrame
+        ? getCallFrameDetails(executionState, selectedFrame)
+        : undefined,
+    [executionState, selectedFrame]
+  )
+
+  useEffect(() => {
+    if (selectedFrameId !== undefined && !selectedFrameStillExists) {
+      setSelectedFrameId(undefined)
+    }
+  }, [selectedFrameId, selectedFrameStillExists])
+
+  if (!selectedFrame || !selectedFrameDetails) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Call-frame state is not available at this step.
+      </p>
+    )
+  }
+
+  const activeFrameIds = new Set(inspectorState.activeFrameIds)
+  const activeFrames = inspectorState.frames
+    .filter(
+      (frame) => activeFrameIds.has(frame.id) || frame.status === 'returning'
+    )
+    .reverse()
+  const completedFrames = inspectorState.frames
+    .filter((frame) => frame.status === 'completed')
+    .reverse()
+
+  return (
+    <div className="grid w-full gap-4 lg:grid-cols-[minmax(13rem,0.4fr)_minmax(0,1fr)]">
+      <aside className="space-y-4" aria-label="Call frames">
+        <section className="space-y-2">
+          <div>
+            <h3 className="text-sm font-semibold">Active stack</h3>
+            <p className="text-xs text-muted-foreground">
+              Current call first, followed by its callers.
+            </p>
+          </div>
+          <div className="space-y-2">
+            {activeFrames.map((frame) => (
+              <FrameButton
+                key={frame.id}
+                frame={frame}
+                isSelected={frame.id === effectiveSelectedFrameId}
+                onSelect={() => setSelectedFrameId(frame.id)}
+              />
+            ))}
+          </div>
+        </section>
+
+        {completedFrames.length > 0 && (
+          <section className="space-y-2">
+            <h3 className="text-sm font-semibold">Completed calls</h3>
+            <div className="max-h-52 space-y-2 overflow-y-auto pr-1">
+              {completedFrames.map((frame) => (
+                <FrameButton
+                  key={frame.id}
+                  frame={frame}
+                  isSelected={frame.id === effectiveSelectedFrameId}
+                  onSelect={() => setSelectedFrameId(frame.id)}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+      </aside>
+
+      <section
+        className="min-w-0 space-y-4 rounded-md border bg-card p-4"
+        aria-label={`${selectedFrame.functionName} #${selectedFrame.id} frame details`}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h3 className="font-mono text-base font-semibold">
+              {selectedFrame.functionName} #{selectedFrame.id}
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              Depth {selectedFrame.depth} · started at step{' '}
+              {selectedFrame.startStepIndex + 1}
+            </p>
+          </div>
+          <Badge
+            variant={
+              selectedFrame.status === 'current' ||
+              selectedFrame.status === 'returning'
+                ? 'default'
+                : 'outline'
+            }
+          >
+            {STATUS_LABELS[selectedFrame.status]}
+          </Badge>
+        </div>
+
+        {selectedFrame.status === 'suspended' && (
+          <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+            Showing the last state observed before this frame was suspended.
+          </p>
+        )}
+
+        <section className="space-y-2">
+          <h4 className="text-sm font-semibold">Parameters</h4>
+          <ValueRows
+            values={selectedFrameDetails.parameters}
+            emptyMessage="No parameters were captured."
+          />
+        </section>
+
+        <section className="space-y-2">
+          <h4 className="text-sm font-semibold">Local variables</h4>
+          <ValueRows
+            values={selectedFrameDetails.locals}
+            emptyMessage="No local variables have been observed yet."
+          />
+        </section>
+
+        {selectedFrame.hasReturnValue && (
+          <section className="space-y-2">
+            <h4 className="text-sm font-semibold">Return value</h4>
+            <code className="block break-all rounded-md border bg-muted/20 px-3 py-2 text-sm text-primary">
+              {stringifyValuePreview(selectedFrameDetails.returnValue)}
+            </code>
+          </section>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/features/visualization/ui/variables-card.test.tsx
+++ b/src/features/visualization/ui/variables-card.test.tsx
@@ -30,6 +30,32 @@ const executionState = {
 }
 
 describe('VariablesCard', () => {
+  it('keeps call frames available when recursive DFS also has a tree graph', () => {
+    const openVisualization = vi.fn()
+
+    render(
+      <VariablesCard
+        executionState={executionState}
+        currentStep={step}
+        variableEntries={Object.entries(step.variables)}
+        expandedVariables={{}}
+        hasRecursion
+        primaryTreeNodeName="root"
+        visualizableTreeNodeNames={['root']}
+        onToggleVariable={vi.fn()}
+        onOpenVisualization={openVisualization}
+        onJumpToStep={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Call Frames' }))
+
+    expect(openVisualization).toHaveBeenCalledWith('tree')
+    expect(
+      screen.getByRole('button', { name: 'Tree Graph' })
+    ).toBeInTheDocument()
+  })
+
   it('keeps inline visualization icon buttons large enough for the pixel frame', () => {
     render(
       <VariablesCard

--- a/src/features/visualization/ui/variables-card.tsx
+++ b/src/features/visualization/ui/variables-card.tsx
@@ -304,7 +304,7 @@ export function VariablesCard({
               Graph View
             </Button>
           )}
-          {hasRecursion && !primaryTreeNodeName && (
+          {hasRecursion && (
             <Button
               variant="outline"
               size="sm"
@@ -312,7 +312,7 @@ export function VariablesCard({
               onClick={() => onOpenVisualization('tree')}
             >
               <GitGraph className="w-4 h-4" />
-              {isClassDesignTrace ? 'Call Stack View' : 'Tree View'}
+              {isClassDesignTrace ? 'Call Stack View' : 'Call Frames'}
             </Button>
           )}
           {primaryMatrixName && (

--- a/src/features/visualization/ui/visualization-modal-content.tsx
+++ b/src/features/visualization/ui/visualization-modal-content.tsx
@@ -28,6 +28,7 @@ import { getExecutionStepSearchOrder } from '../lib/execution-step-search'
 import { getHeapVisualizationState } from '../lib/heap-view'
 import { getWordLadderVisualizationState } from '../lib/word-ladder-view'
 import { getExpressionVisualizationState } from '../lib/expression-view'
+import { hasCallFrameMetadata } from '../lib/call-frame-inspector'
 import type { VisualizationType } from '../model/types'
 import { StackVisualizer } from './stack-visualizer'
 import { RecursionTreeVisualizer } from './recursion-tree-visualizer'
@@ -44,6 +45,7 @@ import { ListGraphVisualizer } from './list-graph-visualizer'
 import { HeapVisualizer } from './heap-visualizer'
 import { WordLadderVisualizer } from './word-ladder-visualizer'
 import { ExpressionVisualizer } from './expression-visualizer'
+import { CallFrameInspector } from './call-frame-inspector'
 
 type ExecutionStepSnapshot = ExecutionState['steps'][number]
 
@@ -60,6 +62,8 @@ type VisualizationContentProps = {
   currentStep: ExecutionStepSnapshot | undefined
   /** Display name for tree graphs when visualizing the return value. */
   treeGraphDisplayName?: string
+  /** Whether the tree modal represents class-design operation calls. */
+  isClassDesignTrace?: boolean
 }
 
 function findNumericArrayStep({
@@ -172,10 +176,15 @@ export function VisualizationModalContent({
   executionState,
   currentStep,
   treeGraphDisplayName,
+  isClassDesignTrace = false,
 }: VisualizationContentProps): ReactNode {
   const getCurrentStepVariable = (name: string) => currentStep?.variables[name]
 
   if (type === 'tree') {
+    if (!isClassDesignTrace && hasCallFrameMetadata(executionState)) {
+      return <CallFrameInspector executionState={executionState} />
+    }
+
     return <RecursionTreeVisualizer state={executionState} />
   }
 

--- a/src/features/visualization/ui/visualization-modal.test.tsx
+++ b/src/features/visualization/ui/visualization-modal.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+import type { ExecutionState } from '@/entities/execution'
+
+import type { VisualizationType } from '../model/types'
+import { VisualizationModal } from './visualization-modal'
+
+const executionState: ExecutionState = {
+  currentStep: 0,
+  totalSteps: 1,
+  isComplete: false,
+  steps: [
+    {
+      stepNumber: 0,
+      type: 'function-entry',
+      line: 1,
+      description: 'Entering function: solve',
+      variables: { matrix: [[1]] },
+      timestamp: 0,
+      metadata: {
+        callFrame: {
+          frameId: 1,
+          functionName: 'solve',
+          phase: 'enter',
+          visibleVariableNames: ['matrix'],
+        },
+      },
+    },
+  ],
+}
+
+function renderModal(type: VisualizationType) {
+  return render(
+    <VisualizationModal
+      isOpen
+      onClose={vi.fn()}
+      type={type}
+      targetVariable="matrix"
+      executionState={executionState}
+      isRunning={false}
+      onPause={vi.fn()}
+      onRunAll={vi.fn()}
+      onReset={vi.fn()}
+      onStepForward={vi.fn()}
+      onStepBackward={vi.fn()}
+      onSkipToEnd={vi.fn()}
+    />
+  )
+}
+
+describe('VisualizationModal', () => {
+  it('keeps body scrolling for non-tree visualizations with call frames', () => {
+    const { container } = renderModal('matrix')
+    const scrollContainer = container.ownerDocument.querySelector(
+      '[data-tree-scroll-container]'
+    )
+
+    expect(scrollContainer).toHaveClass('overflow-y-auto')
+    expect(scrollContainer).not.toHaveClass('lg:overflow-hidden')
+  })
+
+  it('contains overflow inside the call-frame inspector on large screens', () => {
+    const { container } = renderModal('tree')
+    const scrollContainer = container.ownerDocument.querySelector(
+      '[data-tree-scroll-container]'
+    )
+
+    expect(scrollContainer).toHaveClass('lg:overflow-hidden')
+  })
+})

--- a/src/features/visualization/ui/visualization-modal.tsx
+++ b/src/features/visualization/ui/visualization-modal.tsx
@@ -223,6 +223,7 @@ export function VisualizationModal({
         <div
           className={cn(
             'py-4 flex-1 min-h-0 overflow-y-auto overscroll-contain',
+            hasCallFrames && 'lg:overflow-hidden',
             (type === 'matrix' ||
               type === 'expression' ||
               type === 'list-graph' ||

--- a/src/features/visualization/ui/visualization-modal.tsx
+++ b/src/features/visualization/ui/visualization-modal.tsx
@@ -187,6 +187,7 @@ export function VisualizationModal({
       : targetVariable
   const hasCallFrames =
     !isClassDesignTrace && hasCallFrameMetadata(executionState)
+  const showsCallFrameInspector = type === 'tree' && hasCallFrames
   const title = getVisualizationTitle({
     type,
     targetVariable,
@@ -223,7 +224,7 @@ export function VisualizationModal({
         <div
           className={cn(
             'py-4 flex-1 min-h-0 overflow-y-auto overscroll-contain',
-            hasCallFrames && 'lg:overflow-hidden',
+            showsCallFrameInspector && 'lg:overflow-hidden',
             (type === 'matrix' ||
               type === 'expression' ||
               type === 'list-graph' ||

--- a/src/features/visualization/ui/visualization-modal.tsx
+++ b/src/features/visualization/ui/visualization-modal.tsx
@@ -17,6 +17,7 @@ import { Grid3X3 } from 'lucide-react'
 import { PlaybackControls } from './playback-controls'
 import { ReturnValueCard } from './return-value-card'
 import type { VisualizationType } from '../model/types'
+import { hasCallFrameMetadata } from '../lib/call-frame-inspector'
 
 /**
  * Props for VisualizationModal component
@@ -57,6 +58,7 @@ function getVisualizationTitle({
   targetVariable,
   treeGraphDisplayName,
   isClassDesignTrace,
+  hasCallFrames,
 }: {
   /** Type of visualization title to render. */
   type: VisualizationType
@@ -66,6 +68,8 @@ function getVisualizationTitle({
   treeGraphDisplayName?: string
   /** Whether tree visualization represents class-design operation calls. */
   isClassDesignTrace: boolean
+  /** Whether the trace supports per-invocation call-frame inspection. */
+  hasCallFrames: boolean
 }): ReactNode {
   switch (type) {
     case 'expression':
@@ -73,7 +77,11 @@ function getVisualizationTitle({
     case 'stack':
       return `Stack Visualization: ${targetVariable}`
     case 'tree':
-      return isClassDesignTrace ? 'Call Stack View' : 'Recursion Tree'
+      return isClassDesignTrace
+        ? 'Call Stack View'
+        : hasCallFrames
+          ? 'Call Frame Inspector'
+          : 'Recursion Tree'
     case 'tree-graph':
       return `Tree Graph: ${treeGraphDisplayName}`
     case 'list-graph':
@@ -110,7 +118,8 @@ function getVisualizationTitle({
 
 function getVisualizationDescription(
   type: VisualizationType,
-  isClassDesignTrace: boolean
+  isClassDesignTrace: boolean,
+  hasCallFrames: boolean
 ): string {
   switch (type) {
     case 'expression':
@@ -120,7 +129,9 @@ function getVisualizationDescription(
     case 'tree':
       return isClassDesignTrace
         ? 'Visualize class operation calls as a tree.'
-        : 'Visualize recursion call stack as a tree.'
+        : hasCallFrames
+          ? 'Inspect recursive call frames, parameters, local variables, and return values.'
+          : 'Visualize recursion call stack as a tree.'
     case 'tree-graph':
       return 'Visualize binary tree node structure as a graph.'
     case 'list-graph':
@@ -174,13 +185,20 @@ export function VisualizationModal({
     isTreeNodeShape(executionState.returnValue)
       ? RETURN_VALUE_LABEL
       : targetVariable
+  const hasCallFrames =
+    !isClassDesignTrace && hasCallFrameMetadata(executionState)
   const title = getVisualizationTitle({
     type,
     targetVariable,
     treeGraphDisplayName,
     isClassDesignTrace,
+    hasCallFrames,
   })
-  const description = getVisualizationDescription(type, isClassDesignTrace)
+  const description = getVisualizationDescription(
+    type,
+    isClassDesignTrace,
+    hasCallFrames
+  )
   const currentStep = executionState.steps[executionState.currentStep]
   const content = (
     <VisualizationModalContent
@@ -190,6 +208,7 @@ export function VisualizationModal({
       executionState={executionState}
       currentStep={currentStep}
       treeGraphDisplayName={treeGraphDisplayName}
+      isClassDesignTrace={isClassDesignTrace}
     />
   )
 


### PR DESCRIPTION
Related to https://github.com/nyaomaru/dsa-view-view/issues/13

## Summary

Add recursive call frame inspector.

<!-- A brief summary of the changes -->

## Description

- Record stable frame IDs, parent relationships, and lifecycle metadata for each function invocation
- Add a timeline-aware Call Frame Inspector for recursive execution
- Show parameters, local variables, frame status, and return values
- Keep the selected frame synchronized while stepping forward or backward
- Expose Call Frames alongside Tree Graph for recursive tree algorithms
- Preserve the existing class-design Call Stack View

<!-- A detailed explanation of the changes, including why they are needed -->
