### PR TITLE
feat: trace async execution

### DIFF
--- a/src/entities/execution/model/constants.ts
+++ b/src/entities/execution/model/constants.ts
@@ -13,6 +13,9 @@ export const STEP_TYPES = {
   ARRAY_MUTATION: 'array-mutation',
   LOOP_ITERATION: 'loop-iteration',
   CONDITION: 'condition',
+  AWAIT_SUSPEND: 'await-suspend',
+  AWAIT_RESUME: 'await-resume',
+  AWAIT_REJECT: 'await-reject',
 } as const
 
 export type ExecutionStepType = (typeof STEP_TYPES)[keyof typeof STEP_TYPES]

--- a/src/features/code-execution/lib/instrumentation/await-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/await-visitor.ts
@@ -14,16 +14,19 @@ export const createAwaitVisitor = (context: InstrumentationContext) => ({
 
       const line = getLineNumber(path.node)
       const source = safeGenerate(path.node.argument)
+      const operandId = path.scope.generateUidIdentifier(
+        'algorithmVisualizerAwaitOperand'
+      )
       const resultId = path.scope.generateUidIdentifier(
         'algorithmVisualizerAwaitResult'
       )
       const errorId = path.scope.generateUidIdentifier(
         'algorithmVisualizerAwaitError'
       )
-      const wrappedAwait = t.awaitExpression(path.node.argument)
+      const wrappedAwait = t.awaitExpression(operandId)
       const wrapper = context.markInstrumented(
         t.arrowFunctionExpression(
-          [],
+          [operandId],
           t.blockStatement([
             createRecordStepStatement(
               STEP_TYPES.AWAIT_SUSPEND,
@@ -65,7 +68,9 @@ export const createAwaitVisitor = (context: InstrumentationContext) => ({
       path.replaceWith(
         context.markInstrumented(
           t.awaitExpression(
-            context.markInstrumented(t.callExpression(wrapper, []))
+            context.markInstrumented(
+              t.callExpression(wrapper, [path.node.argument])
+            )
           )
         )
       )

--- a/src/features/code-execution/lib/instrumentation/await-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/await-visitor.ts
@@ -1,0 +1,74 @@
+import { type NodePath } from '@babel/traverse'
+import * as t from '@babel/types'
+
+import { STEP_TYPES } from '@/entities/execution'
+import { getLineNumber, safeGenerate } from './ast-utils'
+import { InstrumentationContext } from './context'
+import { createRecordStepStatement } from './step-factory'
+
+/** Records suspension, fulfillment, and rejection around each await boundary. */
+export const createAwaitVisitor = (context: InstrumentationContext) => ({
+  AwaitExpression: {
+    exit(path: NodePath<t.AwaitExpression>) {
+      if (context.isInstrumented(path.node)) return
+
+      const line = getLineNumber(path.node)
+      const source = safeGenerate(path.node.argument)
+      const resultId = path.scope.generateUidIdentifier(
+        'algorithmVisualizerAwaitResult'
+      )
+      const errorId = path.scope.generateUidIdentifier(
+        'algorithmVisualizerAwaitError'
+      )
+      const wrappedAwait = t.awaitExpression(path.node.argument)
+      const wrapper = context.markInstrumented(
+        t.arrowFunctionExpression(
+          [],
+          t.blockStatement([
+            createRecordStepStatement(
+              STEP_TYPES.AWAIT_SUSPEND,
+              line,
+              `Awaiting: ${source}`,
+              context.createScopeProperties()
+            ),
+            t.tryStatement(
+              t.blockStatement([
+                t.variableDeclaration('const', [
+                  t.variableDeclarator(resultId, wrappedAwait),
+                ]),
+                createRecordStepStatement(
+                  STEP_TYPES.AWAIT_RESUME,
+                  line,
+                  `Resumed after await: ${source}`,
+                  context.createScopeProperties()
+                ),
+                t.returnStatement(resultId),
+              ]),
+              t.catchClause(
+                errorId,
+                t.blockStatement([
+                  createRecordStepStatement(
+                    STEP_TYPES.AWAIT_REJECT,
+                    line,
+                    `Await rejected: ${source}`,
+                    context.createScopeProperties()
+                  ),
+                  t.throwStatement(errorId),
+                ])
+              )
+            ),
+          ]),
+          true
+        )
+      )
+
+      path.replaceWith(
+        context.markInstrumented(
+          t.awaitExpression(
+            context.markInstrumented(t.callExpression(wrapper, []))
+          )
+        )
+      )
+    },
+  },
+})

--- a/src/features/code-execution/lib/instrumentation/mutation-visitors.ts
+++ b/src/features/code-execution/lib/instrumentation/mutation-visitors.ts
@@ -44,192 +44,270 @@ const getArrayMutationTargetName = (
   return ''
 }
 
-export const createMutationVisitors = (context: InstrumentationContext) => ({
-  VariableDeclaration: {
-    exit(path: NodePath<t.VariableDeclaration>) {
-      if (
-        context.isInstrumented(path.node) ||
-        shouldSkipVariableDeclarationStep(path)
-      ) {
-        return
-      }
+type AssignmentTrace = { descriptionPrefix: string }
 
-      context.addVariablesToCurrentScope(
-        path.node.declarations.flatMap((declarator) =>
-          collectBindingNames(declarator.id)
-        )
-      )
+type ArrayMutationTrace = { description: string }
 
-      path.node.declarations.forEach((declarator, index) => {
+function hasAwaitExpression(path: NodePath): boolean {
+  let hasAwait = false
+
+  path.traverse({
+    AwaitExpression(awaitPath) {
+      hasAwait = true
+      awaitPath.stop()
+    },
+  })
+
+  return hasAwait
+}
+
+export const createMutationVisitors = (context: InstrumentationContext) => {
+  const initializerDescriptions = new WeakMap<t.VariableDeclaration, string>()
+  const assignmentTraces = new WeakMap<
+    t.AssignmentExpression,
+    AssignmentTrace
+  >()
+  const arrayMutationTraces = new WeakMap<
+    t.CallExpression,
+    ArrayMutationTrace
+  >()
+
+  return {
+    VariableDeclaration: {
+      enter(path: NodePath<t.VariableDeclaration>) {
+        if (context.isInstrumented(path.node)) return
+
+        const lastDeclaration = path.node.declarations.at(-1)
+        if (lastDeclaration) {
+          initializerDescriptions.set(
+            path.node,
+            getInitializerDescription(lastDeclaration.init)
+          )
+        }
+      },
+      exit(path: NodePath<t.VariableDeclaration>) {
         if (
-          !t.isIdentifier(declarator.id) ||
-          index !== path.node.declarations.length - 1
+          context.isInstrumented(path.node) ||
+          shouldSkipVariableDeclarationStep(path)
         ) {
           return
         }
 
-        const variableName = declarator.id.name
-        path.insertAfter(
-          createRecordStepStatement(
-            STEP_TYPES.VARIABLE_DECLARATION,
-            getLineNumber(declarator),
-            `${path.node.kind} ${variableName} = ${getInitializerDescription(declarator.init)}`,
-            context.createScopeProperties([
-              t.objectProperty(
-                t.identifier(variableName),
-                t.identifier(variableName)
+        context.addVariablesToCurrentScope(
+          path.node.declarations.flatMap((declarator) =>
+            collectBindingNames(declarator.id)
+          )
+        )
+
+        path.node.declarations.forEach((declarator, index) => {
+          if (
+            !t.isIdentifier(declarator.id) ||
+            index !== path.node.declarations.length - 1
+          ) {
+            return
+          }
+
+          const variableName = declarator.id.name
+          const initializerDescription =
+            initializerDescriptions.get(path.node) ??
+            getInitializerDescription(declarator.init)
+          path.insertAfter(
+            createRecordStepStatement(
+              STEP_TYPES.VARIABLE_DECLARATION,
+              getLineNumber(declarator),
+              `${path.node.kind} ${variableName} = ${initializerDescription}`,
+              context.createScopeProperties([
+                t.objectProperty(
+                  t.identifier(variableName),
+                  t.identifier(variableName)
+                ),
+              ])
+            )
+          )
+        })
+
+        context.markInstrumented(path.node)
+      },
+    },
+
+    AssignmentExpression: {
+      enter(path: NodePath<t.AssignmentExpression>) {
+        if (context.isInstrumented(path.node)) return
+
+        const variableName = getAssignmentTargetName(path.node.left)
+        if (!variableName) return
+
+        assignmentTraces.set(path.node, {
+          descriptionPrefix: `${variableName} ${path.node.operator} ${safeGenerate(path.node.right)} -> `,
+        })
+      },
+      exit(path: NodePath<t.AssignmentExpression>) {
+        if (context.isInstrumented(path.node)) return
+
+        const trace = assignmentTraces.get(path.node)
+        if (!trace) return
+        const isAsyncAssignment = hasAwaitExpression(path)
+
+        const resultId = path.scope.generateUidIdentifier(
+          'algorithmVisualizerAssignmentResult'
+        )
+        const resultDeclaration = context.markInstrumented(
+          t.variableDeclaration('const', [
+            t.variableDeclarator(resultId, context.markInstrumented(path.node)),
+          ])
+        )
+        const description = t.templateLiteral(
+          [
+            t.templateElement({
+              raw: trace.descriptionPrefix,
+              cooked: trace.descriptionPrefix,
+            }),
+            t.templateElement({ raw: '', cooked: '' }, true),
+          ],
+          [t.identifier(resultId.name)]
+        )
+        const syntheticArrow = context.markInstrumented(
+          t.arrowFunctionExpression(
+            [],
+            t.blockStatement([
+              resultDeclaration,
+              createRecordStepStatement(
+                STEP_TYPES.ASSIGNMENT,
+                getLineNumber(path.node),
+                description,
+                context.createScopeProperties()
+              ),
+              context.markInstrumented(
+                t.returnStatement(t.identifier(resultId.name))
+              ),
+            ]),
+            isAsyncAssignment
+          )
+        )
+
+        const invocation = context.markInstrumented(
+          t.callExpression(syntheticArrow, [])
+        )
+        path.replaceWith(
+          isAsyncAssignment
+            ? context.markInstrumented(t.awaitExpression(invocation))
+            : invocation
+        )
+      },
+    },
+
+    UpdateExpression(path: NodePath<t.UpdateExpression>) {
+      if (
+        context.isInstrumented(path.node) ||
+        !t.isIdentifier(path.node.argument) ||
+        (path.parentPath.isForStatement() && path.key === 'update')
+      ) {
+        return
+      }
+
+      const { operator, prefix } = path.node
+      const variableName = path.node.argument.name
+      const isStandaloneStatement = path.parentPath.isExpressionStatement()
+      if (!isStandaloneStatement && !prefix) return
+
+      path.replaceWith(
+        context.markInstrumented(
+          t.sequenceExpression([
+            context.markInstrumented(path.node),
+            createRecordStepCall(
+              STEP_TYPES.ASSIGNMENT,
+              getLineNumber(path.node),
+              `${prefix ? operator : ''}${variableName}${prefix ? '' : operator}`,
+              context.createScopeProperties()
+            ),
+            t.identifier(variableName),
+          ])
+        )
+      )
+    },
+
+    CallExpression: {
+      enter(path: NodePath<t.CallExpression>) {
+        if (context.isInstrumented(path.node)) return
+
+        const methodName = getMemberPropertyName(path.node.callee)
+        if (!methodName || !MUTATING_ARRAY_METHODS.has(methodName)) return
+
+        const calleeObject = t.isMemberExpression(path.node.callee)
+          ? path.node.callee.object
+          : null
+        const arrayName = getArrayMutationTargetName(calleeObject)
+        if (!arrayName) return
+
+        const argumentsCode = path.node.arguments
+          .map((argument) => safeGenerate(argument))
+          .join(', ')
+        arrayMutationTraces.set(path.node, {
+          description: `${arrayName}.${methodName}(${argumentsCode})`,
+        })
+      },
+      exit(path: NodePath<t.CallExpression>) {
+        if (context.isInstrumented(path.node)) return
+
+        const trace = arrayMutationTraces.get(path.node)
+        if (!trace) return
+
+        if (!path.parentPath.isExpressionStatement()) {
+          const isAsyncMutation = hasAwaitExpression(path)
+          const resultId = path.scope.generateUidIdentifier(
+            'algorithmVisualizerMutationResult'
+          )
+          const syntheticArrow = context.markInstrumented(
+            t.arrowFunctionExpression(
+              [],
+              t.blockStatement([
+                context.markInstrumented(
+                  t.variableDeclaration('const', [
+                    t.variableDeclarator(
+                      resultId,
+                      context.markInstrumented(path.node)
+                    ),
+                  ])
+                ),
+                createRecordStepStatement(
+                  STEP_TYPES.ARRAY_MUTATION,
+                  getLineNumber(path.node),
+                  trace.description,
+                  context.createScopeProperties()
+                ),
+                context.markInstrumented(
+                  t.returnStatement(t.identifier(resultId.name))
+                ),
+              ]),
+              isAsyncMutation
+            )
+          )
+
+          const invocation = context.markInstrumented(
+            t.callExpression(syntheticArrow, [])
+          )
+          path.replaceWith(
+            isAsyncMutation
+              ? context.markInstrumented(t.awaitExpression(invocation))
+              : invocation
+          )
+          return
+        }
+
+        path.replaceWith(
+          context.markInstrumented(
+            t.sequenceExpression([
+              context.markInstrumented(path.node),
+              createRecordStepCall(
+                STEP_TYPES.ARRAY_MUTATION,
+                getLineNumber(path.node),
+                trace.description,
+                context.createScopeProperties()
               ),
             ])
           )
         )
-      })
-
-      context.markInstrumented(path.node)
+      },
     },
-  },
-
-  AssignmentExpression(path: NodePath<t.AssignmentExpression>) {
-    if (context.isInstrumented(path.node)) return
-
-    const variableName = getAssignmentTargetName(path.node.left)
-    if (!variableName) return
-
-    const resultId = path.scope.generateUidIdentifier(
-      'algorithmVisualizerAssignmentResult'
-    )
-    const resultDeclaration = context.markInstrumented(
-      t.variableDeclaration('const', [
-        t.variableDeclarator(resultId, context.markInstrumented(path.node)),
-      ])
-    )
-    const descriptionPrefix = `${variableName} ${path.node.operator} ${safeGenerate(path.node.right)} -> `
-    const description = t.templateLiteral(
-      [
-        t.templateElement({
-          raw: descriptionPrefix,
-          cooked: descriptionPrefix,
-        }),
-        t.templateElement({ raw: '', cooked: '' }, true),
-      ],
-      [t.identifier(resultId.name)]
-    )
-    const syntheticArrow = context.markInstrumented(
-      t.arrowFunctionExpression(
-        [],
-        t.blockStatement([
-          resultDeclaration,
-          createRecordStepStatement(
-            STEP_TYPES.ASSIGNMENT,
-            getLineNumber(path.node),
-            description,
-            context.createScopeProperties()
-          ),
-          context.markInstrumented(
-            t.returnStatement(t.identifier(resultId.name))
-          ),
-        ])
-      )
-    )
-
-    path.replaceWith(
-      context.markInstrumented(t.callExpression(syntheticArrow, []))
-    )
-  },
-
-  UpdateExpression(path: NodePath<t.UpdateExpression>) {
-    if (
-      context.isInstrumented(path.node) ||
-      !t.isIdentifier(path.node.argument) ||
-      (path.parentPath.isForStatement() && path.key === 'update')
-    ) {
-      return
-    }
-
-    const { operator, prefix } = path.node
-    const variableName = path.node.argument.name
-    const isStandaloneStatement = path.parentPath.isExpressionStatement()
-    if (!isStandaloneStatement && !prefix) return
-
-    path.replaceWith(
-      context.markInstrumented(
-        t.sequenceExpression([
-          context.markInstrumented(path.node),
-          createRecordStepCall(
-            STEP_TYPES.ASSIGNMENT,
-            getLineNumber(path.node),
-            `${prefix ? operator : ''}${variableName}${prefix ? '' : operator}`,
-            context.createScopeProperties()
-          ),
-          t.identifier(variableName),
-        ])
-      )
-    )
-  },
-
-  CallExpression(path: NodePath<t.CallExpression>) {
-    if (context.isInstrumented(path.node)) return
-
-    const methodName = getMemberPropertyName(path.node.callee)
-    if (!methodName || !MUTATING_ARRAY_METHODS.has(methodName)) return
-
-    const calleeObject = t.isMemberExpression(path.node.callee)
-      ? path.node.callee.object
-      : null
-    const arrayName = getArrayMutationTargetName(calleeObject)
-    if (!arrayName) return
-
-    const argumentsCode = path.node.arguments
-      .map((argument) => safeGenerate(argument))
-      .join(', ')
-    const description = `${arrayName}.${methodName}(${argumentsCode})`
-
-    if (!path.parentPath.isExpressionStatement()) {
-      const resultId = path.scope.generateUidIdentifier(
-        'algorithmVisualizerMutationResult'
-      )
-      const syntheticArrow = context.markInstrumented(
-        t.arrowFunctionExpression(
-          [],
-          t.blockStatement([
-            context.markInstrumented(
-              t.variableDeclaration('const', [
-                t.variableDeclarator(
-                  resultId,
-                  context.markInstrumented(path.node)
-                ),
-              ])
-            ),
-            createRecordStepStatement(
-              STEP_TYPES.ARRAY_MUTATION,
-              getLineNumber(path.node),
-              description,
-              context.createScopeProperties()
-            ),
-            context.markInstrumented(
-              t.returnStatement(t.identifier(resultId.name))
-            ),
-          ])
-        )
-      )
-
-      path.replaceWith(
-        context.markInstrumented(t.callExpression(syntheticArrow, []))
-      )
-      return
-    }
-
-    path.replaceWith(
-      context.markInstrumented(
-        t.sequenceExpression([
-          context.markInstrumented(path.node),
-          createRecordStepCall(
-            STEP_TYPES.ARRAY_MUTATION,
-            getLineNumber(path.node),
-            description,
-            context.createScopeProperties()
-          ),
-        ])
-      )
-    )
-  },
-})
+  }
+}

--- a/src/features/code-execution/lib/instrumentation/mutation-visitors.ts
+++ b/src/features/code-execution/lib/instrumentation/mutation-visitors.ts
@@ -52,6 +52,9 @@ function hasAwaitExpression(path: NodePath): boolean {
   let hasAwait = false
 
   path.traverse({
+    Function(functionPath) {
+      functionPath.skip()
+    },
     AwaitExpression(awaitPath) {
       hasAwait = true
       awaitPath.stop()

--- a/src/features/code-execution/lib/instrumentation/return-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/return-visitor.ts
@@ -22,56 +22,70 @@ const getReturnArgumentDescription = (argument: t.Expression): string => {
   return safeGenerate(argument)
 }
 
-export const createReturnVisitor = (context: InstrumentationContext) => ({
-  ReturnStatement(path: NodePath<t.ReturnStatement>) {
-    if (context.isInstrumented(path.node)) return
+export const createReturnVisitor = (context: InstrumentationContext) => {
+  const argumentDescriptions = new WeakMap<t.ReturnStatement, string>()
 
-    const line = getLineNumber(path.node)
-    const returnLocation = `${context.getCurrentFunctionName()} line ${line}`
+  return {
+    ReturnStatement: {
+      enter(path: NodePath<t.ReturnStatement>) {
+        if (context.isInstrumented(path.node) || !path.node.argument) return
 
-    if (path.node.argument) {
-      const tempId = path.scope.generateUidIdentifier(RETURN_TEMP_NAME)
-      const declaration = context.markInstrumented(
-        t.variableDeclaration('const', [
-          t.variableDeclarator(tempId, path.node.argument),
-        ])
-      )
-      const recordStep = createRecordStepStatement(
-        STEP_TYPES.RETURN,
-        line,
-        `return from ${returnLocation}: ${getReturnArgumentDescription(path.node.argument)}`,
-        context.createScopeProperties([
-          t.objectProperty(t.stringLiteral(RETURN_VALUE_LABEL), tempId),
-          t.objectProperty(
-            t.stringLiteral(RETURN_LOCATION_LABEL),
-            t.stringLiteral(returnLocation)
-          ),
-        ])
-      )
-      const returnStatement = context.markInstrumented(
-        t.returnStatement(tempId)
-      )
-      path.replaceWithMultiple([declaration, recordStep, returnStatement])
-      return
-    }
+        argumentDescriptions.set(
+          path.node,
+          getReturnArgumentDescription(path.node.argument)
+        )
+      },
+      exit(path: NodePath<t.ReturnStatement>) {
+        if (context.isInstrumented(path.node)) return
 
-    path.insertBefore(
-      createRecordStepStatement(
-        STEP_TYPES.RETURN,
-        line,
-        `return from ${returnLocation}: undefined`,
-        context.createScopeProperties([
-          t.objectProperty(
-            t.stringLiteral(RETURN_VALUE_LABEL),
-            t.identifier('undefined')
-          ),
-          t.objectProperty(
-            t.stringLiteral(RETURN_LOCATION_LABEL),
-            t.stringLiteral(returnLocation)
-          ),
-        ])
-      )
-    )
-    context.markInstrumented(path.node)
-  },
-})
+        const line = getLineNumber(path.node)
+        const returnLocation = `${context.getCurrentFunctionName()} line ${line}`
+
+        if (path.node.argument) {
+          const tempId = path.scope.generateUidIdentifier(RETURN_TEMP_NAME)
+          const declaration = context.markInstrumented(
+            t.variableDeclaration('const', [
+              t.variableDeclarator(tempId, path.node.argument),
+            ])
+          )
+          const recordStep = createRecordStepStatement(
+            STEP_TYPES.RETURN,
+            line,
+            `return from ${returnLocation}: ${argumentDescriptions.get(path.node) ?? getReturnArgumentDescription(path.node.argument)}`,
+            context.createScopeProperties([
+              t.objectProperty(t.stringLiteral(RETURN_VALUE_LABEL), tempId),
+              t.objectProperty(
+                t.stringLiteral(RETURN_LOCATION_LABEL),
+                t.stringLiteral(returnLocation)
+              ),
+            ])
+          )
+          const returnStatement = context.markInstrumented(
+            t.returnStatement(tempId)
+          )
+          path.replaceWithMultiple([declaration, recordStep, returnStatement])
+          return
+        }
+
+        path.insertBefore(
+          createRecordStepStatement(
+            STEP_TYPES.RETURN,
+            line,
+            `return from ${returnLocation}: undefined`,
+            context.createScopeProperties([
+              t.objectProperty(
+                t.stringLiteral(RETURN_VALUE_LABEL),
+                t.identifier('undefined')
+              ),
+              t.objectProperty(
+                t.stringLiteral(RETURN_LOCATION_LABEL),
+                t.stringLiteral(returnLocation)
+              ),
+            ])
+          )
+        )
+        context.markInstrumented(path.node)
+      },
+    },
+  }
+}

--- a/src/features/code-execution/lib/instrumentation/visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/visitor.ts
@@ -1,4 +1,5 @@
 import { InstrumentationContext } from './context'
+import { createAwaitVisitor } from './await-visitor'
 import { createFunctionVisitors } from './function-visitors'
 import { createLoopVisitors } from './loop-visitors'
 import { createMutationVisitors } from './mutation-visitors'
@@ -8,6 +9,7 @@ export const createInstrumentationVisitor = () => {
   const context = new InstrumentationContext()
   return {
     ...createFunctionVisitors(context),
+    ...createAwaitVisitor(context),
     ...createMutationVisitors(context),
     ...createLoopVisitors(context),
     ...createReturnVisitor(context),

--- a/src/features/code-execution/lib/instrumenter.regressions.test.ts
+++ b/src/features/code-execution/lib/instrumenter.regressions.test.ts
@@ -83,6 +83,56 @@ describe('instrumentation regressions', () => {
     })
   })
 
+  it('does not treat awaits in assigned functions as part of the assignment', () => {
+    const state = executeCode(
+      `
+      function configure() {
+        let callback
+        callback = async () => await Promise.resolve(42)
+        return typeof callback
+      }
+      `,
+      {},
+      'configure'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe('function')
+    expect(
+      state.steps.some(
+        (step) =>
+          step.type === 'assignment' &&
+          step.description.startsWith('callback =')
+      )
+    ).toBe(true)
+  })
+
+  it('does not treat awaits in array mutation callbacks as part of the mutation', () => {
+    const state = executeCode(
+      `
+      function configure() {
+        const callbacks = []
+        const length = callbacks.push(
+          async () => await Promise.resolve(42)
+        )
+        return length
+      }
+      `,
+      {},
+      'configure'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(1)
+    expect(
+      state.steps.some(
+        (step) =>
+          step.type === 'array-mutation' &&
+          step.description.startsWith('callbacks.push(')
+      )
+    ).toBe(true)
+  })
+
   it('executes returned functions for LeetCode factory solutions', () => {
     const state = executeCode(
       `

--- a/src/features/code-execution/lib/runner.async.test.ts
+++ b/src/features/code-execution/lib/runner.async.test.ts
@@ -36,6 +36,78 @@ describe('runner - async execution', () => {
     ).toBe(true)
   })
 
+  it('records synchronous operand work before await suspension', async () => {
+    const state = await executeCodeAsync(
+      `function helper(): number {
+  const helperValue = 2
+  return helperValue
+}
+
+async function calculate(): Promise<number> {
+  let value = 0
+  value = await helper()
+  return value
+}`,
+      {},
+      'calculate'
+    )
+    const helperEntryIndex = state.steps.findIndex(
+      (step) => step.description === 'Entering function: helper'
+    )
+    const helperDeclarationIndex = state.steps.findIndex(
+      (step) =>
+        step.type === 'variable-declaration' &&
+        step.description.startsWith('const helperValue =')
+    )
+    const suspendIndex = state.steps.findIndex(
+      (step) => step.type === 'await-suspend'
+    )
+
+    expect(helperEntryIndex).toBeGreaterThan(-1)
+    expect(helperDeclarationIndex).toBeGreaterThan(helperEntryIndex)
+    expect(suspendIndex).toBeGreaterThan(helperDeclarationIndex)
+  })
+
+  it('records a synchronous operand assignment before await suspension', async () => {
+    const state = await executeCodeAsync(
+      `async function assign(): Promise<number> {
+  let value = 0
+  await (value = 1)
+  return value
+}`,
+      {},
+      'assign'
+    )
+    const assignmentIndex = state.steps.findIndex(
+      (step) => step.type === 'assignment'
+    )
+    const suspendIndex = state.steps.findIndex(
+      (step) => step.type === 'await-suspend'
+    )
+
+    expect(assignmentIndex).toBeGreaterThan(-1)
+    expect(suspendIndex).toBeGreaterThan(assignmentIndex)
+  })
+
+  it('does not report suspension when operand evaluation throws', async () => {
+    const state = await executeCodeAsync(
+      `function fail(): never {
+  throw new Error('boom')
+}
+
+async function run(): Promise<void> {
+  await fail()
+}`,
+      {},
+      'run'
+    )
+
+    expect(state.error).toBe('boom')
+    expect(state.steps.some((step) => step.type.startsWith('await-'))).toBe(
+      false
+    )
+  })
+
   it('reports rejected Promises without losing earlier snapshots', async () => {
     const state = await executeCodeAsync(
       `async function fail(): Promise<void> {

--- a/src/features/code-execution/lib/runner.async.test.ts
+++ b/src/features/code-execution/lib/runner.async.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { executeCodeAsync } from './runner'
+import { stepBackward, stepForward } from './execution-state'
+
+describe('runner - async execution', () => {
+  it('records multiple sequential await boundaries in execution order', async () => {
+    const state = await executeCodeAsync(
+      `async function calculate(start: number): Promise<number> {
+  let value = start
+  value += await Promise.resolve(2)
+  const next = await Promise.resolve(value + 3)
+  return await Promise.resolve(next)
+}`,
+      { start: 1 },
+      'calculate'
+    )
+    const awaitSteps = state.steps.filter((step) =>
+      step.type.startsWith('await-')
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(6)
+    expect(awaitSteps.map((step) => step.type)).toEqual([
+      'await-suspend',
+      'await-resume',
+      'await-suspend',
+      'await-resume',
+      'await-suspend',
+      'await-resume',
+    ])
+    expect(
+      state.steps.some(
+        (step) =>
+          step.type === 'assignment' && step.description.startsWith('value +=')
+      )
+    ).toBe(true)
+  })
+
+  it('reports rejected Promises without losing earlier snapshots', async () => {
+    const state = await executeCodeAsync(
+      `async function fail(): Promise<void> {
+  const before = 'recorded'
+  await Promise.reject(new Error('boom'))
+  const after = 'unreachable'
+}`,
+      {},
+      'fail'
+    )
+    const rejectedStep = state.steps.find(
+      (step) => step.type === 'await-reject'
+    )
+
+    expect(state.error).toBe('boom')
+    expect(rejectedStep?.variables.before).toBe('recorded')
+    expect(
+      state.steps.some((step) => Object.hasOwn(step.variables, 'after'))
+    ).toBe(false)
+    expect(state.steps.at(-1)?.description).toBe('Error: boom')
+  })
+
+  it('rewinds and resumes across an await boundary', async () => {
+    const state = await executeCodeAsync(
+      `async function double(value: number): Promise<number> {
+  const result = await Promise.resolve(value * 2)
+  return result
+}`,
+      { value: 3 },
+      'double'
+    )
+    const resumeIndex = state.steps.findIndex(
+      (step) => step.type === 'await-resume'
+    )
+    const atResume = { ...state, currentStep: resumeIndex }
+    const atSuspend = stepBackward(atResume)
+
+    expect(atSuspend.steps[atSuspend.currentStep]?.type).toBe('await-suspend')
+    expect(atSuspend.steps[atSuspend.currentStep]?.variables.value).toBe(3)
+    expect(stepForward(atSuspend).currentStep).toBe(resumeIndex)
+  })
+
+  it('awaits an explicitly returned Promise', async () => {
+    const state = await executeCodeAsync(
+      `function answer(): Promise<number> {
+  return Promise.resolve(42)
+}`,
+      {},
+      'answer'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(42)
+    expect(state.steps.at(-1)?.description).toBe('Returned: 42')
+  })
+
+  it('preserves synchronous execution through the async worker path', async () => {
+    const state = await executeCodeAsync(
+      `function add(left: number, right: number): number {
+  return left + right
+}`,
+      { left: 2, right: 3 },
+      'add'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(5)
+  })
+})

--- a/src/features/code-execution/lib/runner.ts
+++ b/src/features/code-execution/lib/runner.ts
@@ -8,6 +8,7 @@ import type {
 import {
   createTypeScriptExecutionRunner,
   executeTypeScriptCode,
+  executeTypeScriptCodeAsync,
 } from './typescript-runner'
 export {
   resetToStart,
@@ -45,6 +46,24 @@ export function executeCode(
 ): ExecutionState {
   if (language === 'typescript') {
     return executeTypeScriptCode(code, inputs, entryFunctionName)
+  }
+
+  throw new Error(
+    `Language "${String(language)}" does not support execution yet`
+  )
+}
+
+/**
+ * Executes code and waits for asynchronous entry-point completion.
+ */
+export async function executeCodeAsync(
+  code: string,
+  inputs: InputValues,
+  entryFunctionName?: string,
+  language: SupportedLanguage = DEFAULT_LANGUAGE
+): Promise<ExecutionState> {
+  if (language === 'typescript') {
+    return executeTypeScriptCodeAsync(code, inputs, entryFunctionName)
   }
 
   throw new Error(

--- a/src/features/code-execution/lib/typescript-runner.ts
+++ b/src/features/code-execution/lib/typescript-runner.ts
@@ -150,6 +150,75 @@ export function* createTypeScriptExecutionRunner(
 }
 
 /**
+ * Promise-aware execution engine used by the worker runtime.
+ */
+export async function* createAsyncTypeScriptExecutionRunner(
+  code: string,
+  inputs: InputValues,
+  entryFunctionName?: string
+): AsyncGenerator<ExecutionStep, unknown, undefined> {
+  const context = createExecutionContext(inputs)
+
+  const recordStep = (
+    type: ExecutionStep['type'],
+    line: number,
+    description: string,
+    stepVariables: Record<string, unknown>
+  ): ExecutionStep =>
+    recordExecutionStep(context, type, line, description, stepVariables)
+
+  try {
+    yield recordStep(
+      'function-call',
+      0,
+      `Function called with: ${safeStringify(inputs)}`,
+      {}
+    )
+
+    const preparedExecution = prepareExecution(code, inputs, entryFunctionName)
+    const func = createExecutionFunction(
+      preparedExecution.inputNames,
+      preparedExecution.wrapperCode
+    )
+
+    let result: unknown
+    let stepLimitReached = false
+
+    try {
+      result = await func(...Object.values(inputs), recordStep)
+    } catch (err) {
+      if (isStepLimitError(err)) {
+        stepLimitReached = true
+      } else {
+        throw err
+      }
+    }
+
+    for (let i = 1; i < context.steps.length; i++) {
+      yield context.steps[i]
+    }
+
+    if (stepLimitReached) {
+      yield createStepLimitWarningStep(context)
+      return undefined
+    }
+
+    yield recordStep('return', 0, `Returned: ${safeStringify(result)}`, {
+      result,
+    })
+
+    return result
+  } catch (error) {
+    const errorMessage = isError(error) ? error.message : 'Unknown error'
+    for (let i = 1; i < context.steps.length; i++) {
+      yield context.steps[i]
+    }
+    yield recordStep('return', 0, `Error: ${errorMessage}`, {})
+    throw error
+  }
+}
+
+/**
  * Executes TypeScript/JavaScript code and returns complete execution state.
  */
 export function executeTypeScriptCode(
@@ -172,6 +241,56 @@ export function executeTypeScriptCode(
     while (!result.done) {
       steps.push(result.value)
       result = runner.next()
+    }
+
+    returnValue = result.value
+    const lastStep = steps[steps.length - 1]
+    if (
+      lastStep?.description === `Warning: ${getStepLimitMessage(MAX_STEPS)}`
+    ) {
+      error = getStepLimitMessage(MAX_STEPS)
+    }
+  } catch (err) {
+    if (isStepLimitError(err)) {
+      error = err.message
+    } else {
+      error = isError(err) ? err.message : 'Execution failed'
+    }
+  }
+
+  return {
+    currentStep: 0,
+    totalSteps: steps.length,
+    steps,
+    isComplete: false,
+    returnValue,
+    error,
+  }
+}
+
+/**
+ * Executes TypeScript/JavaScript code and waits for a returned Promise.
+ */
+export async function executeTypeScriptCodeAsync(
+  code: string,
+  inputs: InputValues,
+  entryFunctionName?: string
+): Promise<ExecutionState> {
+  const steps: ExecutionStep[] = []
+  let returnValue: unknown
+  let error: string | undefined
+
+  try {
+    const runner = createAsyncTypeScriptExecutionRunner(
+      code,
+      inputs,
+      entryFunctionName
+    )
+
+    let result = await runner.next()
+    while (!result.done) {
+      steps.push(result.value)
+      result = await runner.next()
     }
 
     returnValue = result.value

--- a/src/features/code-execution/ui/input-form.test.tsx
+++ b/src/features/code-execution/ui/input-form.test.tsx
@@ -43,6 +43,12 @@ const numberMatrixSignature: FunctionSignature = {
   returnType: 'number',
 }
 
+const asyncNoInputSignature: FunctionSignature = {
+  name: 'never',
+  parameters: [],
+  returnType: 'any',
+}
+
 const lowestCommonAncestorSignature: FunctionSignature = {
   name: 'lowestCommonAncestor',
   parameters: [
@@ -66,6 +72,31 @@ function listToArray(node: TestListNode | null): number[] {
 }
 
 describe('InputForm ListNode inputs', () => {
+  it('shows pending execution for an async zero-input function', async () => {
+    let finishExecution: (() => void) | undefined
+    const handleSubmit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishExecution = resolve
+        })
+    )
+
+    render(
+      <InputForm signature={asyncNoInputSignature} onSubmit={handleSubmit} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }))
+
+    expect(handleSubmit).toHaveBeenCalledWith({})
+    expect(screen.getByRole('button', { name: 'Running...' })).toBeDisabled()
+
+    finishExecution?.()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Run' })).toBeEnabled()
+    })
+  })
+
   it('prefills primitive and array parameters from default input values', () => {
     render(
       <InputForm

--- a/src/features/code-execution/ui/input-form.tsx
+++ b/src/features/code-execution/ui/input-form.tsx
@@ -65,7 +65,7 @@ type InputFormProps = {
   /** Optional initial values used to prefill example inputs. */
   defaultInputValues?: Record<string, unknown>
   /** Callback invoked with converted input values on submit. */
-  onSubmit: (values: Record<string, unknown>) => void
+  onSubmit: (values: Record<string, unknown>) => void | Promise<void>
   /** Callback invoked with raw form values suitable for restoring/share URLs. */
   onRawInputChange?: (values: Record<string, unknown>) => void
 }
@@ -106,6 +106,7 @@ function InputFormContent({
       resolvedDefaultInputValues
     )
   )
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const defaultValues = createDefaultInputValues(
     signature.parameters,
     resolvedDefaultInputValues
@@ -191,7 +192,7 @@ function InputFormContent({
   /**
    * Handles form submission
    */
-  const onFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const onFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
     const data = getRawFormValues(event.currentTarget)
@@ -212,7 +213,12 @@ function InputFormContent({
     }
 
     onRawInputChange?.(rawInputs)
-    onSubmit(convertInputValues(signature.parameters, rawInputs))
+    setIsSubmitting(true)
+    try {
+      await onSubmit(convertInputValues(signature.parameters, rawInputs))
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (
@@ -295,8 +301,8 @@ function InputFormContent({
               )
             })}
 
-            <Button type="submit" className="w-full">
-              Run
+            <Button type="submit" disabled={isSubmitting} className="w-full">
+              {isSubmitting ? 'Running...' : 'Run'}
             </Button>
           </Stack>
         </form>

--- a/src/features/code-execution/worker/execution-worker-handler.test.ts
+++ b/src/features/code-execution/worker/execution-worker-handler.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { handleExecutionWorkerRequest } from './execution-worker-handler'
+
+describe('handleExecutionWorkerRequest', () => {
+  it('waits for an async entry point before returning its execution state', async () => {
+    const response = await handleExecutionWorkerRequest({
+      type: 'execute',
+      requestId: 'async-request',
+      code: `async function answer(): Promise<number> {
+  const value = await Promise.resolve(42)
+  return value
+}`,
+      inputs: {},
+      entryFunctionName: 'answer',
+      language: 'typescript',
+    })
+
+    expect(response.type).toBe('success')
+    if (response.type !== 'success') return
+
+    expect(response.state.error).toBeUndefined()
+    expect(response.state.returnValue).toBe(42)
+    expect(response.state.steps.some((step) => step.line === 3)).toBe(true)
+    expect(response.state.steps.map((step) => step.type)).toEqual(
+      expect.arrayContaining(['await-suspend', 'await-resume'])
+    )
+  })
+
+  it('returns the recorded trace when an awaited Promise rejects', async () => {
+    const response = await handleExecutionWorkerRequest({
+      type: 'execute',
+      requestId: 'rejected-request',
+      code: `async function fail(): Promise<void> {
+  const before = 'recorded'
+  await Promise.reject(new Error('boom'))
+}`,
+      inputs: {},
+      entryFunctionName: 'fail',
+      language: 'typescript',
+    })
+
+    expect(response.type).toBe('success')
+    if (response.type !== 'success') return
+
+    expect(response.state.error).toBe('boom')
+    expect(
+      response.state.steps.find((step) => step.type === 'await-reject')
+        ?.variables.before
+    ).toBe('recorded')
+  })
+})

--- a/src/features/code-execution/worker/execution-worker-handler.ts
+++ b/src/features/code-execution/worker/execution-worker-handler.ts
@@ -1,0 +1,28 @@
+import { isError } from '@/shared/lib/guards'
+import { executeCodeAsync } from '../lib/runner'
+import type {
+  ExecutionWorkerRequest,
+  ExecutionWorkerResponse,
+} from './execution-worker-protocol'
+
+/** Executes one validated worker request through the Promise-aware runner. */
+export async function handleExecutionWorkerRequest(
+  request: ExecutionWorkerRequest
+): Promise<ExecutionWorkerResponse> {
+  try {
+    const state = await executeCodeAsync(
+      request.code,
+      request.inputs,
+      request.entryFunctionName,
+      request.language
+    )
+
+    return { type: 'success', requestId: request.requestId, state }
+  } catch (error) {
+    return {
+      type: 'failure',
+      requestId: request.requestId,
+      message: isError(error) ? error.message : 'Execution failed',
+    }
+  }
+}

--- a/src/features/code-execution/worker/execution-worker.ts
+++ b/src/features/code-execution/worker/execution-worker.ts
@@ -1,9 +1,8 @@
-import { executeCode } from '../lib/runner'
 import {
   isExecutionWorkerRequest,
   type ExecutionWorkerResponse,
 } from './execution-worker-protocol'
-import { isError } from '@/shared/lib/guards'
+import { handleExecutionWorkerRequest } from './execution-worker-handler'
 import { createWorkerTransferValue } from './worker-transfer'
 
 type WorkerScope = {
@@ -33,24 +32,8 @@ function sendResponse(response: ExecutionWorkerResponse): void {
   }
 }
 
-workerScope.addEventListener('message', (event) => {
+workerScope.addEventListener('message', async (event) => {
   if (!isExecutionWorkerRequest(event.data)) return
 
-  const request = event.data
-
-  try {
-    const state = executeCode(
-      request.code,
-      request.inputs,
-      request.entryFunctionName,
-      request.language
-    )
-    sendResponse({ type: 'success', requestId: request.requestId, state })
-  } catch (error) {
-    sendResponse({
-      type: 'failure',
-      requestId: request.requestId,
-      message: isError(error) ? error.message : 'Execution failed',
-    })
-  }
+  sendResponse(await handleExecutionWorkerRequest(event.data))
 })

--- a/src/features/visualization/ui/execution-timeline-card.test.tsx
+++ b/src/features/visualization/ui/execution-timeline-card.test.tsx
@@ -85,4 +85,55 @@ describe('ExecutionTimelineCard', () => {
       'text-timeline-current-foreground'
     )
   })
+
+  it('identifies await suspension, resumption, and rejection steps', () => {
+    render(
+      <ExecutionTimelineCard
+        executionState={{
+          currentStep: 1,
+          totalSteps: 3,
+          steps: [
+            {
+              stepNumber: 0,
+              type: 'await-suspend',
+              line: 2,
+              description: 'Awaiting: loadValue()',
+              variables: {},
+              timestamp: 0,
+            },
+            {
+              stepNumber: 1,
+              type: 'await-resume',
+              line: 2,
+              description: 'Resumed after await: loadValue()',
+              variables: {},
+              timestamp: 1,
+            },
+            {
+              stepNumber: 2,
+              type: 'await-reject',
+              line: 4,
+              description: 'Await rejected: saveValue()',
+              variables: {},
+              timestamp: 2,
+            },
+          ],
+          isComplete: false,
+        }}
+        isRunning={false}
+        timelineRef={createRef()}
+        currentStepRef={createRef()}
+        onPause={vi.fn()}
+        onStart={vi.fn()}
+        onReset={vi.fn()}
+        onStepForward={vi.fn()}
+        onStepBackward={vi.fn()}
+        onSkipToEnd={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('await-suspend')).toBeInTheDocument()
+    expect(screen.getByText('await-resume')).toBeInTheDocument()
+    expect(screen.getByText('await-reject')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Close #40 

## Summary

Add basic async/await execution tracing.

<!-- A brief summary of the changes -->

## Description

- Wait for Promise-returning entry functions before finalizing execution
- Record await suspension, resumption, and rejection steps
- Preserve recorded steps when an awaited Promise rejects
- Support multiple sequential await expressions and `return await`
- Keep timeline navigation working across async boundaries
- Preserve timeout and cancellation behavior for pending Promises
- Show a `Running...` state while async execution is pending

<!-- A detailed explanation of the changes, including why they are needed -->
