### PR TITLE
fix: trace object-backed heap values

### DIFF
--- a/src/features/code-execution/lib/runner.single-heap-trace.test.ts
+++ b/src/features/code-execution/lib/runner.single-heap-trace.test.ts
@@ -98,6 +98,104 @@ class KthLargest {
 }
 `
 
+const kSmallestPairsCode = `
+type HeapItem = {
+  sum: number
+  i: number
+  j: number
+}
+
+class MinHeapPairs {
+  private heap: HeapItem[] = []
+
+  get size(): number {
+    return this.heap.length
+  }
+
+  push(item: HeapItem): void {
+    this.heap.push(item)
+    this.bubbleUp(this.heap.length - 1)
+  }
+
+  pop(): HeapItem | undefined {
+    if (this.heap.length === 0) return undefined
+
+    const min = this.heap[0]
+    const last = this.heap.pop()!
+
+    if (this.heap.length > 0) {
+      this.heap[0] = last
+      this.bubbleDown(0)
+    }
+
+    return min
+  }
+
+  private bubbleUp(index: number): void {
+    while (index > 0) {
+      const parent = Math.floor((index - 1) / 2)
+      if (this.heap[parent].sum <= this.heap[index].sum) break
+
+      ;[this.heap[parent], this.heap[index]] = [
+        this.heap[index],
+        this.heap[parent],
+      ]
+      index = parent
+    }
+  }
+
+  private bubbleDown(index: number): void {
+    const length = this.heap.length
+
+    while (true) {
+      let smallest = index
+      const left = index * 2 + 1
+      const right = index * 2 + 2
+
+      if (left < length && this.heap[left].sum < this.heap[smallest].sum)
+        smallest = left
+      if (right < length && this.heap[right].sum < this.heap[smallest].sum)
+        smallest = right
+      if (smallest === index) break
+
+      ;[this.heap[index], this.heap[smallest]] = [
+        this.heap[smallest],
+        this.heap[index],
+      ]
+      index = smallest
+    }
+  }
+}
+
+function kSmallestPairs(
+  nums1: number[],
+  nums2: number[],
+  k: number
+): number[][] {
+  const result: number[][] = []
+  const minHeap = new MinHeapPairs()
+
+  for (let i = 0; i < Math.min(nums1.length, k); i++) {
+    minHeap.push({ sum: nums1[i] + nums2[0], i, j: 0 })
+  }
+
+  while (result.length < k && minHeap.size > 0) {
+    const current = minHeap.pop()!
+    result.push([nums1[current.i], nums2[current.j]])
+
+    if (current.j + 1 < nums2.length) {
+      minHeap.push({
+        sum: nums1[current.i] + nums2[current.j + 1],
+        i: current.i,
+        j: current.j + 1,
+      })
+    }
+  }
+
+  return result
+}
+`
+
 function getHeapSnapshotsForCall(
   state: ReturnType<typeof executeCode>,
   functionName: string
@@ -134,5 +232,30 @@ describe('runner - single heap trace', () => {
         .flatMap((step) => step.metadata?.heapTrace?.heaps ?? [])
         .every((heap) => heap.kind === 'min')
     ).toBe(true)
+  })
+
+  it('captures summed object values from a MinHeap-prefixed class', () => {
+    const state = executeCode(
+      kSmallestPairsCode,
+      { nums1: [1, 7, 11], nums2: [2, 4, 6], k: 3 },
+      'kSmallestPairs'
+    )
+    const heaps = state.steps.flatMap(
+      (step) => step.metadata?.heapTrace?.heaps ?? []
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([
+      [1, 2],
+      [1, 4],
+      [1, 6],
+    ])
+    expect(heaps.length).toBeGreaterThan(0)
+    expect(heaps.every((heap) => heap.kind === 'min')).toBe(true)
+    expect(heaps).toContainEqual({
+      name: 'minHeap',
+      kind: 'min',
+      values: [3, 9, 13],
+    })
   })
 })

--- a/src/features/code-execution/lib/step-recorder.ts
+++ b/src/features/code-execution/lib/step-recorder.ts
@@ -10,6 +10,7 @@ import {
 import { deepClone } from '@/shared/lib/deep-clone'
 import {
   arrayOf,
+  define,
   hasKeys,
   isFunction,
   isNonArrayObject,
@@ -22,9 +23,19 @@ import { MAX_STEPS, StepLimitError } from './execution-errors'
 
 const PREPARED_HEAP_KIND_LABEL = '__algorithmVisualizerHeapKind'
 const isPreparedHeapKind = oneOfValues('min', 'max')
-const isLocalHeapClassName = oneOfValues('MinHeap', 'MaxHeap')
+const isLocalMinHeapClassName = define<string>(
+  (value) => isString(value) && /^MinHeap(?:$|[A-Z0-9_])/.test(value)
+)
+const isLocalMaxHeapClassName = define<string>(
+  (value) => isString(value) && /^MaxHeap(?:$|[A-Z0-9_])/.test(value)
+)
 const isHeapStorageName = oneOfValues('heap', 'values')
 const isNumberArray = arrayOf(isNumber)
+const isSummedHeapItem = define<{ sum: number }>(
+  (value) =>
+    isNonArrayObject(value) && hasKeys('sum')(value) && isNumber(value.sum)
+)
+const isSummedHeapItemArray = arrayOf(isSummedHeapItem)
 const hasPreparedHeapKeys = hasKeys(PREPARED_HEAP_KIND_LABEL, 'values')
 const hasPreparedHeapKind = hasKeys(PREPARED_HEAP_KIND_LABEL)
 
@@ -47,26 +58,37 @@ function getHeapKind(
   if (!isFunction(value.constructor)) return undefined
 
   const className = value.constructor.name
-  if (!isLocalHeapClassName(className)) return undefined
+  if (isLocalMinHeapClassName(className)) return 'min'
+  if (isLocalMaxHeapClassName(className)) return 'max'
+  return undefined
+}
 
-  return className === 'MinHeap' ? 'min' : 'max'
+function normalizeHeapValues(value: unknown): number[] | undefined {
+  if (isNumberArray(value)) return [...value]
+  if (isSummedHeapItemArray(value)) {
+    return value.map((item) => item.sum)
+  }
+
+  return undefined
 }
 
 function getHeapValues(
   value: Record<PropertyKey, unknown>
 ): number[] | undefined {
-  if (hasPreparedHeapKeys(value) && isNumberArray(value.values)) {
-    return [...value.values]
+  if (hasPreparedHeapKeys(value)) {
+    const preparedValues = normalizeHeapValues(value.values)
+    if (preparedValues) return preparedValues
   }
 
-  const numericArrays = Object.entries(value).flatMap(([name, candidate]) =>
-    isNumberArray(candidate) ? [[name, candidate] as const] : []
-  )
+  const heapArrays = Object.entries(value).flatMap(([name, candidate]) => {
+    const values = normalizeHeapValues(candidate)
+    return values ? [[name, values] as const] : []
+  })
   const storage =
-    numericArrays.find(([name]) => isHeapStorageName(name)) ??
-    (numericArrays.length === 1 ? numericArrays[0] : undefined)
+    heapArrays.find(([name]) => isHeapStorageName(name)) ??
+    (heapArrays.length === 1 ? heapArrays[0] : undefined)
 
-  return storage ? [...storage[1]] : undefined
+  return storage ? storage[1] : undefined
 }
 
 function getDefaultHeapName(kind: HeapKind): string {


### PR DESCRIPTION
## Summary

Fix trace object-backed heap values.

<!-- A brief summary of the changes -->

## Description

Extend heap detection to recognize `MinHeap`/`MaxHeap`-prefixed class names and object-backed heap storage with numeric sum priorities. This enables Heap View for implementations such as `MinHeapPairs` used by `kSmallestPairs`.

Adds a regression test covering heap snapshots, priority ordering, and the algorithm result.

<!-- A detailed explanation of the changes, including why they are needed -->
