### PR TITLE
feat: add largest rectangle area visualization

### DIFF
--- a/src/features/code-execution/external-algorithms-use-cases.test.tsx
+++ b/src/features/code-execution/external-algorithms-use-cases.test.tsx
@@ -773,14 +773,7 @@ describe('external algorithms use cases', () => {
     expect(state.error).toBeUndefined()
     expect(state.returnValue).toBe(10)
 
-    const currentStep = state.steps.findIndex(
-      (step) =>
-        step.description.startsWith('ans = Math.max') &&
-        step.variables.i === 4 &&
-        step.variables.mid === 2
-    )
-    expect(currentStep).toBeGreaterThanOrEqual(0)
-    renderVisualizer(completeAtStep(state, currentStep))
+    renderVisualizer(completeAtStep(state, state.steps.length - 1))
 
     fireEvent.click(screen.getByText('Area View'))
 
@@ -792,6 +785,7 @@ describe('external algorithms use cases', () => {
     ).toBeInTheDocument()
     expect(screen.getByText('stack=[1]')).toBeInTheDocument()
     expect(screen.getByText('area=10')).toBeInTheDocument()
+    expect(screen.getByText('best=10')).toBeInTheDocument()
   })
 
   it('runs integer square root and shows only the return value view', () => {

--- a/src/features/code-execution/external-algorithms-use-cases.test.tsx
+++ b/src/features/code-execution/external-algorithms-use-cases.test.tsx
@@ -298,6 +298,26 @@ function maxArea(height: number[]): number {
   return best
 }
 `
+const largestRectangleAreaCode = `
+function largestRectangleArea(heights: number[]): number {
+  const hs = [...heights, 0];
+  const stack: number[] = [];
+  let ans = 0;
+
+  for (let i = 0; i < hs.length; i++) {
+    while (stack.length > 0 && hs[stack[stack.length - 1]] > hs[i]) {
+      const mid = stack.pop()!;
+      const h = hs[mid];
+      const leftSmallIndex = stack.length > 0 ? stack[stack.length - 1] : -1;
+      const width = i - leftSmallIndex - 1;
+      ans = Math.max(ans, h * width);
+    }
+    stack.push(i);
+  }
+
+  return ans;
+}
+`
 const minWindowCode = `
 function minWindow(s: string, t: string): string {
   if (t.length === 0 || s.length === 0) return ''
@@ -734,6 +754,44 @@ describe('external algorithms use cases', () => {
     expect(screen.getByText('L=1')).toBeInTheDocument()
     expect(screen.getByText('R=8')).toBeInTheDocument()
     expect(screen.getByText('area=49')).toBeInTheDocument()
+  })
+
+  it('runs largest rectangle and exposes the histogram area view', () => {
+    const parameters: FunctionParameter[] = [
+      { name: 'heights', type: 'number-array', optional: false },
+    ]
+    const inputs = convertInputValues(parameters, {
+      heights: '2,1,5,6,2,3',
+    })
+
+    const state = executeCode(
+      largestRectangleAreaCode,
+      inputs,
+      'largestRectangleArea'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(10)
+
+    const currentStep = state.steps.findIndex(
+      (step) =>
+        step.description.startsWith('ans = Math.max') &&
+        step.variables.i === 4 &&
+        step.variables.mid === 2
+    )
+    expect(currentStep).toBeGreaterThanOrEqual(0)
+    renderVisualizer(completeAtStep(state, currentStep))
+
+    fireEvent.click(screen.getByText('Area View'))
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Area View: hs' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Rectangle Area View: hs' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('stack=[1]')).toBeInTheDocument()
+    expect(screen.getByText('area=10')).toBeInTheDocument()
   })
 
   it('runs integer square root and shows only the return value view', () => {

--- a/src/features/visualization/lib/area-view.test.ts
+++ b/src/features/visualization/lib/area-view.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import type { ExecutionState } from '@/entities/execution'
+
+import {
+  getAreaVisualizationState,
+  getHistogramPointerState,
+  isHistogramAreaCandidate,
+} from './area-view'
+
+describe('histogram area view', () => {
+  it('derives the active rectangle from a monotonic-stack pop', () => {
+    expect(
+      getHistogramPointerState([2, 1, 5, 6, 2, 3, 0], {
+        i: 4,
+        stack: [1],
+        ans: 6,
+        mid: 2,
+        h: 5,
+        leftSmallIndex: 1,
+        width: 2,
+      })
+    ).toEqual({
+      mode: 'histogram',
+      currentIndex: 4,
+      stackIndices: [1],
+      bestArea: 6,
+      rectangle: {
+        poppedIndex: 2,
+        leftIndex: 2,
+        rightIndex: 3,
+        height: 5,
+        width: 2,
+        area: 10,
+      },
+    })
+  })
+
+  it('rejects stale rectangle locals while keeping valid stack state', () => {
+    expect(
+      getHistogramPointerState([2, 1, 5, 6, 2, 3, 0], {
+        i: 5,
+        stack: [1, 4, 5],
+        ans: 10,
+        mid: 2,
+        h: 5,
+        leftSmallIndex: 1,
+        width: 2,
+      })
+    ).toEqual({
+      mode: 'histogram',
+      currentIndex: 5,
+      stackIndices: [1, 4, 5],
+      bestArea: 10,
+      rectangle: undefined,
+    })
+  })
+
+  it('resolves a histogram snapshot through the shared area view', () => {
+    const executionState: ExecutionState = {
+      currentStep: 1,
+      totalSteps: 2,
+      isComplete: false,
+      steps: [
+        {
+          stepNumber: 0,
+          type: 'function-call',
+          line: 0,
+          description: 'Function called',
+          variables: { heights: [2, 1, 5, 6, 2, 3] },
+          timestamp: 0,
+        },
+        {
+          stepNumber: 1,
+          type: 'assignment',
+          line: 9,
+          description: 'ans = Math.max(ans, h * width)',
+          variables: {
+            hs: [2, 1, 5, 6, 2, 3, 0],
+            stack: [1],
+            i: 4,
+            ans: 10,
+            mid: 2,
+            h: 5,
+            leftSmallIndex: 1,
+            width: 2,
+          },
+          timestamp: 1,
+        },
+      ],
+    }
+
+    expect(
+      getAreaVisualizationState({
+        executionState,
+        variableName: 'hs',
+      })
+    ).toEqual({
+      data: [2, 1, 5, 6, 2, 3, 0],
+      areaState: expect.objectContaining({
+        mode: 'histogram',
+        bestArea: 10,
+        rectangle: expect.objectContaining({ area: 10 }),
+      }),
+    })
+    expect(
+      isHistogramAreaCandidate(
+        'hs',
+        executionState.steps[1].variables.hs,
+        executionState.steps[1].variables
+      )
+    ).toBe(true)
+  })
+})

--- a/src/features/visualization/lib/area-view.test.ts
+++ b/src/features/visualization/lib/area-view.test.ts
@@ -83,6 +83,41 @@ describe('histogram area view', () => {
     })
   })
 
+  it('derives a final-flush cursor when the loop index is unavailable or stale', () => {
+    const flushVariables = {
+      stack: [],
+      ans: 3,
+      mid: 1,
+      h: 1,
+      leftSmallIndex: -1,
+      width: 3,
+    }
+    const expectedState = {
+      mode: 'histogram',
+      currentIndex: 3,
+      stackIndices: [],
+      bestArea: 3,
+      rectangle: {
+        poppedIndex: 1,
+        leftIndex: 0,
+        rightIndex: 2,
+        height: 1,
+        width: 3,
+        area: 3,
+      },
+    }
+
+    expect(getHistogramPointerState([2, 1, 2], flushVariables)).toEqual(
+      expectedState
+    )
+    expect(
+      getHistogramPointerState([2, 1, 2], {
+        ...flushVariables,
+        i: 2,
+      })
+    ).toEqual(expectedState)
+  })
+
   it('still rejects out-of-range stack entries during a final flush', () => {
     expect(
       getHistogramPointerState([2, 1, 2], {
@@ -116,7 +151,6 @@ describe('histogram area view', () => {
           variables: {
             heights,
             stack: [],
-            i: heights.length,
             ans: 3,
             mid: 1,
             h: 1,
@@ -133,7 +167,6 @@ describe('histogram area view', () => {
           variables: {
             heights,
             stack: [],
-            i: heights.length,
             ans: 3,
           },
           timestamp: 2,

--- a/src/features/visualization/lib/area-view.test.ts
+++ b/src/features/visualization/lib/area-view.test.ts
@@ -111,4 +111,76 @@ describe('histogram area view', () => {
       )
     ).toBe(true)
   })
+
+  it('preserves the best rectangle when the final loop index is invalid', () => {
+    const hs = [2, 1, 5, 6, 2, 3, 0]
+    const executionState: ExecutionState = {
+      currentStep: 3,
+      totalSteps: 4,
+      isComplete: true,
+      steps: [
+        {
+          stepNumber: 0,
+          type: 'loop-iteration',
+          line: 6,
+          description: 'for (...; i < hs.length; ...)',
+          variables: { hs, stack: [], i: 0, ans: 0 },
+          timestamp: 0,
+        },
+        {
+          stepNumber: 1,
+          type: 'assignment',
+          line: 12,
+          description: 'ans = Math.max(ans, h * width)',
+          variables: {
+            hs,
+            stack: [1],
+            i: 4,
+            ans: 10,
+            mid: 2,
+            h: 5,
+            leftSmallIndex: 1,
+            width: 2,
+          },
+          timestamp: 1,
+        },
+        {
+          stepNumber: 2,
+          type: 'array-mutation',
+          line: 14,
+          description: 'stack.push(i)',
+          variables: { hs, stack: [6], i: 6, ans: 10 },
+          timestamp: 2,
+        },
+        {
+          stepNumber: 3,
+          type: 'return',
+          line: 17,
+          description: 'return ans',
+          variables: { hs, stack: [6], i: hs.length, ans: 10 },
+          timestamp: 3,
+        },
+      ],
+    }
+
+    expect(
+      getAreaVisualizationState({
+        executionState,
+        variableName: 'hs',
+        targetStepIndex: 0,
+      })
+    ).toEqual({
+      data: hs,
+      areaState: expect.objectContaining({
+        mode: 'histogram',
+        bestArea: 10,
+        stackIndices: [1],
+        rectangle: expect.objectContaining({
+          area: 10,
+          leftIndex: 2,
+          rightIndex: 3,
+        }),
+      }),
+    })
+  })
 })

--- a/src/features/visualization/lib/area-view.test.ts
+++ b/src/features/visualization/lib/area-view.test.ts
@@ -36,6 +36,61 @@ describe('histogram area view', () => {
     })
   })
 
+  it('accepts common aliases for popped histogram locals', () => {
+    const data = [2, 1, 2]
+    const variables = {
+      i: 1,
+      stack: [-1],
+      maxArea: 2,
+      top: 0,
+      height: 2,
+      left: -1,
+      w: 1,
+    }
+
+    expect(getHistogramPointerState(data, variables)).toEqual({
+      mode: 'histogram',
+      currentIndex: 1,
+      stackIndices: [-1],
+      bestArea: 2,
+      rectangle: {
+        poppedIndex: 0,
+        leftIndex: 0,
+        rightIndex: 0,
+        height: 2,
+        width: 1,
+        area: 2,
+      },
+    })
+    expect(isHistogramAreaCandidate('heights', data, variables)).toBe(true)
+  })
+
+  it('derives the left boundary from the remaining stack', () => {
+    expect(
+      getHistogramPointerState([1, 2, 1], {
+        i: 2,
+        stack: [-1, 0],
+        maxArea: 2,
+        top: 1,
+        height: 2,
+        width: 1,
+      })
+    ).toEqual({
+      mode: 'histogram',
+      currentIndex: 2,
+      stackIndices: [-1, 0],
+      bestArea: 2,
+      rectangle: {
+        poppedIndex: 1,
+        leftIndex: 1,
+        rightIndex: 1,
+        height: 2,
+        width: 1,
+        area: 2,
+      },
+    })
+  })
+
   it('accepts a leading -1 stack sentinel as a histogram boundary', () => {
     const data = [2, 1, 2]
     const variables = {

--- a/src/features/visualization/lib/area-view.test.ts
+++ b/src/features/visualization/lib/area-view.test.ts
@@ -56,6 +56,111 @@ describe('histogram area view', () => {
     })
   })
 
+  it('allows one-past-end cursors for final stack flushes', () => {
+    expect(
+      getHistogramPointerState([2, 1, 2], {
+        i: 3,
+        stack: [],
+        ans: 3,
+        mid: 1,
+        h: 1,
+        leftSmallIndex: -1,
+        width: 3,
+      })
+    ).toEqual({
+      mode: 'histogram',
+      currentIndex: 3,
+      stackIndices: [],
+      bestArea: 3,
+      rectangle: {
+        poppedIndex: 1,
+        leftIndex: 0,
+        rightIndex: 2,
+        height: 1,
+        width: 3,
+        area: 3,
+      },
+    })
+  })
+
+  it('still rejects out-of-range stack entries during a final flush', () => {
+    expect(
+      getHistogramPointerState([2, 1, 2], {
+        i: 3,
+        stack: [3],
+        ans: 3,
+      })
+    ).toBeNull()
+  })
+
+  it('keeps a best rectangle discovered only during the final flush', () => {
+    const heights = [2, 1, 2]
+    const executionState: ExecutionState = {
+      currentStep: 2,
+      totalSteps: 3,
+      isComplete: true,
+      steps: [
+        {
+          stepNumber: 0,
+          type: 'loop-iteration',
+          line: 6,
+          description: 'for (...; i < heights.length; ...)',
+          variables: { heights, stack: [], i: 0, ans: 0 },
+          timestamp: 0,
+        },
+        {
+          stepNumber: 1,
+          type: 'assignment',
+          line: 16,
+          description: 'ans = Math.max(ans, h * width)',
+          variables: {
+            heights,
+            stack: [],
+            i: heights.length,
+            ans: 3,
+            mid: 1,
+            h: 1,
+            leftSmallIndex: -1,
+            width: 3,
+          },
+          timestamp: 1,
+        },
+        {
+          stepNumber: 2,
+          type: 'return',
+          line: 19,
+          description: 'return ans',
+          variables: {
+            heights,
+            stack: [],
+            i: heights.length,
+            ans: 3,
+          },
+          timestamp: 2,
+        },
+      ],
+    }
+
+    expect(
+      getAreaVisualizationState({
+        executionState,
+        variableName: 'heights',
+        targetStepIndex: 0,
+      })
+    ).toEqual({
+      data: heights,
+      areaState: expect.objectContaining({
+        mode: 'histogram',
+        bestArea: 3,
+        rectangle: expect.objectContaining({
+          area: 3,
+          leftIndex: 0,
+          rightIndex: 2,
+        }),
+      }),
+    })
+  })
+
   it('resolves a histogram snapshot through the shared area view', () => {
     const executionState: ExecutionState = {
       currentStep: 1,

--- a/src/features/visualization/lib/area-view.test.ts
+++ b/src/features/visualization/lib/area-view.test.ts
@@ -36,6 +36,52 @@ describe('histogram area view', () => {
     })
   })
 
+  it('accepts a leading -1 stack sentinel as a histogram boundary', () => {
+    const data = [2, 1, 2]
+    const variables = {
+      i: 1,
+      stack: [-1],
+      ans: 2,
+      mid: 0,
+      h: 2,
+      leftSmallIndex: -1,
+      width: 1,
+    }
+
+    expect(getHistogramPointerState(data, variables)).toEqual({
+      mode: 'histogram',
+      currentIndex: 1,
+      stackIndices: [-1],
+      bestArea: 2,
+      rectangle: {
+        poppedIndex: 0,
+        leftIndex: 0,
+        rightIndex: 0,
+        height: 2,
+        width: 1,
+        area: 2,
+      },
+    })
+    expect(isHistogramAreaCandidate('heights', data, variables)).toBe(true)
+  })
+
+  it('rejects invalid or misplaced negative stack indexes', () => {
+    const variables = { i: 1, ans: 0 }
+
+    expect(
+      getHistogramPointerState([2, 1, 2], {
+        ...variables,
+        stack: [-2],
+      })
+    ).toBeNull()
+    expect(
+      getHistogramPointerState([2, 1, 2], {
+        ...variables,
+        stack: [0, -1],
+      })
+    ).toBeNull()
+  })
+
   it('rejects stale rectangle locals while keeping valid stack state', () => {
     expect(
       getHistogramPointerState([2, 1, 5, 6, 2, 3, 0], {

--- a/src/features/visualization/lib/area-view.ts
+++ b/src/features/visualization/lib/area-view.ts
@@ -138,17 +138,24 @@ type HistogramRectangleVariables = {
 }
 
 function readHistogramRectangleVariables(
-  variables: Record<string, unknown>
+  variables: Record<string, unknown>,
+  stackTop: number
 ): HistogramRectangleVariables | null {
-  const poppedIndex = variables.mid
-  const height = variables.h
-  const leftSmallIndex = variables.leftSmallIndex
-  const width = variables.width
+  const poppedIndex = readIntegerVariable(variables, ['mid', 'top'])
+  const height = readNumberVariable(variables, ['h', 'height'])
+  const recordedLeftSmallIndex = readIntegerVariable(variables, [
+    'leftSmallIndex',
+    'left',
+  ])
+  const width = readIntegerVariable(variables, ['width', 'w'])
 
-  if (!isInteger(poppedIndex)) return null
-  if (!isNumber(height)) return null
-  if (!isInteger(leftSmallIndex)) return null
-  if (!isInteger(width)) return null
+  if (isNull(poppedIndex)) return null
+  if (isUndefined(height)) return null
+  if (isNull(width)) return null
+
+  const leftSmallIndex = isNull(recordedLeftSmallIndex)
+    ? stackTop
+    : recordedLeftSmallIndex
 
   return { poppedIndex, height, leftSmallIndex, width }
 }
@@ -183,9 +190,12 @@ function resolveHistogramCurrentIndex(
   variables: Record<string, unknown>,
   stackIndices: number[]
 ): number | null {
-  const rectangleVariables = readHistogramRectangleVariables(variables)
   const finalFlushIndex = data.length
   const stackTop = stackIndices[stackIndices.length - 1] ?? -1
+  const rectangleVariables = readHistogramRectangleVariables(
+    variables,
+    stackTop
+  )
   const isFinalFlushRectangle =
     !isNull(rectangleVariables) &&
     matchesPoppedBar(data, rectangleVariables) &&
@@ -210,10 +220,13 @@ function getHistogramRectangle(
   currentIndex: number,
   stackIndices: number[]
 ): HistogramRectangle | undefined {
-  const rectangleVariables = readHistogramRectangleVariables(variables)
+  const stackTop = stackIndices[stackIndices.length - 1] ?? -1
+  const rectangleVariables = readHistogramRectangleVariables(
+    variables,
+    stackTop
+  )
   if (isNull(rectangleVariables)) return undefined
 
-  const stackTop = stackIndices[stackIndices.length - 1] ?? -1
   if (!matchesPoppedBar(data, rectangleVariables)) return undefined
   if (
     !matchesHistogramSpan({

--- a/src/features/visualization/lib/area-view.ts
+++ b/src/features/visualization/lib/area-view.ts
@@ -18,6 +18,7 @@ const isHistogramVariableName = oneOfValues(
   'hs'
 )
 const isIntegerArray = arrayOf(isInteger)
+const HISTOGRAM_STACK_SENTINEL = -1
 
 /** Pointer-derived area metrics for a two-pointer execution step. */
 export type AreaPointerState = {
@@ -77,7 +78,7 @@ export type HistogramPointerState = {
   mode: 'histogram'
   /** Index currently being processed. */
   currentIndex: number
-  /** Bar indexes currently held by the monotonic stack. */
+  /** Bar indexes currently held by the monotonic stack, optionally prefixed by -1. */
   stackIndices: number[]
   /** Best rectangle area recorded by the algorithm. */
   bestArea: number
@@ -240,6 +241,35 @@ function getHistogramRectangle(
   }
 }
 
+function isValidHistogramStackIndex(
+  index: number,
+  dataLength: number
+): boolean {
+  return (
+    index === HISTOGRAM_STACK_SENTINEL || (index >= 0 && index < dataLength)
+  )
+}
+
+function isMonotonicHistogramStack(
+  data: number[],
+  stackIndices: number[],
+  currentIndex: number
+): boolean {
+  return stackIndices.every((index, position) => {
+    if (index === HISTOGRAM_STACK_SENTINEL) return position === 0
+    if (index > currentIndex) return false
+    if (position === 0) return true
+
+    const previousIndex = stackIndices[position - 1]
+    const followsPreviousIndex = previousIndex < index
+    const followsPreviousHeight =
+      previousIndex === HISTOGRAM_STACK_SENTINEL ||
+      data[previousIndex] <= data[index]
+
+    return followsPreviousIndex && followsPreviousHeight
+  })
+}
+
 /** Derives monotonic-stack state for largest-rectangle-in-histogram code. */
 export function getHistogramPointerState(
   data: number[],
@@ -251,7 +281,11 @@ export function getHistogramPointerState(
   if (!isIntegerArray(rawStack)) return null
   if (isUndefined(bestArea)) return null
   if (data.some((height) => height < 0)) return null
-  if (rawStack.some((index) => index < 0 || index >= data.length)) return null
+  if (
+    rawStack.some((index) => !isValidHistogramStackIndex(index, data.length))
+  ) {
+    return null
+  }
 
   const stackIndices = [...rawStack]
   const currentIndex = resolveHistogramCurrentIndex(
@@ -261,14 +295,7 @@ export function getHistogramPointerState(
   )
   if (isNull(currentIndex)) return null
 
-  const isMonotonic = stackIndices.every((index, position) => {
-    if (index > currentIndex) return false
-    if (position === 0) return true
-
-    const previousIndex = stackIndices[position - 1]
-    return previousIndex < index && data[previousIndex] <= data[index]
-  })
-  if (!isMonotonic) return null
+  if (!isMonotonicHistogramStack(data, stackIndices, currentIndex)) return null
 
   return {
     mode: 'histogram',

--- a/src/features/visualization/lib/area-view.ts
+++ b/src/features/visualization/lib/area-view.ts
@@ -129,32 +129,76 @@ function readNumberVariable(
   return undefined
 }
 
+type HistogramRectangleVariables = {
+  poppedIndex: number
+  height: number
+  leftSmallIndex: number
+  width: number
+}
+
+function readHistogramRectangleVariables(
+  variables: Record<string, unknown>
+): HistogramRectangleVariables | null {
+  const poppedIndex = variables.mid
+  const height = variables.h
+  const leftSmallIndex = variables.leftSmallIndex
+  const width = variables.width
+
+  if (!isInteger(poppedIndex)) return null
+  if (!isNumber(height)) return null
+  if (!isInteger(leftSmallIndex)) return null
+  if (!isInteger(width)) return null
+
+  return { poppedIndex, height, leftSmallIndex, width }
+}
+
+function matchesPoppedBar(
+  data: number[],
+  { poppedIndex, height }: HistogramRectangleVariables
+): boolean {
+  const isInBounds = poppedIndex >= 0 && poppedIndex < data.length
+  return isInBounds && height === data[poppedIndex]
+}
+
+function matchesHistogramSpan({
+  rectangleVariables,
+  currentIndex,
+  stackTop,
+}: {
+  rectangleVariables: HistogramRectangleVariables
+  currentIndex: number
+  stackTop: number
+}): boolean {
+  const { leftSmallIndex, width } = rectangleVariables
+  const expectedWidth = currentIndex - leftSmallIndex - 1
+  const matchesStackBoundary = leftSmallIndex === stackTop
+  const matchesWidth = width === expectedWidth
+
+  return matchesStackBoundary && matchesWidth && width > 0
+}
+
 function getHistogramRectangle(
   data: number[],
   variables: Record<string, unknown>,
   currentIndex: number,
   stackIndices: number[]
 ): HistogramRectangle | undefined {
-  const poppedIndex = variables.mid
-  const height = variables.h
-  const leftSmallIndex = variables.leftSmallIndex
-  const width = variables.width
-  const stackTop = stackIndices[stackIndices.length - 1] ?? -1
+  const rectangleVariables = readHistogramRectangleVariables(variables)
+  if (isNull(rectangleVariables)) return undefined
 
+  const stackTop = stackIndices[stackIndices.length - 1] ?? -1
+  if (!matchesPoppedBar(data, rectangleVariables)) return undefined
   if (
-    !isInteger(poppedIndex) ||
-    !isNumber(height) ||
-    !isInteger(leftSmallIndex) ||
-    !isInteger(width) ||
-    poppedIndex < 0 ||
-    poppedIndex >= data.length ||
-    height !== data[poppedIndex] ||
-    leftSmallIndex !== stackTop ||
-    width !== currentIndex - leftSmallIndex - 1 ||
-    width <= 0
+    !matchesHistogramSpan({
+      rectangleVariables,
+      currentIndex,
+      stackTop,
+    })
   ) {
     return undefined
   }
+
+  const { poppedIndex, height, leftSmallIndex, width } = rectangleVariables
 
   const leftIndex = leftSmallIndex + 1
   const rightIndex = currentIndex - 1
@@ -184,7 +228,7 @@ export function getHistogramPointerState(
     !isIntegerArray(rawStack) ||
     isUndefined(bestArea) ||
     currentIndex < 0 ||
-    currentIndex >= data.length ||
+    currentIndex > data.length ||
     data.some((height) => height < 0) ||
     rawStack.some((index) => index < 0 || index >= data.length)
   ) {

--- a/src/features/visualization/lib/area-view.ts
+++ b/src/features/visualization/lib/area-view.ts
@@ -1,14 +1,23 @@
 import {
+  arrayOf,
   equals,
   isInteger,
   isNull,
   isNumber,
   isNumericArray,
   isUndefined,
+  oneOfValues,
 } from '@/shared/lib/guards'
 import type { ExecutionState } from '@/entities/execution'
 
 const isHeightVariableName = equals('height')
+const isHistogramVariableName = oneOfValues(
+  'height',
+  'heights',
+  'histogram',
+  'hs'
+)
+const isIntegerArray = arrayOf(isInteger)
 
 /** Pointer-derived area metrics for a two-pointer execution step. */
 export type AreaPointerState = {
@@ -46,8 +55,41 @@ export type RainWaterPointerState = {
   waterDepths: number[]
 }
 
-/** Area-view state supported by the container and rain-water modes. */
-export type AreaViewPointerState = AreaPointerState | RainWaterPointerState
+/** Rectangle evaluated after popping one bar from a monotonic stack. */
+export type HistogramRectangle = {
+  /** Index popped from the monotonic stack. */
+  poppedIndex: number
+  /** Inclusive left edge of the rectangle. */
+  leftIndex: number
+  /** Inclusive right edge of the rectangle. */
+  rightIndex: number
+  /** Height of the popped bar. */
+  height: number
+  /** Number of bars covered by the rectangle. */
+  width: number
+  /** Area of the evaluated rectangle. */
+  area: number
+}
+
+/** Monotonic-stack metrics for a largest-rectangle execution step. */
+export type HistogramPointerState = {
+  /** Largest-rectangle-in-histogram visualization mode. */
+  mode: 'histogram'
+  /** Index currently being processed. */
+  currentIndex: number
+  /** Bar indexes currently held by the monotonic stack. */
+  stackIndices: number[]
+  /** Best rectangle area recorded by the algorithm. */
+  bestArea: number
+  /** Rectangle currently being evaluated after a pop. */
+  rectangle?: HistogramRectangle
+}
+
+/** Area-view state supported by container, rain-water, and histogram modes. */
+export type AreaViewPointerState =
+  | AreaPointerState
+  | RainWaterPointerState
+  | HistogramPointerState
 
 /** Data and pointer metrics required by the area visualization. */
 export type AreaVisualizationState = {
@@ -85,6 +127,92 @@ function readNumberVariable(
   }
 
   return undefined
+}
+
+function getHistogramRectangle(
+  data: number[],
+  variables: Record<string, unknown>,
+  currentIndex: number,
+  stackIndices: number[]
+): HistogramRectangle | undefined {
+  const poppedIndex = variables.mid
+  const height = variables.h
+  const leftSmallIndex = variables.leftSmallIndex
+  const width = variables.width
+  const stackTop = stackIndices[stackIndices.length - 1] ?? -1
+
+  if (
+    !isInteger(poppedIndex) ||
+    !isNumber(height) ||
+    !isInteger(leftSmallIndex) ||
+    !isInteger(width) ||
+    poppedIndex < 0 ||
+    poppedIndex >= data.length ||
+    height !== data[poppedIndex] ||
+    leftSmallIndex !== stackTop ||
+    width !== currentIndex - leftSmallIndex - 1 ||
+    width <= 0
+  ) {
+    return undefined
+  }
+
+  const leftIndex = leftSmallIndex + 1
+  const rightIndex = currentIndex - 1
+  if (poppedIndex < leftIndex || poppedIndex > rightIndex) return undefined
+
+  return {
+    poppedIndex,
+    leftIndex,
+    rightIndex,
+    height,
+    width,
+    area: height * width,
+  }
+}
+
+/** Derives monotonic-stack state for largest-rectangle-in-histogram code. */
+export function getHistogramPointerState(
+  data: number[],
+  variables: Record<string, unknown>
+): HistogramPointerState | null {
+  const currentIndex = variables.i
+  const rawStack = variables.stack
+  const bestArea = readNumberVariable(variables, ['ans', 'maxArea'])
+
+  if (
+    !isInteger(currentIndex) ||
+    !isIntegerArray(rawStack) ||
+    isUndefined(bestArea) ||
+    currentIndex < 0 ||
+    currentIndex >= data.length ||
+    data.some((height) => height < 0) ||
+    rawStack.some((index) => index < 0 || index >= data.length)
+  ) {
+    return null
+  }
+
+  const stackIndices = [...rawStack]
+  const isMonotonic = stackIndices.every((index, position) => {
+    if (index > currentIndex) return false
+    if (position === 0) return true
+
+    const previousIndex = stackIndices[position - 1]
+    return previousIndex < index && data[previousIndex] <= data[index]
+  })
+  if (!isMonotonic) return null
+
+  return {
+    mode: 'histogram',
+    currentIndex,
+    stackIndices,
+    bestArea,
+    rectangle: getHistogramRectangle(
+      data,
+      variables,
+      currentIndex,
+      stackIndices
+    ),
+  }
 }
 
 /**
@@ -277,6 +405,10 @@ export function getAreaVisualizationState({
   const fallbackStep =
     executionState.steps[targetStepIndex ?? executionState.currentStep]
   const currentData = currentStep?.variables[variableName]
+  const currentHistogramState =
+    isNumericArray(currentData) && currentStep
+      ? getHistogramPointerState(currentData.map(Number), currentStep.variables)
+      : null
   const currentRainWaterState =
     isNumericArray(currentData) && currentStep
       ? getRainWaterPointerState(currentData.map(Number), currentStep.variables)
@@ -286,12 +418,21 @@ export function getAreaVisualizationState({
       ? getAreaPointerState(currentData.map(Number), currentStep.variables)
       : null
   const areaStep =
-    currentAreaState || currentRainWaterState ? currentStep : fallbackStep
+    currentAreaState || currentRainWaterState || currentHistogramState
+      ? currentStep
+      : fallbackStep
   const data = areaStep?.variables[variableName]
 
   if (!isNumericArray(data)) return null
 
   const numericData = data.map(Number)
+  const histogramState = areaStep
+    ? getHistogramPointerState(numericData, areaStep.variables)
+    : null
+  if (!isNull(histogramState)) {
+    return { data: numericData, areaState: histogramState }
+  }
+
   const rainWaterState = areaStep
     ? getRainWaterPointerState(numericData, areaStep.variables)
     : null
@@ -314,19 +455,37 @@ export function getAreaVisualizationState({
   return isNull(areaState) ? null : { data: numericData, areaState }
 }
 
+/** Checks whether a runtime value represents largest-rectangle stack state. */
+export function isHistogramAreaCandidate(
+  variableName: string,
+  value: unknown,
+  variables: Record<string, unknown>
+): boolean {
+  if (
+    !isHistogramVariableName(variableName.toLowerCase()) ||
+    !isNumericArray(value) ||
+    value.length === 0
+  ) {
+    return false
+  }
+
+  return !isNull(getHistogramPointerState(value.map(Number), variables))
+}
+
 /**
- * Checks whether a runtime value represents a two-pointer area problem.
+ * Checks whether a runtime value represents a supported area problem.
  *
  * @param variableName Candidate source variable name.
  * @param value Candidate runtime value.
  * @param variables Variables captured for the same execution step.
- * @returns Whether the value has compatible data, pointers, and area metadata.
+ * @returns Whether the value has compatible area or histogram metadata.
  */
 export function isAreaViewCandidate(
   variableName: string,
   value: unknown,
   variables: Record<string, unknown>
 ): boolean {
+  if (isHistogramAreaCandidate(variableName, value, variables)) return true
   if (!isNumericArray(value) || value.length < 2) return false
   if (!isHeightVariableName(variableName.toLowerCase())) return false
   const numericValue = value.map(Number)

--- a/src/features/visualization/lib/area-view.ts
+++ b/src/features/visualization/lib/area-view.ts
@@ -177,6 +177,32 @@ function matchesHistogramSpan({
   return matchesStackBoundary && matchesWidth && width > 0
 }
 
+function resolveHistogramCurrentIndex(
+  data: number[],
+  variables: Record<string, unknown>,
+  stackIndices: number[]
+): number | null {
+  const rectangleVariables = readHistogramRectangleVariables(variables)
+  const finalFlushIndex = data.length
+  const stackTop = stackIndices[stackIndices.length - 1] ?? -1
+  const isFinalFlushRectangle =
+    !isNull(rectangleVariables) &&
+    matchesPoppedBar(data, rectangleVariables) &&
+    matchesHistogramSpan({
+      rectangleVariables,
+      currentIndex: finalFlushIndex,
+      stackTop,
+    })
+
+  if (isFinalFlushRectangle) return finalFlushIndex
+
+  const currentIndex = variables.i
+  if (!isInteger(currentIndex)) return null
+  if (currentIndex < 0 || currentIndex > data.length) return null
+
+  return currentIndex
+}
+
 function getHistogramRectangle(
   data: number[],
   variables: Record<string, unknown>,
@@ -219,23 +245,22 @@ export function getHistogramPointerState(
   data: number[],
   variables: Record<string, unknown>
 ): HistogramPointerState | null {
-  const currentIndex = variables.i
   const rawStack = variables.stack
   const bestArea = readNumberVariable(variables, ['ans', 'maxArea'])
 
-  if (
-    !isInteger(currentIndex) ||
-    !isIntegerArray(rawStack) ||
-    isUndefined(bestArea) ||
-    currentIndex < 0 ||
-    currentIndex > data.length ||
-    data.some((height) => height < 0) ||
-    rawStack.some((index) => index < 0 || index >= data.length)
-  ) {
-    return null
-  }
+  if (!isIntegerArray(rawStack)) return null
+  if (isUndefined(bestArea)) return null
+  if (data.some((height) => height < 0)) return null
+  if (rawStack.some((index) => index < 0 || index >= data.length)) return null
 
   const stackIndices = [...rawStack]
+  const currentIndex = resolveHistogramCurrentIndex(
+    data,
+    variables,
+    stackIndices
+  )
+  if (isNull(currentIndex)) return null
+
   const isMonotonic = stackIndices.every((index, position) => {
     if (index > currentIndex) return false
     if (position === 0) return true

--- a/src/features/visualization/lib/area-view.ts
+++ b/src/features/visualization/lib/area-view.ts
@@ -387,6 +387,53 @@ export function getBestAreaPointerState(
 }
 
 /**
+ * Finds the highest recorded histogram result through a target step.
+ *
+ * When multiple snapshots have the same best area, the snapshot that shows
+ * the rectangle producing that area is preferred over a later stack-only step.
+ */
+export function getBestHistogramPointerState(
+  executionState: ExecutionState,
+  variableName: string,
+  targetStepIndex?: number
+): HistogramPointerState | null {
+  const endStepIndex = Math.min(
+    targetStepIndex ?? executionState.currentStep,
+    executionState.steps.length - 1
+  )
+  let bestState: HistogramPointerState | null = null
+
+  for (let index = 0; index <= endStepIndex; index += 1) {
+    const step = executionState.steps[index]
+    const data = step?.variables[variableName]
+
+    if (!isNumericArray(data)) continue
+
+    const histogramState = getHistogramPointerState(
+      data.map(Number),
+      step.variables
+    )
+    if (isNull(histogramState)) continue
+
+    const showsBestRectangle =
+      histogramState.rectangle?.area === histogramState.bestArea
+    const previousShowsBestRectangle =
+      bestState?.rectangle?.area === bestState?.bestArea
+
+    if (
+      isNull(bestState) ||
+      histogramState.bestArea > bestState.bestArea ||
+      (histogramState.bestArea === bestState.bestArea &&
+        (showsBestRectangle || !previousShowsBestRectangle))
+    ) {
+      bestState = histogramState
+    }
+  }
+
+  return bestState
+}
+
+/**
  * Resolves the data and pointer state displayed by the area visualization.
  *
  * @param options Execution state, source variable name, and optional target step.
@@ -426,6 +473,19 @@ export function getAreaVisualizationState({
   if (!isNumericArray(data)) return null
 
   const numericData = data.map(Number)
+  const shouldUseBestAreaState =
+    executionState.isComplete || currentStep?.type === 'return'
+  const bestHistogramState = shouldUseBestAreaState
+    ? getBestHistogramPointerState(
+        executionState,
+        variableName,
+        executionState.currentStep
+      )
+    : null
+  if (!isNull(bestHistogramState)) {
+    return { data: numericData, areaState: bestHistogramState }
+  }
+
   const histogramState = areaStep
     ? getHistogramPointerState(numericData, areaStep.variables)
     : null
@@ -440,8 +500,6 @@ export function getAreaVisualizationState({
     return { data: numericData, areaState: rainWaterState }
   }
 
-  const shouldUseBestAreaState =
-    executionState.isComplete || currentStep?.type === 'return'
   const areaState = shouldUseBestAreaState
     ? getBestAreaPointerState(
         executionState,

--- a/src/features/visualization/model/visualization-detection/detect-visualization-state.test.ts
+++ b/src/features/visualization/model/visualization-detection/detect-visualization-state.test.ts
@@ -236,6 +236,32 @@ describe('detectVisualizationState', () => {
     expect(detectVisualizationState(state).primaryAreaArrayName).toBe('height')
   })
 
+  it('prefers the sentinel histogram for a largest-rectangle area view', () => {
+    const state = createExecutionState([
+      createStep(0, 'Function called', {
+        heights: [2, 1, 5, 6, 2, 3],
+      }),
+      createStep(1, 'ans = Math.max(ans, h * width)', {
+        heights: [2, 1, 5, 6, 2, 3],
+        hs: [2, 1, 5, 6, 2, 3, 0],
+        stack: [1],
+        i: 4,
+        ans: 10,
+        mid: 2,
+        h: 5,
+        leftSmallIndex: 1,
+        width: 2,
+      }),
+    ])
+
+    expect(detectVisualizationState(state)).toEqual(
+      expect.objectContaining({
+        primaryAreaArrayName: 'hs',
+        primaryAreaStepIndex: 1,
+      })
+    )
+  })
+
   it('selects mutated numeric dp arrays for DP View', () => {
     const coinChangeState = createExecutionState([
       createStep(0, 'Initialized dp', { dp: [0, 12, 12, 12] }),

--- a/src/features/visualization/model/visualization-detection/indexed-candidates.ts
+++ b/src/features/visualization/model/visualization-detection/indexed-candidates.ts
@@ -1,6 +1,9 @@
 import type { ExecutionState } from '@/entities/execution'
 import { isBinarySearchArrayCandidate } from '../../lib/binary-search-view'
-import { isAreaViewCandidate } from '../../lib/area-view'
+import {
+  isAreaViewCandidate,
+  isHistogramAreaCandidate,
+} from '../../lib/area-view'
 import { isSlidingWindowCandidate } from '../../lib/sliding-window-view'
 import { isRollingDpCandidate } from '../../lib/rolling-dp-view'
 import { getExecutionStepSearchOrder } from '../../lib/execution-step-search'
@@ -30,12 +33,24 @@ export function getPrimaryAreaCandidate(
   executionState: ExecutionState,
   initialVariableNames: Set<string>
 ): IndexedVariableCandidate | undefined {
-  return findIndexedVariableCandidate(
+  const stepIndexes = getAllStepIndexes(executionState)
+  const derivedHistogramCandidate = findIndexedVariableCandidate(
     executionState,
-    getAllStepIndexes(executionState),
+    stepIndexes,
     (name, value, variables) =>
-      initialVariableNames.has(name) &&
-      isAreaViewCandidate(name, value, variables)
+      !initialVariableNames.has(name) &&
+      isHistogramAreaCandidate(name, value, variables)
+  )
+
+  return (
+    derivedHistogramCandidate ??
+    findIndexedVariableCandidate(
+      executionState,
+      stepIndexes,
+      (name, value, variables) =>
+        initialVariableNames.has(name) &&
+        isAreaViewCandidate(name, value, variables)
+    )
   )
 }
 

--- a/src/features/visualization/model/visualization-detection/types.ts
+++ b/src/features/visualization/model/visualization-detection/types.ts
@@ -19,7 +19,7 @@ export type VisualizationDetection = {
   primaryStackName: string | undefined
   /** Primary numeric array to show as a bar chart. */
   primaryArrayName: string | undefined
-  /** Primary height source to show in area or rain-water view. */
+  /** Primary height source to show in container, histogram, or rain-water view. */
   primaryAreaArrayName: string | undefined
   /** Step index where area pointers are available. */
   primaryAreaStepIndex: number | undefined

--- a/src/features/visualization/ui/area-visualizer.test.tsx
+++ b/src/features/visualization/ui/area-visualizer.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { AreaVisualizer } from './area-visualizer'
+
+describe('AreaVisualizer histogram mode', () => {
+  it('shows the monotonic stack and active rectangle', () => {
+    render(
+      <AreaVisualizer
+        data={[2, 1, 5, 6, 2, 3, 0]}
+        name="hs"
+        areaState={{
+          mode: 'histogram',
+          currentIndex: 4,
+          stackIndices: [1],
+          bestArea: 10,
+          rectangle: {
+            poppedIndex: 2,
+            leftIndex: 2,
+            rightIndex: 3,
+            height: 5,
+            width: 2,
+            area: 10,
+          },
+        }}
+      />
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Rectangle Area View: hs' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('i=4')).toBeInTheDocument()
+    expect(screen.getByText('stack=[1]')).toBeInTheDocument()
+    expect(screen.getByText('mid=2')).toBeInTheDocument()
+    expect(screen.getByText('width=2')).toBeInTheDocument()
+    expect(screen.getByText('area=10')).toBeInTheDocument()
+    expect(screen.getByText('best=10')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(
+        'Current rectangle: indexes 2 through 3, height 5, area 10'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/visualization/ui/area-visualizer.tsx
+++ b/src/features/visualization/ui/area-visualizer.tsx
@@ -10,6 +10,8 @@ const LABEL_CELL_CLASS =
   'min-w-8 text-center font-mono text-xs text-muted-foreground'
 const BOUNDARY_LABEL_CELL_CLASS =
   'h-6 min-w-8 text-center font-mono text-xs font-bold text-primary'
+const STACK_LABEL_CELL_CLASS =
+  'h-6 min-w-8 text-center font-mono text-xs font-bold text-amber-600 dark:text-amber-400'
 const INDEX_LABEL_CELL_CLASS =
   'h-6 min-w-8 text-center font-mono text-xs text-muted-foreground'
 
@@ -26,17 +28,49 @@ function getMarkerLabel(
   index: number,
   areaState: AreaViewPointerState
 ): string {
+  if (areaState.mode === 'histogram') {
+    if (index === areaState.currentIndex) return 'I'
+    if (index === areaState.rectangle?.poppedIndex) return 'M'
+
+    const stackPosition = areaState.stackIndices.indexOf(index)
+    return stackPosition >= 0 ? `S${stackPosition}` : String(index)
+  }
+
   if (index === areaState.leftIndex) return 'L'
   if (index === areaState.rightIndex) return 'R'
 
   return String(index)
 }
 
-function isBoundaryIndex(
+function isPrimaryIndex(
   index: number,
   areaState: AreaViewPointerState
 ): boolean {
+  if (areaState.mode === 'histogram') {
+    return (
+      index === areaState.currentIndex ||
+      index === areaState.rectangle?.poppedIndex
+    )
+  }
+
   return index === areaState.leftIndex || index === areaState.rightIndex
+}
+
+function isStackIndex(index: number, areaState: AreaViewPointerState): boolean {
+  return (
+    areaState.mode === 'histogram' && areaState.stackIndices.includes(index)
+  )
+}
+
+function getViewTitle(areaState: AreaViewPointerState): string {
+  switch (areaState.mode) {
+    case 'rain-water':
+      return 'Rain Water View'
+    case 'histogram':
+      return 'Rectangle Area View'
+    case 'container':
+      return 'Area View'
+  }
 }
 
 function AreaStat({
@@ -82,13 +116,22 @@ function AreaGridLabels({
 
 export function AreaVisualizer({ data, name, areaState }: AreaVisualizerProps) {
   const maxValue = Math.max(...data, 1)
-  const leftPercent = (areaState.leftIndex / data.length) * 100
-  const rightPercent =
-    ((data.length - areaState.rightIndex - 1) / data.length) * 100
-  const areaHeightPercent =
+  const rectangle =
     areaState.mode === 'container'
-      ? (areaState.currentHeight / maxValue) * 100
-      : 0
+      ? {
+          leftIndex: areaState.leftIndex,
+          rightIndex: areaState.rightIndex,
+          height: areaState.currentHeight,
+          area: areaState.currentArea,
+        }
+      : areaState.mode === 'histogram'
+        ? areaState.rectangle
+        : undefined
+  const leftPercent = rectangle ? (rectangle.leftIndex / data.length) * 100 : 0
+  const rightPercent = rectangle
+    ? ((data.length - rectangle.rightIndex - 1) / data.length) * 100
+    : 0
+  const areaHeightPercent = rectangle ? (rectangle.height / maxValue) * 100 : 0
   const columnTemplate = `repeat(${data.length}, ${CHART_COLUMN_TEMPLATE_MIN})`
   const markerLabels = data.map((_, index) => getMarkerLabel(index, areaState))
 
@@ -96,25 +139,48 @@ export function AreaVisualizer({ data, name, areaState }: AreaVisualizerProps) {
     <Card className="h-full border-0 shadow-none">
       <div className="flex h-full flex-col gap-4 p-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h3 className="font-mono text-lg font-semibold text-muted-foreground">
-            {areaState.mode === 'rain-water' ? 'Rain Water View' : 'Area View'}:{' '}
-            {name}
-          </h3>
+          <div>
+            <h3 className="font-mono text-lg font-semibold text-muted-foreground">
+              {getViewTitle(areaState)}: {name}
+            </h3>
+            {areaState.mode === 'histogram' && (
+              <p className="mt-1 font-mono text-xs text-muted-foreground">
+                I=current · S=stack position · M=popped bar
+              </p>
+            )}
+          </div>
           <div className="flex flex-wrap gap-2 font-mono text-xs">
-            <AreaStat>L={areaState.leftIndex}</AreaStat>
-            <AreaStat>R={areaState.rightIndex}</AreaStat>
             {areaState.mode === 'container' ? (
               <>
+                <AreaStat>L={areaState.leftIndex}</AreaStat>
+                <AreaStat>R={areaState.rightIndex}</AreaStat>
                 <AreaStat emphasized>area={areaState.currentArea}</AreaStat>
                 {areaState.bestArea !== undefined && (
                   <AreaStat>best={areaState.bestArea}</AreaStat>
                 )}
               </>
-            ) : (
+            ) : areaState.mode === 'rain-water' ? (
               <>
+                <AreaStat>L={areaState.leftIndex}</AreaStat>
+                <AreaStat>R={areaState.rightIndex}</AreaStat>
                 <AreaStat>leftMax={areaState.leftMax}</AreaStat>
                 <AreaStat>rightMax={areaState.rightMax}</AreaStat>
                 <AreaStat emphasized>water={areaState.totalWater}</AreaStat>
+              </>
+            ) : (
+              <>
+                <AreaStat>i={areaState.currentIndex}</AreaStat>
+                <AreaStat>stack=[{areaState.stackIndices.join(', ')}]</AreaStat>
+                {areaState.rectangle && (
+                  <>
+                    <AreaStat>mid={areaState.rectangle.poppedIndex}</AreaStat>
+                    <AreaStat>width={areaState.rectangle.width}</AreaStat>
+                    <AreaStat emphasized>
+                      area={areaState.rectangle.area}
+                    </AreaStat>
+                  </>
+                )}
+                <AreaStat>best={areaState.bestArea}</AreaStat>
               </>
             )}
           </div>
@@ -132,9 +198,19 @@ export function AreaVisualizer({ data, name, areaState }: AreaVisualizerProps) {
                 gridTemplateColumns: columnTemplate,
               }}
             >
-              {areaState.mode === 'container' && (
+              {rectangle && (
                 <div
-                  className="pointer-events-none absolute bottom-0 border-2 border-primary/80 bg-primary/20"
+                  aria-label={
+                    areaState.mode === 'histogram'
+                      ? `Current rectangle: indexes ${rectangle.leftIndex} through ${rectangle.rightIndex}, height ${rectangle.height}, area ${rectangle.area}`
+                      : `Current area: ${rectangle.area}`
+                  }
+                  className={[
+                    'pointer-events-none absolute bottom-0 border-2',
+                    areaState.mode === 'histogram'
+                      ? 'border-amber-500/90 bg-amber-400/20'
+                      : 'border-primary/80 bg-primary/20',
+                  ].join(' ')}
                   style={{
                     left: `${leftPercent}%`,
                     right: `${rightPercent}%`,
@@ -148,7 +224,8 @@ export function AreaVisualizer({ data, name, areaState }: AreaVisualizerProps) {
                   areaState.mode === 'rain-water'
                     ? (areaState.waterDepths[index] / maxValue) * 100
                     : 0
-                const isBoundary = isBoundaryIndex(index, areaState)
+                const isPrimary = isPrimaryIndex(index, areaState)
+                const isStacked = isStackIndex(index, areaState)
 
                 return (
                   <div
@@ -158,9 +235,11 @@ export function AreaVisualizer({ data, name, areaState }: AreaVisualizerProps) {
                     <div
                       className={[
                         'w-full rounded-t-sm border transition-colors',
-                        isBoundary
+                        isPrimary
                           ? 'border-primary bg-primary'
-                          : 'border-primary/20 bg-primary/70',
+                          : isStacked
+                            ? 'border-amber-500 bg-amber-400/80'
+                            : 'border-primary/20 bg-primary/70',
                       ].join(' ')}
                       style={{
                         height: `${Math.max(barHeightPercent, MIN_BAR_HEIGHT)}%`,
@@ -188,9 +267,11 @@ export function AreaVisualizer({ data, name, areaState }: AreaVisualizerProps) {
                 <div
                   key={index}
                   className={
-                    isBoundaryIndex(index, areaState)
+                    isPrimaryIndex(index, areaState)
                       ? BOUNDARY_LABEL_CELL_CLASS
-                      : INDEX_LABEL_CELL_CLASS
+                      : isStackIndex(index, areaState)
+                        ? STACK_LABEL_CELL_CLASS
+                        : INDEX_LABEL_CELL_CLASS
                   }
                 >
                   {label}

--- a/src/features/visualization/ui/variables-card.tsx
+++ b/src/features/visualization/ui/variables-card.tsx
@@ -50,7 +50,7 @@ type VariablesCardProps = {
   primaryExpressionStepIndex?: number
   /** Primary array variable detected for chart visualization. */
   primaryArrayName?: string
-  /** Primary numeric array detected for container-area visualization. */
+  /** Primary numeric array detected for an area visualization. */
   primaryAreaArrayName?: string
   /** Step index where area pointers are available. */
   primaryAreaStepIndex?: number

--- a/src/features/visualization/ui/visualization-modal.tsx
+++ b/src/features/visualization/ui/visualization-modal.tsx
@@ -132,7 +132,7 @@ function getVisualizationDescription(
     case 'bar-chart':
       return 'Visualize numeric array as a bar chart.'
     case 'area':
-      return 'Visualize the current two-pointer area or trapped water.'
+      return 'Visualize the current container, histogram rectangle, or trapped water.'
     case 'binary-search':
       return 'Visualize the current binary-search range and mid index.'
     case 'sliding-window':


### PR DESCRIPTION
## Summary

Add largest rectangle area visualization.

<!-- A brief summary of the changes -->

## Description

- add histogram mode to Area View
- visualize the monotonic stack, current index, popped bar, and active rectangle
- display current width, area, and best area

<!-- A detailed explanation of the changes, including why they are needed -->
