### PR TITLE
chore: enable changelog why sections

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -24,10 +24,13 @@ jobs:
           changelog-path: CHANGELOG.md
           base-branch: main
           provider: openai
-          npm-version: 0.6.5
+          npm-version: 0.6.6
           release-tag: ${{ github.event.release.tag_name }}
           release-name: ${{ github.event.release.tag_name }}
           release-body: ${{ github.event.release.body }}
+          why: "true"
+          why-confidence: medium
+          why-label: Why
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary

Enable changelog why sections.

<!-- A brief summary of the changes -->

## Description

- update `ChangelogBot’s` npm version to 0.6.6
- enable `Why` sections with medium confidence
- label generated rationale sections as `Why`

<!-- A detailed explanation of the changes, including why they are needed -->
