### PR TITLE
feat: support ListNode array inputs

### DIFF
--- a/src/entities/code/index.ts
+++ b/src/entities/code/index.ts
@@ -18,6 +18,7 @@ export {
   isParamTypeBooleanMatrix,
   isParamTypeGraphNode,
   isParamTypeListNode,
+  isParamTypeListNodeArray,
   isParamTypeMatrix,
   isParamTypeNumber,
   isParamTypeNumberArray,

--- a/src/entities/code/model/parameter-type.test.ts
+++ b/src/entities/code/model/parameter-type.test.ts
@@ -4,6 +4,7 @@ import type { FunctionParameter } from './types'
 import {
   isParamTypeArrayLike,
   isParamTypeListNode,
+  isParamTypeListNodeArray,
   isParamTypeMatrix,
   isParamTypeNumber,
   isParamTypeTreeNode,
@@ -20,11 +21,13 @@ describe('parameter type predicates', () => {
     expect(isParamTypeNumber(parameter('number'))).toBe(true)
     expect(isParamTypeTreeNode(parameter('tree-node'))).toBe(true)
     expect(isParamTypeListNode(parameter('tree-node'))).toBe(false)
+    expect(isParamTypeListNodeArray(parameter('list-node-array'))).toBe(true)
   })
 
   it('matches supported array and matrix groups', () => {
     expect(isParamTypeArrayLike(parameter('array'))).toBe(true)
     expect(isParamTypeArrayLike(parameter('boolean-array'))).toBe(true)
+    expect(isParamTypeArrayLike(parameter('list-node-array'))).toBe(true)
     expect(isParamTypeArrayLike(parameter('number-matrix'))).toBe(false)
     expect(isParamTypeMatrix(parameter('string-matrix'))).toBe(true)
     expect(isParamTypeMatrix(parameter('string-array'))).toBe(false)

--- a/src/entities/code/model/parameter-type.ts
+++ b/src/entities/code/model/parameter-type.ts
@@ -28,6 +28,8 @@ export const isParamTypeBooleanMatrix = isParameterType('boolean-matrix')
 export const isParamTypeTreeNode = isParameterType('tree-node')
 /** Whether a parameter accepts a list node. */
 export const isParamTypeListNode = isParameterType('list-node')
+/** Whether a parameter accepts an array of list nodes. */
+export const isParamTypeListNodeArray = isParameterType('list-node-array')
 /** Whether a parameter accepts a graph node. */
 export const isParamTypeGraphNode = isParameterType('graph-node')
 
@@ -35,7 +37,8 @@ const isArrayType = oneOfValues(
   'array',
   'number-array',
   'string-array',
-  'boolean-array'
+  'boolean-array',
+  'list-node-array'
 )
 
 /** Whether a parameter accepts any supported array representation. */

--- a/src/features/code-editing/lib/parser-guards.ts
+++ b/src/features/code-editing/lib/parser-guards.ts
@@ -24,12 +24,19 @@ import type {
   VariableDeclaration,
   VariableDeclarator,
 } from '@babel/types'
-import { define } from '@/shared/lib/guards'
+import {
+  and,
+  define,
+  equals,
+  oneOfValues,
+  predicateToRefine,
+  type Guard,
+} from '@/shared/lib/guards'
 
-const LIST_NODE_TYPE_NAME = 'ListNode'
-const TREE_NODE_TYPE_NAME = 'TreeNode'
-const GRAPH_NODE_TYPE_NAMES = new Set(['_Node', 'GraphNode'])
-const ARRAY_TYPE_NAMES = new Set(['Array', 'ReadonlyArray'])
+const isListNodeTypeName = equals('ListNode')
+const isTreeNodeTypeName = equals('TreeNode')
+const isGraphNodeTypeName = oneOfValues('_Node', 'GraphNode')
+const isArrayTypeName = oneOfValues('Array', 'ReadonlyArray')
 
 /**
  * Function declaration with a guaranteed identifier.
@@ -67,6 +74,10 @@ export type ArrowFunctionVariableDeclarator = VariableDeclarator & {
   init: ArrowFunctionExpression
 }
 
+type NamedVariableDeclarator = VariableDeclarator & {
+  id: Identifier
+}
+
 export const isIdentifierNode = define<Identifier>((value) =>
   isBabelIdentifier(value as Node | null | undefined)
 )
@@ -97,14 +108,33 @@ const isTSTypeReferenceNode = define<TSTypeReference>(
     isBabelTSTypeReference(value as Node | null | undefined)
 )
 
-export const isArrayTypeReference = define<ArrayTypeReference>((value) => {
-  return (
-    isTSTypeReferenceNode(value) &&
-    isIdentifierNode(value.typeName) &&
-    ARRAY_TYPE_NAMES.has(value.typeName.name) &&
-    value.typeArguments?.params.length === 1
+const hasIdentifierTypeName = (
+  value: TSTypeReference
+): value is TreeNodeTypeReference => isIdentifierNode(value.typeName)
+
+const isNamedTypeReferenceNode = and(
+  isTSTypeReferenceNode,
+  hasIdentifierTypeName
+)
+
+const hasTypeName = (isTypeName: Guard<string>) =>
+  predicateToRefine<TreeNodeTypeReference>((value) =>
+    isTypeName(value.typeName.name)
   )
-})
+
+const isArrayNamedTypeReference = and(
+  isNamedTypeReferenceNode,
+  hasTypeName(isArrayTypeName)
+)
+
+const hasSingleTypeArgument = (
+  value: TreeNodeTypeReference
+): value is ArrayTypeReference => value.typeArguments?.params.length === 1
+
+export const isArrayTypeReference = and(
+  isArrayNamedTypeReference,
+  hasSingleTypeArgument
+)
 
 export const isTSUnionTypeNode = define<TSUnionType>((value) =>
   isBabelTSUnionType(value as Node | null | undefined)
@@ -118,56 +148,52 @@ export const isTypeAnnotationNode = define<TSTypeAnnotation>((value) =>
   isBabelTSTypeAnnotation(value as Node | null | undefined)
 )
 
-export const isTreeNodeTypeReference = define<TreeNodeTypeReference>(
-  (value) => {
-    return (
-      isTSTypeReferenceNode(value) &&
-      isIdentifierNode(value.typeName) &&
-      value.typeName.name === TREE_NODE_TYPE_NAME
-    )
-  }
+export const isTreeNodeTypeReference = and(
+  isNamedTypeReferenceNode,
+  hasTypeName(isTreeNodeTypeName)
 )
 
-export const isListNodeTypeReference = define<TreeNodeTypeReference>(
-  (value) => {
-    return (
-      isTSTypeReferenceNode(value) &&
-      isIdentifierNode(value.typeName) &&
-      value.typeName.name === LIST_NODE_TYPE_NAME
-    )
-  }
+export const isListNodeTypeReference = and(
+  isNamedTypeReferenceNode,
+  hasTypeName(isListNodeTypeName)
 )
 
-export const isGraphNodeTypeReference = define<TreeNodeTypeReference>(
-  (value) => {
-    return (
-      isTSTypeReferenceNode(value) &&
-      isIdentifierNode(value.typeName) &&
-      GRAPH_NODE_TYPE_NAMES.has(value.typeName.name)
-    )
-  }
+export const isGraphNodeTypeReference = and(
+  isNamedTypeReferenceNode,
+  hasTypeName(isGraphNodeTypeName)
 )
 
-export const isNamedFunctionDeclaration = define<NamedFunctionDeclaration>(
-  (value) => {
-    return isFunctionDeclarationNode(value) && isIdentifierNode(value.id)
-  }
+const hasFunctionName = (
+  value: FunctionDeclaration
+): value is NamedFunctionDeclaration => isIdentifierNode(value.id)
+
+export const isNamedFunctionDeclaration = and(
+  isFunctionDeclarationNode,
+  hasFunctionName
 )
 
-export const isArrowFunctionVariableDeclarator =
-  define<ArrowFunctionVariableDeclarator>((value) => {
-    return (
-      isVariableDeclaratorNode(value) &&
-      isIdentifierNode(value.id) &&
-      isArrowFunctionExpressionNode(value.init)
-    )
-  })
+const hasVariableName = (
+  value: VariableDeclarator
+): value is NamedVariableDeclarator => isIdentifierNode(value.id)
 
-export const isArrowFunctionVariableDeclaration = define<VariableDeclaration>(
-  (value) => {
-    return (
-      isVariableDeclarationNode(value) &&
-      value.declarations.some(isArrowFunctionVariableDeclarator)
-    )
-  }
+const isNamedVariableDeclarator = and(
+  isVariableDeclaratorNode,
+  hasVariableName
+)
+
+const hasArrowFunctionInitializer = (
+  value: NamedVariableDeclarator
+): value is ArrowFunctionVariableDeclarator =>
+  isArrowFunctionExpressionNode(value.init)
+
+export const isArrowFunctionVariableDeclarator = and(
+  isNamedVariableDeclarator,
+  hasArrowFunctionInitializer
+)
+
+export const isArrowFunctionVariableDeclaration = and(
+  isVariableDeclarationNode,
+  predicateToRefine<VariableDeclaration>((value) =>
+    value.declarations.some(isArrowFunctionVariableDeclarator)
+  )
 )

--- a/src/features/code-editing/lib/parser-guards.ts
+++ b/src/features/code-editing/lib/parser-guards.ts
@@ -18,6 +18,7 @@ import type {
   TSArrayType,
   TSParenthesizedType,
   TSTypeAnnotation,
+  TSTypeParameterInstantiation,
   TSTypeReference,
   TSUnionType,
   VariableDeclaration,
@@ -28,6 +29,7 @@ import { define } from '@/shared/lib/guards'
 const LIST_NODE_TYPE_NAME = 'ListNode'
 const TREE_NODE_TYPE_NAME = 'TreeNode'
 const GRAPH_NODE_TYPE_NAMES = new Set(['_Node', 'GraphNode'])
+const ARRAY_TYPE_NAMES = new Set(['Array', 'ReadonlyArray'])
 
 /**
  * Function declaration with a guaranteed identifier.
@@ -43,6 +45,16 @@ export type NamedFunctionDeclaration = FunctionDeclaration & {
 export type TreeNodeTypeReference = TSTypeReference & {
   /** Referenced type name. */
   typeName: Identifier
+}
+
+/**
+ * Array or ReadonlyArray type reference with one element type argument.
+ */
+export type ArrayTypeReference = TSTypeReference & {
+  /** Referenced Array type name. */
+  typeName: Identifier
+  /** Single array element type. */
+  typeArguments: TSTypeParameterInstantiation
 }
 
 /**
@@ -84,6 +96,15 @@ const isTSTypeReferenceNode = define<TSTypeReference>(
   (value): value is TSTypeReference =>
     isBabelTSTypeReference(value as Node | null | undefined)
 )
+
+export const isArrayTypeReference = define<ArrayTypeReference>((value) => {
+  return (
+    isTSTypeReferenceNode(value) &&
+    isIdentifierNode(value.typeName) &&
+    ARRAY_TYPE_NAMES.has(value.typeName.name) &&
+    value.typeArguments?.params.length === 1
+  )
+})
 
 export const isTSUnionTypeNode = define<TSUnionType>((value) =>
   isBabelTSUnionType(value as Node | null | undefined)

--- a/src/features/code-editing/lib/parser.test.ts
+++ b/src/features/code-editing/lib/parser.test.ts
@@ -85,6 +85,46 @@ function mergeTwoLists(
     expect(signature?.returnType).toBe('list-node')
   })
 
+  it('detects arrays of nullable ListNode values as list-node-array inputs', () => {
+    const signature = extractFunctionSignature(`
+function mergeKLists(lists: (ListNode | null)[]): ListNode | null {
+  return lists[0] ?? null
+}
+`)
+
+    expect(signature).not.toBeNull()
+    expect(signature?.parameters).toEqual([
+      { name: 'lists', type: 'list-node-array', optional: false },
+    ])
+    expect(signature?.returnType).toBe('list-node')
+  })
+
+  it('detects non-nullable ListNode arrays as list-node-array inputs', () => {
+    const signature = extractFunctionSignature(`
+function firstList(lists: ListNode[]): ListNode | null {
+  return lists[0] ?? null
+}
+`)
+
+    expect(signature?.parameters[0]?.type).toBe('list-node-array')
+  })
+
+  it('detects generic Array and ReadonlyArray ListNode inputs', () => {
+    const signature = extractFunctionSignature(`
+function inspectLists(
+  lists: Array<ListNode | null>,
+  readonlyLists: ReadonlyArray<ListNode>
+): number {
+  return lists.length + readonlyLists.length
+}
+`)
+
+    expect(signature?.parameters).toEqual([
+      { name: 'lists', type: 'list-node-array', optional: false },
+      { name: 'readonlyLists', type: 'list-node-array', optional: false },
+    ])
+  })
+
   it('detects _Node union parameters as graph-node inputs', () => {
     const signature = extractFunctionSignature(`
 function cloneGraph(node: _Node | null): _Node | null {

--- a/src/features/code-editing/lib/type-parser.ts
+++ b/src/features/code-editing/lib/type-parser.ts
@@ -1,5 +1,6 @@
 import type { TSTypeAnnotation, TSType, TypeAnnotation } from '@babel/types'
 import {
+  isArrayTypeReference,
   isGraphNodeTypeReference,
   isListNodeTypeReference,
   isTreeNodeTypeReference,
@@ -19,6 +20,7 @@ const PARSED_TYPES = {
   booleanMatrix: 'boolean-matrix',
   graphNode: 'graph-node',
   listNode: 'list-node',
+  listNodeArray: 'list-node-array',
   null: 'null',
   number: 'number',
   numberArray: 'number-array',
@@ -42,6 +44,10 @@ function getArrayTypeName(elementType: TSType): string {
   if (elementType.type === 'TSStringKeyword') return PARSED_TYPES.stringArray
   if (elementType.type === 'TSBooleanKeyword') return PARSED_TYPES.booleanArray
 
+  if (getTypeFromTSType(elementType) === PARSED_TYPES.listNode) {
+    return PARSED_TYPES.listNodeArray
+  }
+
   return PARSED_TYPES.array
 }
 
@@ -64,6 +70,10 @@ function getTypeFromTSType(typeNode: TSType): string {
 
   if (isTSArrayTypeNode(typeNode)) {
     return getArrayTypeName(typeNode.elementType)
+  }
+
+  if (isArrayTypeReference(typeNode)) {
+    return getArrayTypeName(typeNode.typeArguments.params[0])
   }
 
   if (isTreeNodeTypeReference(typeNode)) {

--- a/src/features/code-execution/lib/structured-inputs.list-node.test.ts
+++ b/src/features/code-execution/lib/structured-inputs.list-node.test.ts
@@ -187,4 +187,85 @@ function mergeTwoLists(
       1, 1, 2, 3, 4, 4,
     ])
   })
+
+  it('executes mergeKLists with an array of generated linked lists', () => {
+    const code = `
+function mergeKLists(lists: (ListNode | null)[]): ListNode | null {
+  if (!lists.length) return null
+
+  const heap: ListNode[] = []
+  const push = (node: ListNode) => {
+    heap.push(node)
+    bubbleUp(heap.length - 1)
+  }
+
+  const pop = (): ListNode | undefined => {
+    if (heap.length === 0) return undefined
+    const min = heap[0]
+    const last = heap.pop()
+    if (heap.length > 0) {
+      heap[0] = last
+      bubbleDown(0)
+    }
+    return min
+  }
+
+  const bubbleUp = (index: number) => {
+    while (index > 0) {
+      const parent = Math.floor((index - 1) / 2)
+      if (heap[parent].val <= heap[index].val) break
+      ;[heap[parent], heap[index]] = [heap[index], heap[parent]]
+      index = parent
+    }
+  }
+
+  const bubbleDown = (index: number) => {
+    const n = heap.length
+    while (true) {
+      let smallest = index
+      const left = 2 * index + 1
+      const right = 2 * index + 2
+      if (left < n && heap[left].val < heap[smallest].val) smallest = left
+      if (right < n && heap[right].val < heap[smallest].val) smallest = right
+      if (smallest === index) break
+      ;[heap[index], heap[smallest]] = [heap[smallest], heap[index]]
+      index = smallest
+    }
+  }
+
+  for (const node of lists) {
+    if (node) push(node)
+  }
+
+  const dummy = new ListNode()
+  let current = dummy
+  while (heap.length > 0) {
+    const minNode = pop()!
+    current.next = minNode
+    current = current.next
+    if (minNode.next) push(minNode.next)
+  }
+
+  return dummy.next
+}
+`
+
+    const inputs = convertInputValues(
+      [{ name: 'lists', type: 'list-node-array', optional: false }],
+      { lists: '[[1,4,5],[1,3,4],[2,6]]' }
+    ) as { lists: (TestListNode | null)[] }
+
+    expect(inputs.lists.map(listToArray)).toEqual([
+      [1, 4, 5],
+      [1, 3, 4],
+      [2, 6],
+    ])
+
+    const state = executeCode(code, inputs, 'mergeKLists')
+
+    expect(state.error).toBeUndefined()
+    expect(listToArray(state.returnValue as TestListNode | null)).toEqual([
+      1, 1, 2, 3, 4, 4, 5, 6,
+    ])
+  })
 })

--- a/src/features/code-execution/lib/structured-inputs.ts
+++ b/src/features/code-execution/lib/structured-inputs.ts
@@ -4,6 +4,7 @@ import {
   isParamTypeBooleanArray,
   isParamTypeGraphNode,
   isParamTypeListNode,
+  isParamTypeListNodeArray,
   isParamTypeMatrix,
   isParamTypeNumber,
   isParamTypeNumberArray,
@@ -76,6 +77,19 @@ function parseGraphInput(value: unknown): GraphNodeValue | null {
   })
 
   return nodes[0] ?? null
+}
+
+function parseListNodeArrayInput(
+  value: unknown
+): ReturnType<typeof parseListInput>[] {
+  const parsed = isString(value) ? safeJsonParse(value, isArray) : null
+  const listValues = parsed?.valid
+    ? parsed.value
+    : isArray(value)
+      ? value
+      : []
+
+  return listValues.map(parseListInput)
 }
 
 /**
@@ -162,6 +176,7 @@ function convertParameterInput(
     return convertTreeInput(param, value, context)
   }
   if (isParamTypeListNode(param)) return parseListInput(value)
+  if (isParamTypeListNodeArray(param)) return parseListNodeArrayInput(value)
   if (isParamTypeGraphNode(param)) return parseGraphInput(value)
   return convertScalarInput(param, value)
 }

--- a/src/features/code-execution/lib/validator.test.ts
+++ b/src/features/code-execution/lib/validator.test.ts
@@ -96,4 +96,26 @@ describe('input validation', () => {
       success: true,
     })
   })
+
+  it('validates arrays of nullable linked-list inputs', () => {
+    const parameters: FunctionParameter[] = [
+      { name: 'lists', type: 'list-node-array', optional: false },
+    ]
+
+    expect(
+      validateInputs(parameters, {
+        lists: '[[1,4,5],null,[],[1,3,4],[2,6]]',
+      })
+    ).toEqual({ success: true })
+
+    expect(
+      validateInputs(parameters, { lists: '[[1,4],"not-a-list"]' })
+    ).toEqual({
+      success: false,
+      errors: {
+        lists:
+          'Must be a JSON array of linked lists (e.g., [[1,4,5],[1,3,4],[2,6]])',
+      },
+    })
+  })
 })

--- a/src/features/code-execution/lib/validator.ts
+++ b/src/features/code-execution/lib/validator.ts
@@ -3,10 +3,12 @@ import type { FunctionParameter } from '@/entities/code'
 import {
   arrayOf,
   isBoolean,
+  isNull,
   isNumber,
   isNumericString,
   isString,
   oneOfValues,
+  or,
   safeJsonParse,
 } from '@/shared/lib/guards'
 import { parseTypedArrayInput } from './typed-array-input'
@@ -14,6 +16,7 @@ import { parseTypedArrayInput } from './typed-array-input'
 const isNumberMatrix = arrayOf(arrayOf(isNumber))
 const isStringMatrix = arrayOf(arrayOf(isString))
 const isBooleanMatrix = arrayOf(arrayOf(isBoolean))
+const isListNodeArray = arrayOf(or(isNull, arrayOf(isNumber)))
 const isBooleanLiteral = oneOfValues('true', 'false')
 
 /**
@@ -121,6 +124,15 @@ export function typeToZodSchema(
       break
     case 'list-node':
       schema = z.any()
+      break
+    case 'list-node-array':
+      schema = z.string().refine(
+        (val) => safeJsonParse(val, isListNodeArray).valid,
+        {
+          message:
+            'Must be a JSON array of linked lists (e.g., [[1,4,5],[1,3,4],[2,6]])',
+        }
+      )
       break
     case 'graph-node':
       schema = z.string().refine(

--- a/src/features/code-execution/ui/input-form.test.tsx
+++ b/src/features/code-execution/ui/input-form.test.tsx
@@ -16,6 +16,14 @@ const listSignature: FunctionSignature = {
   returnType: 'list-node',
 }
 
+const listArraySignature: FunctionSignature = {
+  name: 'mergeKLists',
+  parameters: [
+    { name: 'lists', type: 'list-node-array', optional: false },
+  ],
+  returnType: 'list-node',
+}
+
 const binarySearchSignature: FunctionSignature = {
   name: 'binarySearch',
   parameters: [
@@ -172,6 +180,30 @@ describe('InputForm ListNode inputs', () => {
     }
     expect(listToArray(submitted.head)).toEqual([1, 2, 3])
     expect(submitted.head?.next?.next?.next).toBeNull()
+  })
+
+  it('submits each nested array as a linked list', async () => {
+    const handleSubmit = vi.fn()
+
+    render(<InputForm signature={listArraySignature} onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByLabelText(/lists/), {
+      target: { value: '[[1,4,5],[1,3,4],[2,6]]' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    const submitted = handleSubmit.mock.calls[0][0] as {
+      lists: (TestListNode | null)[]
+    }
+    expect(submitted.lists.map(listToArray)).toEqual([
+      [1, 4, 5],
+      [1, 3, 4],
+      [2, 6],
+    ])
   })
 
   it('submits variable-length string matrix rows', async () => {

--- a/src/features/code-execution/ui/parameter-input-field.tsx
+++ b/src/features/code-execution/ui/parameter-input-field.tsx
@@ -5,6 +5,7 @@ import {
   isParamTypeBoolean,
   isParamTypeGraphNode,
   isParamTypeListNode,
+  isParamTypeListNodeArray,
   isParamTypeMatrix,
   isParamTypeNumber,
   isParamTypeTreeNode,
@@ -71,6 +72,8 @@ const getPlaceholder = (
         : 'e.g., 2'
     case 'list-node':
       return 'Node value'
+    case 'list-node-array':
+      return 'e.g., [[1,4,5],[1,3,4],[2,6]]'
     case 'graph-node':
       return 'e.g., [[2,4],[1,3],[2,4],[1,3]]'
     default:
@@ -82,6 +85,9 @@ const getHelperText = (
   param: FunctionParameter,
   primaryTreeParamName?: string
 ): string | null => {
+  if (isParamTypeListNodeArray(param)) {
+    return 'Enter each linked list as an array inside a JSON array.'
+  }
   if (isParamTypeArrayLike(param)) {
     return 'Enter a JSON array or values separated by commas'
   }


### PR DESCRIPTION
## Summary

Support `ListNode` array inputs.

<!-- A brief summary of the changes -->

## Description

- detect `ListNode[]`, `(ListNode | null)[]`, `Array<ListNode | null>`, and `ReadonlyArray<ListNode>` as `list-node-array`
- validate nested Verification inputs such as `[[1,4,5],[1,3,4],[2,6]]`
- convert each nested array into an independent linked list before runtime execution

<!-- A detailed explanation of the changes, including why they are needed -->
