### PR TITLE
feat: track concurrent promise frames

### DIFF
--- a/src/entities/execution/model/constants.ts
+++ b/src/entities/execution/model/constants.ts
@@ -7,6 +7,7 @@ export const FUNCTION_NAME_LABEL = '__algorithmVisualizerFunctionName'
 export const STEP_TYPES = {
   FUNCTION_CALL: 'function-call',
   FUNCTION_ENTRY: 'function-entry',
+  FUNCTION_THROW: 'function-throw',
   VARIABLE_DECLARATION: 'variable-declaration',
   RETURN: 'return',
   ASSIGNMENT: 'assignment',

--- a/src/entities/execution/model/types.ts
+++ b/src/entities/execution/model/types.ts
@@ -18,7 +18,7 @@ export type HeapTraceSnapshot = {
   heaps: HeapSnapshot[]
 }
 
-export type CallFramePhase = 'enter' | 'update' | 'return'
+export type CallFramePhase = 'enter' | 'update' | 'return' | 'throw'
 
 /** Runtime identity and visible binding names for one logical call frame. */
 export type CallFrameStepMetadata = {

--- a/src/features/code-execution/lib/frame-identity.ts
+++ b/src/features/code-execution/lib/frame-identity.ts
@@ -1,0 +1,2 @@
+/** Hidden step payload key carrying the current runtime invocation ID. */
+export const CALL_FRAME_ID_LABEL = '__algorithmVisualizerCallFrameId'

--- a/src/features/code-execution/lib/instrumentation/context.ts
+++ b/src/features/code-execution/lib/instrumentation/context.ts
@@ -7,12 +7,14 @@ import {
   STEP_TYPES,
 } from '@/entities/execution'
 import { getUniqueNames } from './binding-names'
-import { createRecordStepStatement } from './step-factory'
+import { CALL_FRAME_ID_LABEL } from '../frame-identity'
+import { createRecordStepCall } from './step-factory'
 
 export class InstrumentationContext {
   private readonly scopeStack: string[][] = []
   private readonly functionStack: string[] = []
   private readonly classReceiverStack: boolean[] = []
+  private readonly frameIdentifierStack: t.Identifier[] = []
   private readonly instrumentedNodes = new WeakSet<t.Node>()
 
   isInstrumented(node: t.Node): boolean {
@@ -49,7 +51,8 @@ export class InstrumentationContext {
   }
 
   createScopeProperties(
-    extraProperties: t.ObjectProperty[] = []
+    extraProperties: t.ObjectProperty[] = [],
+    includeFrameIdentity = true
   ): t.ObjectProperty[] {
     const visibleVariables = getUniqueNames(this.scopeStack.flat())
     return [
@@ -65,6 +68,19 @@ export class InstrumentationContext {
             ),
           ]
         : []),
+      ...(includeFrameIdentity ? this.createFrameIdentityProperties() : []),
+    ]
+  }
+
+  createFrameIdentityProperties(): t.ObjectProperty[] {
+    const frameIdentifier = this.frameIdentifierStack.at(-1)
+    if (!frameIdentifier) return []
+
+    return [
+      t.objectProperty(
+        t.stringLiteral(CALL_FRAME_ID_LABEL),
+        t.identifier(frameIdentifier.name)
+      ),
     ]
   }
 
@@ -74,16 +90,17 @@ export class InstrumentationContext {
     line: number,
     description: string,
     parameterNames: string[],
+    frameIdentifier: t.Identifier,
     captureClassReceiver = false
   ): void {
     this.pushScope(parameterNames)
     this.classReceiverStack.push(captureClassReceiver)
-    body.body.unshift(
-      createRecordStepStatement(
-        STEP_TYPES.FUNCTION_ENTRY,
-        line,
-        description,
-        this.createScopeProperties([
+    const entryStep = createRecordStepCall(
+      STEP_TYPES.FUNCTION_ENTRY,
+      line,
+      description,
+      this.createScopeProperties(
+        [
           t.objectProperty(
             t.stringLiteral(FUNCTION_NAME_LABEL),
             t.stringLiteral(functionName)
@@ -96,14 +113,31 @@ export class InstrumentationContext {
               )
             )
           ),
+        ],
+        false
+      )
+    )
+    const frameId = t.memberExpression(
+      t.memberExpression(
+        t.memberExpression(entryStep, t.identifier('metadata')),
+        t.identifier('callFrame')
+      ),
+      t.identifier('frameId')
+    )
+    body.body.unshift(
+      this.markInstrumented(
+        t.variableDeclaration('const', [
+          t.variableDeclarator(frameIdentifier, frameId),
         ])
       )
     )
+    this.frameIdentifierStack.push(frameIdentifier)
     this.functionStack.push(functionName)
   }
 
   exitFunction(): void {
     this.functionStack.pop()
+    this.frameIdentifierStack.pop()
     this.classReceiverStack.pop()
     this.popScope()
   }

--- a/src/features/code-execution/lib/instrumentation/function-visitors.ts
+++ b/src/features/code-execution/lib/instrumentation/function-visitors.ts
@@ -45,6 +45,49 @@ const addImplicitReturnStep = (
   )
 }
 
+const wrapFunctionBodyWithThrowStep = (
+  context: InstrumentationContext,
+  body: t.BlockStatement,
+  functionName: string,
+  line: number,
+  errorId: t.Identifier
+): void => {
+  const entryStatement = body.body[0]
+  if (!entryStatement) return
+
+  const functionBody = body.body.slice(1)
+  const throwLocation = `${functionName} line ${line}`
+  const throwStep = createRecordStepStatement(
+    STEP_TYPES.FUNCTION_THROW,
+    line,
+    `throw from ${throwLocation}`,
+    context.createFrameIdentityProperties()
+  )
+  const rethrow = context.markInstrumented(
+    t.throwStatement(t.identifier(errorId.name))
+  )
+  const boundary = context.markInstrumented(
+    t.tryStatement(
+      t.blockStatement(functionBody),
+      t.catchClause(errorId, t.blockStatement([throwStep, rethrow]))
+    )
+  )
+
+  body.body = [entryStatement, boundary]
+}
+
+const finishFunction = (
+  context: InstrumentationContext,
+  body: t.BlockStatement,
+  functionName: string,
+  line: number,
+  errorId: t.Identifier
+): void => {
+  addImplicitReturnStep(context, body, functionName, line)
+  wrapFunctionBodyWithThrowStep(context, body, functionName, line, errorId)
+  context.exitFunction()
+}
+
 export const createFunctionVisitors = (context: InstrumentationContext) => ({
   FunctionDeclaration: {
     enter(path: NodePath<t.FunctionDeclaration>) {
@@ -54,18 +97,19 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
         functionName,
         getLineNumber(path.node),
         `Entering function: ${functionName}`,
-        getParameterNames(path.node.params)
+        getParameterNames(path.node.params),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameId')
       )
     },
     exit(path: NodePath<t.FunctionDeclaration>) {
       const functionName = path.node.id?.name ?? 'anonymous'
-      addImplicitReturnStep(
+      finishFunction(
         context,
         path.node.body,
         functionName,
-        path.node.loc?.end.line ?? getLineNumber(path.node)
+        path.node.loc?.end.line ?? getLineNumber(path.node),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameError')
       )
-      context.exitFunction()
     },
   },
 
@@ -82,20 +126,21 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
         'anonymous function',
         getLineNumber(path.node),
         'Entering anonymous function',
-        getParameterNames(path.node.params)
+        getParameterNames(path.node.params),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameId')
       )
     },
     exit(path: NodePath<t.FunctionExpression>) {
       if (context.isInstrumented(path.node) || isSkippedArrayCallback(path)) {
         return
       }
-      addImplicitReturnStep(
+      finishFunction(
         context,
         path.node.body,
         'anonymous function',
-        path.node.loc?.end.line ?? getLineNumber(path.node)
+        path.node.loc?.end.line ?? getLineNumber(path.node),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameError')
       )
-      context.exitFunction()
     },
   },
 
@@ -117,6 +162,7 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
         getLineNumber(path.node),
         'Entering arrow function',
         getParameterNames(path.node.params),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameId'),
         context.shouldCaptureClassReceiver()
       )
     },
@@ -124,13 +170,13 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
       if (context.isInstrumented(path.node) || isSkippedArrayCallback(path)) {
         return
       }
-      addImplicitReturnStep(
+      finishFunction(
         context,
         path.node.body as t.BlockStatement,
         'arrow function',
-        path.node.loc?.end.line ?? getLineNumber(path.node)
+        path.node.loc?.end.line ?? getLineNumber(path.node),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameError')
       )
-      context.exitFunction()
     },
   },
 
@@ -142,18 +188,19 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
         methodName,
         getLineNumber(path.node),
         `Entering method: ${methodName}`,
-        getParameterNames(path.node.params)
+        getParameterNames(path.node.params),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameId')
       )
     },
     exit(path: NodePath<t.ObjectMethod>) {
       const methodName = getMethodName(path.node)
-      addImplicitReturnStep(
+      finishFunction(
         context,
         path.node.body,
         methodName,
-        path.node.loc?.end.line ?? getLineNumber(path.node)
+        path.node.loc?.end.line ?? getLineNumber(path.node),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameError')
       )
-      context.exitFunction()
     },
   },
 
@@ -173,18 +220,19 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
         getLineNumber(path.node),
         `Entering method: ${methodName}`,
         getParameterNames(path.node.params),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameId'),
         !isDerivedConstructor
       )
     },
     exit(path: NodePath<t.ClassMethod>) {
       const methodName = getMethodName(path.node)
-      addImplicitReturnStep(
+      finishFunction(
         context,
         path.node.body,
         methodName,
-        path.node.loc?.end.line ?? getLineNumber(path.node)
+        path.node.loc?.end.line ?? getLineNumber(path.node),
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameError')
       )
-      context.exitFunction()
     },
   },
 })

--- a/src/features/code-execution/lib/instrumenter.regressions.test.ts
+++ b/src/features/code-execution/lib/instrumenter.regressions.test.ts
@@ -133,6 +133,49 @@ describe('instrumentation regressions', () => {
     ).toBe(true)
   })
 
+  it('restores the caller frame after a caught synchronous throw', () => {
+    const state = executeCode(
+      `
+      function fail(): never {
+        throw new Error('boom')
+      }
+
+      function recover(): boolean {
+        let recovered = false
+        try {
+          fail()
+        } catch {
+          recovered = true
+        }
+        return recovered
+      }
+      `,
+      {},
+      'recover'
+    )
+    const recoverEntry = state.steps.find(
+      (step) =>
+        step.metadata?.callFrame?.phase === 'enter' &&
+        step.metadata.callFrame.functionName === 'recover'
+    )
+    const failThrow = state.steps.find(
+      (step) =>
+        step.metadata?.callFrame?.phase === 'throw' &&
+        step.metadata.callFrame.functionName === 'fail'
+    )
+    const recoveredAssignment = state.steps.find(
+      (step) =>
+        step.type === 'assignment' && step.description.startsWith('recovered =')
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(true)
+    expect(failThrow?.type).toBe('function-throw')
+    expect(recoveredAssignment?.metadata?.callFrame?.frameId).toBe(
+      recoverEntry?.metadata?.callFrame?.frameId
+    )
+  })
+
   it('executes returned functions for LeetCode factory solutions', () => {
     const state = executeCode(
       `

--- a/src/features/code-execution/lib/runner.concurrent-frames.test.ts
+++ b/src/features/code-execution/lib/runner.concurrent-frames.test.ts
@@ -244,4 +244,47 @@ async function run(): Promise<string> {
     )
     expect(completedReturn?.variables.after).toBe('complete:after')
   })
+
+  it('does not reactivate a suspended parent when a child completes', async () => {
+    for (const shouldThrow of [false, true]) {
+      const state = await executeCodeAsync(
+        `function queuedCallback(): void {
+  const callbackState = 'ran'
+}
+
+async function child(shouldThrow: boolean): Promise<void> {
+  await Promise.resolve()
+  Promise.resolve().then(queuedCallback)
+  if (shouldThrow) throw new Error('boom')
+}
+
+async function run(shouldThrow: boolean): Promise<string> {
+  try {
+    await child(shouldThrow)
+  } catch {}
+  const after = 'parent:resumed'
+  return after
+}`,
+        { shouldThrow },
+        'run'
+      )
+      const runEntry = getFrameEntries(state, 'run')[0]
+      const callbackEntry = getFrameEntries(state, 'queuedCallback')[0]
+      const runFrameId = runEntry?.metadata?.callFrame?.frameId
+      const continuationType = shouldThrow ? 'await-reject' : 'await-resume'
+      const callbackIndex = state.steps.indexOf(callbackEntry!)
+      const parentContinuationIndex = state.steps.findIndex(
+        (step) =>
+          step.type === continuationType &&
+          step.metadata?.callFrame?.frameId === runFrameId
+      )
+
+      expect(state.error).toBeUndefined()
+      expect(state.returnValue).toBe('parent:resumed')
+      expect(callbackEntry?.metadata?.callFrame?.parentFrameId).toBeUndefined()
+      expect(callbackEntry?.callStack).toEqual(['root', 'queuedCallback'])
+      expect(callbackIndex).toBeGreaterThan(-1)
+      expect(parentContinuationIndex).toBeGreaterThan(callbackIndex)
+    }
+  })
 })

--- a/src/features/code-execution/lib/runner.concurrent-frames.test.ts
+++ b/src/features/code-execution/lib/runner.concurrent-frames.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import {
+  FUNCTION_ARGUMENTS_LABEL,
+  type ExecutionState,
+  type ExecutionStep,
+} from '@/entities/execution'
+import { executeCodeAsync } from './runner'
+
+function getFrameEntries(
+  state: ExecutionState,
+  functionName: string
+): ExecutionStep[] {
+  return state.steps.filter(
+    (step) =>
+      step.metadata?.callFrame?.phase === 'enter' &&
+      step.metadata.callFrame.functionName === functionName
+  )
+}
+
+function getFrameSteps(
+  state: ExecutionState,
+  frameId: number | undefined
+): ExecutionStep[] {
+  return state.steps.filter(
+    (step) => step.metadata?.callFrame?.frameId === frameId
+  )
+}
+
+describe('runner - concurrent call frames', () => {
+  it('attributes out-of-order Promise.all completion to each branch', async () => {
+    const state = await executeCodeAsync(
+      `async function fast(): Promise<string> {
+  const before = 'fast:before'
+  await Promise.resolve()
+  const after = 'fast:after'
+  return after
+}
+
+async function slow(): Promise<string> {
+  const before = 'slow:before'
+  await Promise.resolve()
+  await Promise.resolve()
+  const after = 'slow:after'
+  return after
+}
+
+async function run(): Promise<string> {
+  const results = await Promise.all([fast(), slow()])
+  return results.join(',')
+}`,
+      {},
+      'run'
+    )
+    const runEntry = getFrameEntries(state, 'run')[0]
+    const fastEntry = getFrameEntries(state, 'fast')[0]
+    const slowEntry = getFrameEntries(state, 'slow')[0]
+    const runFrameId = runEntry?.metadata?.callFrame?.frameId
+    const fastFrameId = fastEntry?.metadata?.callFrame?.frameId
+    const slowFrameId = slowEntry?.metadata?.callFrame?.frameId
+    const fastSteps = getFrameSteps(state, fastFrameId)
+    const slowSteps = getFrameSteps(state, slowFrameId)
+    const fastReturnIndex = state.steps.findIndex(
+      (step) =>
+        step.metadata?.callFrame?.frameId === fastFrameId &&
+        step.metadata?.callFrame?.phase === 'return'
+    )
+    const slowReturnIndex = state.steps.findIndex(
+      (step) =>
+        step.metadata?.callFrame?.frameId === slowFrameId &&
+        step.metadata?.callFrame?.phase === 'return'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe('fast:after,slow:after')
+    expect(fastEntry?.metadata?.callFrame?.parentFrameId).toBe(runFrameId)
+    expect(slowEntry?.metadata?.callFrame?.parentFrameId).toBe(runFrameId)
+    expect(fastReturnIndex).toBeGreaterThan(-1)
+    expect(slowReturnIndex).toBeGreaterThan(fastReturnIndex)
+    expect(
+      fastSteps.map((step) => step.metadata?.callFrame?.functionName)
+    ).toEqual(Array(fastSteps.length).fill('fast'))
+    expect(
+      slowSteps.map((step) => step.metadata?.callFrame?.functionName)
+    ).toEqual(Array(slowSteps.length).fill('slow'))
+    const fastActiveSteps = fastSteps.filter(
+      (step) => step.metadata?.callFrame?.phase !== 'return'
+    )
+    expect(fastActiveSteps.map((step) => step.callStack)).toEqual(
+      fastActiveSteps.map(() => ['root', 'run', 'fast'])
+    )
+  })
+
+  it('assigns distinct IDs to concurrent invocations of the same function', async () => {
+    const state = await executeCodeAsync(
+      `async function task(label: string, waitAgain: boolean): Promise<string> {
+  await Promise.resolve()
+  if (waitAgain) await Promise.resolve()
+  const result = label + ':done'
+  return result
+}
+
+async function run(): Promise<string[]> {
+  return await Promise.all([task('first', true), task('second', false)])
+}`,
+      {},
+      'run'
+    )
+    const taskEntries = getFrameEntries(state, 'task')
+    const taskFrameIds = taskEntries.map(
+      (step) => step.metadata?.callFrame?.frameId
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual(['first:done', 'second:done'])
+    expect(taskEntries).toHaveLength(2)
+    expect(new Set(taskFrameIds).size).toBe(2)
+    expect(
+      taskEntries.map((step) => step.variables[FUNCTION_ARGUMENTS_LABEL])
+    ).toEqual([
+      { label: 'first', waitAgain: true },
+      { label: 'second', waitAgain: false },
+    ])
+
+    for (const [index, frameId] of taskFrameIds.entries()) {
+      const returnStep = getFrameSteps(state, frameId).find(
+        (step) => step.metadata?.callFrame?.phase === 'return'
+      )
+
+      expect(returnStep?.variables.label).toBe(index === 0 ? 'first' : 'second')
+    }
+
+    const returnFrameIds = state.steps.flatMap((step) =>
+      step.metadata?.callFrame?.phase === 'return' &&
+      taskFrameIds.includes(step.metadata.callFrame.frameId)
+        ? [step.metadata.callFrame.frameId]
+        : []
+    )
+    expect(returnFrameIds).toEqual([taskFrameIds[1], taskFrameIds[0]])
+  })
+
+  it('preserves parent IDs through nested concurrent branches', async () => {
+    const state = await executeCodeAsync(
+      `async function leaf(label: string, waitAgain: boolean): Promise<string> {
+  await Promise.resolve()
+  if (waitAgain) await Promise.resolve()
+  return label
+}
+
+async function branch(label: string, waitAgain: boolean): Promise<string> {
+  return await leaf(label, waitAgain)
+}
+
+async function run(): Promise<string[]> {
+  return await Promise.all([
+    branch('left', false),
+    branch('right', true),
+  ])
+}`,
+      {},
+      'run'
+    )
+    const branchEntries = getFrameEntries(state, 'branch')
+    const leafEntries = getFrameEntries(state, 'leaf')
+    const branchIdByLabel = new Map(
+      branchEntries.map((step) => [
+        (
+          step.variables[FUNCTION_ARGUMENTS_LABEL] as {
+            label: string
+          }
+        ).label,
+        step.metadata?.callFrame?.frameId,
+      ])
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual(['left', 'right'])
+    expect(leafEntries).toHaveLength(2)
+
+    for (const leafEntry of leafEntries) {
+      const args = leafEntry.variables[FUNCTION_ARGUMENTS_LABEL] as {
+        label: string
+      }
+
+      expect(leafEntry.metadata?.callFrame?.parentFrameId).toBe(
+        branchIdByLabel.get(args.label)
+      )
+    }
+  })
+
+  it('completes a rejected branch without corrupting a sibling frame', async () => {
+    const state = await executeCodeAsync(
+      `async function rejectBranch(): Promise<void> {
+  const before = 'reject:before'
+  await Promise.reject(new Error('boom'))
+}
+
+async function completeBranch(): Promise<string> {
+  await Promise.resolve()
+  const after = 'complete:after'
+  return after
+}
+
+async function run(): Promise<string> {
+  const results = await Promise.allSettled([
+    rejectBranch(),
+    completeBranch(),
+  ])
+  return results.map((result) => result.status).join(',')
+}`,
+      {},
+      'run'
+    )
+    const rejectedEntry = getFrameEntries(state, 'rejectBranch')[0]
+    const completedEntry = getFrameEntries(state, 'completeBranch')[0]
+    const rejectedFrameId = rejectedEntry?.metadata?.callFrame?.frameId
+    const completedFrameId = completedEntry?.metadata?.callFrame?.frameId
+    const throwStep = state.steps.find(
+      (step) =>
+        step.type === 'function-throw' &&
+        step.metadata?.callFrame?.frameId === rejectedFrameId
+    )
+    const completedReturn = state.steps.find(
+      (step) =>
+        step.metadata?.callFrame?.frameId === completedFrameId &&
+        step.metadata?.callFrame?.phase === 'return'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe('rejected,fulfilled')
+    expect(throwStep?.metadata?.callFrame).toEqual(
+      expect.objectContaining({
+        frameId: rejectedFrameId,
+        functionName: 'rejectBranch',
+        phase: 'throw',
+      })
+    )
+    expect(completedReturn?.metadata?.callFrame).toEqual(
+      expect.objectContaining({
+        frameId: completedFrameId,
+        functionName: 'completeBranch',
+        phase: 'return',
+      })
+    )
+    expect(completedReturn?.variables.after).toBe('complete:after')
+  })
+})

--- a/src/features/code-execution/lib/step-recorder.ts
+++ b/src/features/code-execution/lib/step-recorder.ts
@@ -1,14 +1,23 @@
 import {
   CLASS_RECEIVER_LABEL,
   FUNCTION_NAME_LABEL,
+  STEP_TYPES,
   type CallFrameStepMetadata,
   type ExecutionStep,
   type InputValues,
 } from '@/entities/execution'
 import { deepClone } from '@/shared/lib/deep-clone'
-import { isString } from '@/shared/lib/guards'
+import { isInteger, isString } from '@/shared/lib/guards'
 import { MAX_STEPS, StepLimitError } from './execution-errors'
+import { CALL_FRAME_ID_LABEL } from './frame-identity'
 import { createHeapTraceCollector, type HeapTraceCollector } from './heap-trace'
+
+type RuntimeCallFrame = {
+  frameId: number
+  functionName: string
+  parentFrameId?: number
+  visibleVariableNames: string[]
+}
 
 /**
  * Mutable execution context used while instrumented code records steps.
@@ -24,16 +33,12 @@ export type ExecutionContext = {
   variableSnapshotCache: Array<Record<string, unknown> | undefined>
   /** Recorded execution steps. */
   steps: ExecutionStep[]
-  /** Current logical call stack. */
-  callStack: string[]
   /** Next stable identifier assigned to a function invocation. */
   nextFrameId: number
-  /** Active runtime invocations ordered from caller to callee. */
-  frameStack: Array<{
-    frameId: number
-    functionName: string
-    parentFrameId?: number
-  }>
+  /** Runtime invocations addressable independently of completion order. */
+  frames: Map<number, RuntimeCallFrame>
+  /** Invocation currently executing synchronous work. */
+  activeFrameId?: number
   /** Execution-scoped heap snapshot collector. */
   heapTraceCollector: HeapTraceCollector
 }
@@ -45,9 +50,9 @@ export function createExecutionContext(inputs: InputValues): ExecutionContext {
     variableDeltas: [],
     variableSnapshotCache: [],
     steps: [],
-    callStack: ['root'],
     nextFrameId: 1,
-    frameStack: [],
+    frames: new Map(),
+    activeFrameId: undefined,
     heapTraceCollector: createHeapTraceCollector(),
   }
 }
@@ -56,21 +61,26 @@ function getCallFrameMetadata({
   context,
   type,
   functionName,
+  frameId,
   visibleVariableNames,
 }: {
   context: ExecutionContext
   type: ExecutionStep['type']
   functionName: unknown
+  frameId: unknown
   visibleVariableNames: string[]
 }): CallFrameStepMetadata | undefined {
   if (type === 'function-entry') {
-    const parentFrame = context.frameStack[context.frameStack.length - 1]
+    const parentFrame = isInteger(context.activeFrameId)
+      ? context.frames.get(context.activeFrameId)
+      : undefined
     const frame = {
       frameId: context.nextFrameId++,
       functionName: isString(functionName) ? functionName : 'anonymous',
       parentFrameId: parentFrame?.frameId,
+      visibleVariableNames,
     }
-    context.frameStack.push(frame)
+    context.frames.set(frame.frameId, frame)
 
     return {
       ...frame,
@@ -79,14 +89,70 @@ function getCallFrameMetadata({
     }
   }
 
-  const frame = context.frameStack[context.frameStack.length - 1]
+  const frame = isInteger(frameId)
+    ? context.frames.get(frameId)
+    : isInteger(context.activeFrameId)
+      ? context.frames.get(context.activeFrameId)
+      : undefined
   if (!frame) return undefined
+
+  const retainedVariableNames =
+    type === STEP_TYPES.FUNCTION_THROW && visibleVariableNames.length === 0
+      ? frame.visibleVariableNames
+      : visibleVariableNames
+  if (visibleVariableNames.length > 0) {
+    frame.visibleVariableNames = visibleVariableNames
+  }
 
   return {
     ...frame,
-    phase: type === 'return' ? 'return' : 'update',
-    visibleVariableNames,
+    phase:
+      type === STEP_TYPES.RETURN
+        ? 'return'
+        : type === STEP_TYPES.FUNCTION_THROW
+          ? 'throw'
+          : 'update',
+    visibleVariableNames: retainedVariableNames,
   }
+}
+
+function updateActiveFrame(
+  context: ExecutionContext,
+  type: ExecutionStep['type'],
+  callFrame: CallFrameStepMetadata | undefined
+): void {
+  if (!callFrame) return
+
+  if (
+    type === STEP_TYPES.AWAIT_SUSPEND ||
+    type === STEP_TYPES.RETURN ||
+    type === STEP_TYPES.FUNCTION_THROW
+  ) {
+    context.activeFrameId = callFrame.parentFrameId
+    return
+  }
+
+  context.activeFrameId = callFrame.frameId
+}
+
+function getFrameCallStack(
+  context: ExecutionContext,
+  frameId: number | undefined
+): string[] {
+  const functionNames: string[] = []
+  const visitedFrameIds = new Set<number>()
+  let currentFrameId = frameId
+
+  while (isInteger(currentFrameId) && !visitedFrameIds.has(currentFrameId)) {
+    visitedFrameIds.add(currentFrameId)
+    const frame = context.frames.get(currentFrameId)
+    if (!frame) break
+
+    functionNames.push(frame.functionName)
+    currentFrameId = frame.parentFrameId
+  }
+
+  return ['root', ...functionNames.reverse()]
 }
 
 function getVariableSnapshot(
@@ -154,10 +220,13 @@ export function recordExecutionStep(
   delete visibleStepVariables[CLASS_RECEIVER_LABEL]
   const functionName = visibleStepVariables[FUNCTION_NAME_LABEL]
   delete visibleStepVariables[FUNCTION_NAME_LABEL]
+  const frameId = visibleStepVariables[CALL_FRAME_ID_LABEL]
+  delete visibleStepVariables[CALL_FRAME_ID_LABEL]
   const callFrame = getCallFrameMetadata({
     context,
     type,
     functionName,
+    frameId,
     visibleVariableNames: Object.keys(visibleStepVariables),
   })
 
@@ -166,12 +235,11 @@ export function recordExecutionStep(
     context.stepNumber === 0 ? context.variables : visibleStepVariables
   const variableDelta = deepClone(variablesForStep)
 
-  if (type === 'function-entry') {
-    context.callStack.push(callFrame?.functionName ?? 'anonymous')
-  } else if (type === 'return' && context.callStack.length > 1) {
-    context.callStack.pop()
-    context.frameStack.pop()
-  }
+  updateActiveFrame(context, type, callFrame)
+  const callStackFrameId =
+    type === STEP_TYPES.RETURN || type === STEP_TYPES.FUNCTION_THROW
+      ? callFrame?.parentFrameId
+      : (callFrame?.frameId ?? context.activeFrameId)
 
   const stepIndex = context.stepNumber++
   context.variableDeltas[stepIndex] = variableDelta
@@ -183,7 +251,7 @@ export function recordExecutionStep(
       line,
       description,
       timestamp: Date.now(),
-      callStack: [...context.callStack],
+      callStack: getFrameCallStack(context, callStackFrameId),
       metadata:
         heapTrace || callFrame
           ? {

--- a/src/features/code-execution/lib/step-recorder.ts
+++ b/src/features/code-execution/lib/step-recorder.ts
@@ -17,6 +17,7 @@ type RuntimeCallFrame = {
   functionName: string
   parentFrameId?: number
   visibleVariableNames: string[]
+  status: 'active' | 'suspended' | 'completed'
 }
 
 /**
@@ -74,16 +75,19 @@ function getCallFrameMetadata({
     const parentFrame = isInteger(context.activeFrameId)
       ? context.frames.get(context.activeFrameId)
       : undefined
-    const frame = {
+    const frame: RuntimeCallFrame = {
       frameId: context.nextFrameId++,
       functionName: isString(functionName) ? functionName : 'anonymous',
       parentFrameId: parentFrame?.frameId,
       visibleVariableNames,
+      status: 'active',
     }
     context.frames.set(frame.frameId, frame)
 
     return {
-      ...frame,
+      frameId: frame.frameId,
+      functionName: frame.functionName,
+      parentFrameId: frame.parentFrameId,
       phase: 'enter',
       visibleVariableNames,
     }
@@ -105,7 +109,9 @@ function getCallFrameMetadata({
   }
 
   return {
-    ...frame,
+    frameId: frame.frameId,
+    functionName: frame.functionName,
+    parentFrameId: frame.parentFrameId,
     phase:
       type === STEP_TYPES.RETURN
         ? 'return'
@@ -123,16 +129,31 @@ function updateActiveFrame(
 ): void {
   if (!callFrame) return
 
-  if (
-    type === STEP_TYPES.AWAIT_SUSPEND ||
-    type === STEP_TYPES.RETURN ||
-    type === STEP_TYPES.FUNCTION_THROW
-  ) {
-    context.activeFrameId = callFrame.parentFrameId
+  const frame = context.frames.get(callFrame.frameId)
+  if (!frame) return
+
+  if (type === STEP_TYPES.AWAIT_SUSPEND) {
+    frame.status = 'suspended'
+    const parentFrame = isInteger(frame.parentFrameId)
+      ? context.frames.get(frame.parentFrameId)
+      : undefined
+    context.activeFrameId =
+      parentFrame?.status === 'active' ? parentFrame.frameId : undefined
     return
   }
 
-  context.activeFrameId = callFrame.frameId
+  if (type === STEP_TYPES.RETURN || type === STEP_TYPES.FUNCTION_THROW) {
+    frame.status = 'completed'
+    const parentFrame = isInteger(frame.parentFrameId)
+      ? context.frames.get(frame.parentFrameId)
+      : undefined
+    context.activeFrameId =
+      parentFrame?.status === 'active' ? parentFrame.frameId : undefined
+    return
+  }
+
+  frame.status = 'active'
+  context.activeFrameId = frame.frameId
 }
 
 function getFrameCallStack(

--- a/src/features/code-execution/lib/typescript-runner.ts
+++ b/src/features/code-execution/lib/typescript-runner.ts
@@ -76,7 +76,7 @@ function createStepLimitWarningStep(
     description: `Warning: ${message}`,
     variables: lastStep ? lastStep.variables : {},
     timestamp: Date.now(),
-    callStack: [...context.callStack],
+    callStack: lastStep?.callStack ?? ['root'],
   }
 }
 

--- a/src/features/visualization/lib/call-frame-inspector.test.ts
+++ b/src/features/visualization/lib/call-frame-inspector.test.ts
@@ -36,7 +36,9 @@ function createStep({
         ? 'function-entry'
         : phase === 'return'
           ? 'return'
-          : 'assignment',
+          : phase === 'throw'
+            ? 'function-throw'
+            : 'assignment',
     line: 1,
     description: `${functionName} ${phase}`,
     variables,
@@ -254,6 +256,164 @@ describe('call-frame inspector', () => {
       total: 1,
     })
     expect(getCallFrameDetails(createState(5), childFrame!).returnValue).toBe(1)
+  })
+
+  it('reconstructs concurrent sibling frames across timeline steps', () => {
+    const concurrentSteps = [
+      createStep({
+        frameId: 1,
+        functionName: 'run',
+        phase: 'enter',
+        variables: {},
+      }),
+      createStep({
+        frameId: 2,
+        parentFrameId: 1,
+        functionName: 'fast',
+        phase: 'enter',
+        variables: { branch: 'fast' },
+      }),
+      createStep({
+        frameId: 2,
+        parentFrameId: 1,
+        functionName: 'fast',
+        phase: 'update',
+        variables: { branch: 'fast', state: 'suspended' },
+      }),
+      createStep({
+        frameId: 3,
+        parentFrameId: 1,
+        functionName: 'slow',
+        phase: 'enter',
+        variables: { branch: 'slow' },
+      }),
+      createStep({
+        frameId: 3,
+        parentFrameId: 1,
+        functionName: 'slow',
+        phase: 'update',
+        variables: { branch: 'slow', state: 'suspended' },
+      }),
+      createStep({
+        frameId: 2,
+        parentFrameId: 1,
+        functionName: 'fast',
+        phase: 'update',
+        variables: { branch: 'fast', state: 'resumed' },
+      }),
+      createStep({
+        frameId: 2,
+        parentFrameId: 1,
+        functionName: 'fast',
+        phase: 'return',
+        variables: { branch: 'fast', [RETURN_VALUE_LABEL]: 'fast' },
+      }),
+      createStep({
+        frameId: 3,
+        parentFrameId: 1,
+        functionName: 'slow',
+        phase: 'update',
+        variables: { branch: 'slow', state: 'resumed' },
+      }),
+    ]
+    const createConcurrentState = (currentStep: number): ExecutionState => ({
+      currentStep,
+      totalSteps: concurrentSteps.length,
+      steps: concurrentSteps,
+      isComplete: false,
+    })
+    const atSlowSuspend = getCallFrameInspectorState(createConcurrentState(4))
+    const atFastResume = getCallFrameInspectorState(createConcurrentState(5))
+    const atFastReturn = getCallFrameInspectorState(createConcurrentState(6))
+    const afterFastReturn = getCallFrameInspectorState(createConcurrentState(7))
+
+    expect(atSlowSuspend.activeFrameIds).toEqual([1, 2, 3])
+    expect(atSlowSuspend.currentFrameId).toBe(3)
+    expect(
+      atSlowSuspend.frames.map((frame) => ({
+        id: frame.id,
+        depth: frame.depth,
+        status: frame.status,
+      }))
+    ).toEqual([
+      { id: 1, depth: 0, status: 'suspended' },
+      { id: 2, depth: 1, status: 'suspended' },
+      { id: 3, depth: 1, status: 'current' },
+    ])
+    expect(atFastResume.currentFrameId).toBe(2)
+    expect(atFastResume.frames.find((frame) => frame.id === 3)?.status).toBe(
+      'suspended'
+    )
+    expect(atFastReturn.activeFrameIds).toEqual([1, 3])
+    expect(atFastReturn.frames.find((frame) => frame.id === 2)?.status).toBe(
+      'returning'
+    )
+    expect(afterFastReturn.currentFrameId).toBe(3)
+    expect(afterFastReturn.frames.find((frame) => frame.id === 2)?.status).toBe(
+      'completed'
+    )
+  })
+
+  it('completes a throwing frame without removing its active sibling', () => {
+    const throwingSteps = [
+      createStep({
+        frameId: 1,
+        functionName: 'run',
+        phase: 'enter',
+        variables: {},
+      }),
+      createStep({
+        frameId: 2,
+        parentFrameId: 1,
+        functionName: 'rejectBranch',
+        phase: 'enter',
+        variables: { branch: 'reject' },
+      }),
+      createStep({
+        frameId: 3,
+        parentFrameId: 1,
+        functionName: 'completeBranch',
+        phase: 'enter',
+        variables: { branch: 'complete' },
+      }),
+      createStep({
+        frameId: 2,
+        parentFrameId: 1,
+        functionName: 'rejectBranch',
+        phase: 'throw',
+        variables: { branch: 'reject' },
+      }),
+      createStep({
+        frameId: 3,
+        parentFrameId: 1,
+        functionName: 'completeBranch',
+        phase: 'update',
+        variables: { branch: 'complete', state: 'resumed' },
+      }),
+    ]
+    const createThrowingState = (currentStep: number): ExecutionState => ({
+      currentStep,
+      totalSteps: throwingSteps.length,
+      steps: throwingSteps,
+      isComplete: false,
+    })
+    const atThrow = getCallFrameInspectorState(createThrowingState(3))
+    const afterThrow = getCallFrameInspectorState(createThrowingState(4))
+
+    expect(atThrow.activeFrameIds).toEqual([1, 3])
+    expect(atThrow.currentFrameId).toBe(2)
+    expect(atThrow.frames.find((frame) => frame.id === 2)).toEqual(
+      expect.objectContaining({
+        status: 'throwing',
+        completionPhase: 'throw',
+        hasReturnValue: false,
+      })
+    )
+    expect(afterThrow.currentFrameId).toBe(3)
+    expect(afterThrow.activeFrameIds).toEqual([1, 3])
+    expect(afterThrow.frames.find((frame) => frame.id === 2)?.status).toBe(
+      'completed'
+    )
   })
 
   it('reconstructs only frames that exist at an earlier timeline step', () => {

--- a/src/features/visualization/lib/call-frame-inspector.ts
+++ b/src/features/visualization/lib/call-frame-inspector.ts
@@ -10,6 +10,7 @@ export type CallFrameStatus =
   | 'current'
   | 'suspended'
   | 'returning'
+  | 'throwing'
   | 'completed'
 
 export type InspectedCallFrame = {
@@ -29,10 +30,12 @@ export type InspectedCallFrame = {
   lastObservedStepIndex: number
   /** Binding names visible at the frame's last observed step. */
   visibleVariableNames: string[]
-  /** Step index where the invocation returned. */
+  /** Step index where the invocation returned or threw. */
   endStepIndex?: number
-  /** Whether a return event has been recorded. */
+  /** Whether a successful return event has been recorded. */
   hasReturnValue: boolean
+  /** How this invocation completed, when it has finished. */
+  completionPhase?: 'return' | 'throw'
 }
 
 export type CallFrameDetails = {
@@ -56,9 +59,9 @@ export type CallerFrameContext = {
 export type CallFrameInspectorState = {
   /** All invocations that have started by the selected step. */
   frames: InspectedCallFrame[]
-  /** Active invocation identifiers ordered from caller to callee. */
+  /** Active invocation identifiers in stable entry order. */
   activeFrameIds: number[]
-  /** Currently executing or returning invocation identifier. */
+  /** Currently executing, returning, or throwing invocation identifier. */
   currentFrameId?: number
 }
 
@@ -72,16 +75,20 @@ const SPECIAL_VARIABLE_NAMES = new Set([
 
 function getCallFrameStatus({
   frameId,
-  returningFrameId,
+  terminalFrameId,
+  terminalPhase,
   currentFrameId,
   activeFrameIds,
 }: {
   frameId: number
-  returningFrameId?: number
+  terminalFrameId?: number
+  terminalPhase?: 'return' | 'throw'
   currentFrameId?: number
   activeFrameIds: number[]
 }): CallFrameStatus {
-  if (frameId === returningFrameId) return 'returning'
+  if (frameId === terminalFrameId) {
+    return terminalPhase === 'throw' ? 'throwing' : 'returning'
+  }
   if (frameId === currentFrameId) return 'current'
   if (activeFrameIds.includes(frameId)) return 'suspended'
 
@@ -147,9 +154,10 @@ export function getCallFrameDetails(
   frame: InspectedCallFrame
 ): CallFrameDetails {
   const parameters = getParameters(executionState, frame)
-  const returnVariables = !isUndefined(frame.endStepIndex)
-    ? executionState.steps[frame.endStepIndex]?.variables
-    : undefined
+  const returnVariables =
+    frame.completionPhase === 'return' && !isUndefined(frame.endStepIndex)
+      ? executionState.steps[frame.endStepIndex]?.variables
+      : undefined
 
   return {
     parameters,
@@ -191,7 +199,6 @@ export function getCallFrameInspectorState(
 ): CallFrameInspectorState {
   const frames = new Map<number, MutableCallFrame>()
   const activeFrameIds: number[] = []
-  let returningFrameId: number | undefined
   const lastStepIndex = Math.min(
     executionState.currentStep,
     executionState.steps.length - 1
@@ -203,11 +210,14 @@ export function getCallFrameInspectorState(
     if (!step || !callFrame) continue
 
     if (callFrame.phase === 'enter') {
+      const parentFrame = !isUndefined(callFrame.parentFrameId)
+        ? frames.get(callFrame.parentFrameId)
+        : undefined
       frames.set(callFrame.frameId, {
         id: callFrame.frameId,
         parentId: callFrame.parentFrameId,
         functionName: callFrame.functionName,
-        depth: activeFrameIds.length,
+        depth: parentFrame ? parentFrame.depth + 1 : 0,
         startStepIndex: stepIndex,
         lastObservedStepIndex: stepIndex,
         visibleVariableNames: callFrame.visibleVariableNames,
@@ -218,19 +228,29 @@ export function getCallFrameInspectorState(
 
     const frame = frames.get(callFrame.frameId)
     if (!frame) continue
-    frame.lastObservedStepIndex = stepIndex
-    frame.visibleVariableNames = callFrame.visibleVariableNames
+    if (callFrame.phase !== 'throw') {
+      frame.lastObservedStepIndex = stepIndex
+      frame.visibleVariableNames = callFrame.visibleVariableNames
+    }
 
-    if (callFrame.phase !== 'return') continue
-
-    frame.endStepIndex = stepIndex
-    const activeIndex = activeFrameIds.lastIndexOf(callFrame.frameId)
-    if (activeIndex >= 0) activeFrameIds.splice(activeIndex, 1)
-    if (stepIndex === lastStepIndex) returningFrameId = callFrame.frameId
+    if (callFrame.phase === 'return' || callFrame.phase === 'throw') {
+      frame.endStepIndex = stepIndex
+      frame.completionPhase = callFrame.phase
+      const activeIndex = activeFrameIds.lastIndexOf(callFrame.frameId)
+      if (activeIndex >= 0) activeFrameIds.splice(activeIndex, 1)
+    }
   }
 
+  const selectedCallFrame =
+    executionState.steps[lastStepIndex]?.metadata?.callFrame
+  const terminalPhase =
+    selectedCallFrame?.phase === 'return' ||
+    selectedCallFrame?.phase === 'throw'
+      ? selectedCallFrame.phase
+      : undefined
+  const terminalFrameId = terminalPhase ? selectedCallFrame?.frameId : undefined
   const currentFrameId =
-    returningFrameId ?? activeFrameIds[activeFrameIds.length - 1]
+    selectedCallFrame?.frameId ?? activeFrameIds[activeFrameIds.length - 1]
 
   return {
     activeFrameIds,
@@ -238,7 +258,8 @@ export function getCallFrameInspectorState(
     frames: [...frames.values()].map((frame) => {
       const status = getCallFrameStatus({
         frameId: frame.id,
-        returningFrameId,
+        terminalFrameId,
+        terminalPhase,
         currentFrameId,
         activeFrameIds,
       })
@@ -253,7 +274,8 @@ export function getCallFrameInspectorState(
         lastObservedStepIndex: frame.lastObservedStepIndex,
         visibleVariableNames: frame.visibleVariableNames,
         endStepIndex: frame.endStepIndex,
-        hasReturnValue: !isUndefined(frame.endStepIndex),
+        hasReturnValue: frame.completionPhase === 'return',
+        completionPhase: frame.completionPhase,
       }
     }),
   }

--- a/src/features/visualization/ui/call-frame-inspector.test.tsx
+++ b/src/features/visualization/ui/call-frame-inspector.test.tsx
@@ -30,7 +30,9 @@ function createStep({
         ? 'function-entry'
         : phase === 'return'
           ? 'return'
-          : 'assignment',
+          : phase === 'throw'
+            ? 'function-throw'
+            : 'assignment',
     line: 1,
     description: `dfs ${phase}`,
     variables,
@@ -211,6 +213,41 @@ describe('CallFrameInspector', () => {
       .closest('section')
     expect(returnSection).not.toBeNull()
     expect(within(returnSection!).getByText('1')).toBeInTheDocument()
+  })
+
+  it('shows a throwing frame without a return value', () => {
+    const throwingSteps = [
+      createStep({
+        frameId: 1,
+        phase: 'enter',
+        variables: { value: 'before error' },
+      }),
+      createStep({
+        frameId: 1,
+        phase: 'throw',
+        variables: { value: 'before error' },
+      }),
+    ]
+
+    render(
+      <CallFrameInspector
+        executionState={{
+          currentStep: 1,
+          totalSteps: throwingSteps.length,
+          steps: throwingSteps,
+          isComplete: false,
+        }}
+      />
+    )
+
+    const throwingButton = screen.getByRole('button', { name: /dfs #1/i })
+    const details = screen.getByRole('region', {
+      name: 'dfs #1 frame details',
+    })
+
+    expect(throwingButton).toHaveAttribute('aria-current', 'true')
+    expect(throwingButton).toHaveTextContent('Throwing')
+    expect(within(details).queryByText('Return value')).not.toBeInTheDocument()
   })
 
   it('keeps completed calls without repeating the Completed label', () => {

--- a/src/features/visualization/ui/call-frame-inspector.tsx
+++ b/src/features/visualization/ui/call-frame-inspector.tsx
@@ -20,6 +20,7 @@ const STATUS_LABELS: Record<CallFrameStatus, string> = {
   current: 'Current',
   suspended: 'Suspended',
   returning: 'Returning',
+  throwing: 'Throwing',
   completed: 'Completed',
 }
 
@@ -32,7 +33,10 @@ function FrameButton({
   isSelected: boolean
   onSelect: () => void
 }) {
-  const isExecuting = frame.status === 'current' || frame.status === 'returning'
+  const isExecuting =
+    frame.status === 'current' ||
+    frame.status === 'returning' ||
+    frame.status === 'throwing'
 
   return (
     <button
@@ -160,9 +164,16 @@ export function CallFrameInspector({
   const activeFrameIds = new Set(inspectorState.activeFrameIds)
   const activeFrames = inspectorState.frames
     .filter(
-      (frame) => activeFrameIds.has(frame.id) || frame.status === 'returning'
+      (frame) =>
+        activeFrameIds.has(frame.id) ||
+        frame.status === 'returning' ||
+        frame.status === 'throwing'
     )
-    .reverse()
+    .sort((left, right) => {
+      if (left.id === inspectorState.currentFrameId) return -1
+      if (right.id === inspectorState.currentFrameId) return 1
+      return right.lastObservedStepIndex - left.lastObservedStepIndex
+    })
   const completedFrames = inspectorState.frames
     .filter((frame) => frame.status === 'completed')
     .reverse()
@@ -175,9 +186,9 @@ export function CallFrameInspector({
       >
         <section className="space-y-2 lg:shrink-0">
           <header>
-            <h3 className="text-sm font-semibold">Active stack</h3>
+            <h3 className="text-sm font-semibold">Active frames</h3>
             <p className="text-xs text-muted-foreground">
-              Current call first, followed by its callers.
+              Current call first, followed by suspended invocations.
             </p>
           </header>
           {activeFrames.length > 0 ? (
@@ -241,7 +252,8 @@ export function CallFrameInspector({
             <Badge
               variant={
                 selectedFrame.status === 'current' ||
-                selectedFrame.status === 'returning'
+                selectedFrame.status === 'returning' ||
+                selectedFrame.status === 'throwing'
                   ? 'default'
                   : 'outline'
               }


### PR DESCRIPTION
Closes #44.

## Summary

Track call frames across concurrent Promises.

<!-- A brief summary of the changes -->

## Description

- Assign stable frame IDs to individual function invocations
- Preserve frame identity across await suspension and resumption
- Track concurrent Promise branches independently

<!-- A detailed explanation of the changes, including why they are needed -->
