### PR TITLE
feat: generator execution support

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -21,6 +21,48 @@ test('formats TypeScript with Ctrl+S', async ({ page }) => {
   await expect(page.locator('.view-lines')).toContainText('return 1')
 })
 
+test('allows entry functions that share names with DOM globals', async ({
+  page,
+}) => {
+  await page.goto('/')
+
+  const editor = page.locator('.monaco-editor')
+  await expect(editor).toBeVisible()
+  const sourceCode = `function* parent(): Generator<number | string, string, void> {
+  const childResult = yield* child()
+
+  yield childResult
+  return 'parent done'
+}
+
+function* child(): Generator<number, string, void> {
+  yield 1
+  return 'child done'
+}`
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+  await page.evaluate((clipboardValue) => {
+    const clipboardNavigator = navigator as Navigator & {
+      clipboard: { writeText: (value: string) => Promise<void> }
+    }
+    return clipboardNavigator.clipboard.writeText(clipboardValue)
+  }, sourceCode)
+  await editor.click()
+  await page.keyboard.press('Control+A')
+  await page.keyboard.press('Control+V')
+
+  const compileButton = page.getByRole('button', { name: 'Compile Code' })
+  await expect(compileButton).toBeEnabled()
+  await compileButton.click()
+
+  await expect(page.getByText('Input Parameters')).toBeVisible()
+  await page.getByRole('button', { name: 'Run', exact: true }).click()
+  await expect(page.getByText('All execution steps')).toBeVisible()
+  await expect(page.getByText('Duplicate identifier')).toHaveCount(0)
+  await expect(
+    page.getByText('Returned: "parent done"', { exact: true })
+  ).toBeVisible()
+})
+
 test('loads, compiles, runs a demo, and opens core dialogs', async ({
   page,
   isMobile,

--- a/src/entities/execution/index.ts
+++ b/src/entities/execution/index.ts
@@ -4,6 +4,8 @@ export {
   CLASS_RECEIVER_LABEL,
   RETURN_LOCATION_LABEL,
   RETURN_VALUE_LABEL,
+  YIELD_INPUT_LABEL,
+  YIELD_VALUE_LABEL,
   STEP_TYPES,
 } from './model/constants'
 export type {

--- a/src/entities/execution/model/constants.ts
+++ b/src/entities/execution/model/constants.ts
@@ -1,6 +1,8 @@
 export const FUNCTION_ARGUMENTS_LABEL = 'function arguments'
 export const RETURN_VALUE_LABEL = 'return value'
 export const RETURN_LOCATION_LABEL = 'return location'
+export const YIELD_VALUE_LABEL = 'yield value'
+export const YIELD_INPUT_LABEL = 'yield input'
 export const CLASS_RECEIVER_LABEL = '__algorithmVisualizerClassReceiver'
 export const FUNCTION_NAME_LABEL = '__algorithmVisualizerFunctionName'
 
@@ -17,6 +19,10 @@ export const STEP_TYPES = {
   AWAIT_SUSPEND: 'await-suspend',
   AWAIT_RESUME: 'await-resume',
   AWAIT_REJECT: 'await-reject',
+  YIELD_SUSPEND: 'yield-suspend',
+  YIELD_RESUME: 'yield-resume',
+  YIELD_THROW: 'yield-throw',
+  GENERATOR_CLOSE: 'generator-close',
 } as const
 
 export type ExecutionStepType = (typeof STEP_TYPES)[keyof typeof STEP_TYPES]

--- a/src/entities/execution/model/types.ts
+++ b/src/entities/execution/model/types.ts
@@ -18,7 +18,14 @@ export type HeapTraceSnapshot = {
   heaps: HeapSnapshot[]
 }
 
-export type CallFramePhase = 'enter' | 'update' | 'return' | 'throw'
+export type CallFramePhase =
+  | 'enter'
+  | 'update'
+  | 'suspend'
+  | 'resume'
+  | 'return'
+  | 'throw'
+  | 'close'
 
 /** Runtime identity and visible binding names for one logical call frame. */
 export type CallFrameStepMetadata = {
@@ -32,6 +39,8 @@ export type CallFrameStepMetadata = {
   phase: CallFramePhase
   /** Variable names visible while this frame recorded the step. */
   visibleVariableNames: string[]
+  /** Invocation executing after this lifecycle event, when one remains active. */
+  activeFrameIdAfterStep?: number
 }
 
 /** Map of user-provided values for function parameters. */

--- a/src/features/code-editing/ui/code-editor.tsx
+++ b/src/features/code-editing/ui/code-editor.tsx
@@ -23,6 +23,10 @@ import { CodeEditorSpinner } from './code-editor-spinner'
 
 configureMonaco()
 
+// Keep Monaco diagnostics out of the DOM global scope without modifying the
+// source that Babel later executes inside the generated function wrapper.
+const TYPESCRIPT_MODEL_PATH = 'algorithm-visualizer-input.mts'
+
 /** Preloads Monaco so mounting the rich editor does not start from cold. */
 export const prepareCodeEditor = prepareMonaco
 
@@ -195,6 +199,7 @@ export function CodeEditor({
       <Editor
         height="100%"
         language={language}
+        path={language === 'typescript' ? TYPESCRIPT_MODEL_PATH : undefined}
         value={value}
         onChange={handleEditorChange}
         onMount={handleEditorDidMount}

--- a/src/features/code-execution/lib/generator-execution.ts
+++ b/src/features/code-execution/lib/generator-execution.ts
@@ -1,0 +1,24 @@
+import { define, isFunction, isNonArrayObject } from '@/shared/lib/guards'
+
+type SyncGeneratorIterator = Iterator<unknown, unknown, unknown> &
+  Iterable<unknown>
+
+/** Matches synchronous generator-like iterators without consuming them. */
+export const isSyncGeneratorIterator = define<SyncGeneratorIterator>(
+  (value) => {
+    if (!isNonArrayObject(value) || !isFunction(value.next)) return false
+
+    return isFunction(Reflect.get(value, Symbol.iterator))
+  }
+)
+
+/** Advances a synchronous generator returned by an entry function to completion. */
+export function consumeGenerator(iterator: SyncGeneratorIterator): unknown {
+  let iteration = iterator.next()
+
+  while (!iteration.done) {
+    iteration = iterator.next()
+  }
+
+  return iteration.value
+}

--- a/src/features/code-execution/lib/generator-execution.ts
+++ b/src/features/code-execution/lib/generator-execution.ts
@@ -1,3 +1,5 @@
+import { parse } from '@babel/parser'
+
 import { define, isFunction, isNonArrayObject } from '@/shared/lib/guards'
 
 type SyncGeneratorIterator = Iterator<unknown, unknown, unknown> &
@@ -11,6 +13,43 @@ export const isSyncGeneratorIterator = define<SyncGeneratorIterator>(
     return isFunction(Reflect.get(value, Symbol.iterator))
   }
 )
+
+/** Identifies a synchronous generator selected as the execution entry. */
+export function isSyncGeneratorEntry(
+  code: string,
+  entryFunctionName: string
+): boolean {
+  try {
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['typescript'],
+    })
+
+    return ast.program.body.some((node) => {
+      if (node.type === 'FunctionDeclaration') {
+        return (
+          node.id?.name === entryFunctionName && node.generator && !node.async
+        )
+      }
+
+      if (node.type !== 'VariableDeclaration') return false
+
+      return node.declarations.some((declaration) => {
+        if (
+          declaration.id.type !== 'Identifier' ||
+          declaration.id.name !== entryFunctionName ||
+          declaration.init?.type !== 'FunctionExpression'
+        ) {
+          return false
+        }
+
+        return declaration.init.generator && !declaration.init.async
+      })
+    })
+  } catch {
+    return false
+  }
+}
 
 /** Advances a synchronous generator returned by an entry function to completion. */
 export function consumeGenerator(iterator: SyncGeneratorIterator): unknown {

--- a/src/features/code-execution/lib/instrumentation/context.ts
+++ b/src/features/code-execution/lib/instrumentation/context.ts
@@ -15,6 +15,10 @@ export class InstrumentationContext {
   private readonly functionStack: string[] = []
   private readonly classReceiverStack: boolean[] = []
   private readonly frameIdentifierStack: t.Identifier[] = []
+  private readonly frameCompletionIdentifierStack: Array<
+    t.Identifier | undefined
+  > = []
+  private readonly tracedGeneratorStack: boolean[] = []
   private readonly instrumentedNodes = new WeakSet<t.Node>()
 
   isInstrumented(node: t.Node): boolean {
@@ -91,7 +95,9 @@ export class InstrumentationContext {
     description: string,
     parameterNames: string[],
     frameIdentifier: t.Identifier,
-    captureClassReceiver = false
+    captureClassReceiver = false,
+    frameCompletionIdentifier?: t.Identifier,
+    traceGeneratorYields = false
   ): void {
     this.pushScope(parameterNames)
     this.classReceiverStack.push(captureClassReceiver)
@@ -124,19 +130,36 @@ export class InstrumentationContext {
       ),
       t.identifier('frameId')
     )
-    body.body.unshift(
+    const prelude = [
       this.markInstrumented(
         t.variableDeclaration('const', [
           t.variableDeclarator(frameIdentifier, frameId),
         ])
+      ),
+    ]
+    if (frameCompletionIdentifier) {
+      prelude.push(
+        this.markInstrumented(
+          t.variableDeclaration('let', [
+            t.variableDeclarator(
+              frameCompletionIdentifier,
+              t.booleanLiteral(false)
+            ),
+          ])
+        )
       )
-    )
+    }
+    body.body.unshift(...prelude)
     this.frameIdentifierStack.push(frameIdentifier)
+    this.frameCompletionIdentifierStack.push(frameCompletionIdentifier)
+    this.tracedGeneratorStack.push(traceGeneratorYields)
     this.functionStack.push(functionName)
   }
 
   exitFunction(): void {
     this.functionStack.pop()
+    this.tracedGeneratorStack.pop()
+    this.frameCompletionIdentifierStack.pop()
     this.frameIdentifierStack.pop()
     this.classReceiverStack.pop()
     this.popScope()
@@ -150,5 +173,13 @@ export class InstrumentationContext {
     return (
       this.functionStack[this.functionStack.length - 1] ?? 'current function'
     )
+  }
+
+  getCurrentFrameCompletionIdentifier(): t.Identifier | undefined {
+    return this.frameCompletionIdentifierStack.at(-1)
+  }
+
+  isCurrentFunctionTracedGenerator(): boolean {
+    return this.tracedGeneratorStack.at(-1) ?? false
   }
 }

--- a/src/features/code-execution/lib/instrumentation/context.ts
+++ b/src/features/code-execution/lib/instrumentation/context.ts
@@ -9,6 +9,7 @@ import {
 import { getUniqueNames } from './binding-names'
 import { CALL_FRAME_ID_LABEL } from '../frame-identity'
 import { createRecordStepCall } from './step-factory'
+import type { InstrumentationIntrinsicName } from './intrinsics'
 
 export class InstrumentationContext {
   private readonly scopeStack: string[][] = []
@@ -20,6 +21,11 @@ export class InstrumentationContext {
   > = []
   private readonly tracedGeneratorStack: boolean[] = []
   private readonly instrumentedNodes = new WeakSet<t.Node>()
+  private readonly intrinsicsIdentifier: t.Identifier
+
+  constructor(intrinsicsIdentifier: t.Identifier) {
+    this.intrinsicsIdentifier = intrinsicsIdentifier
+  }
 
   isInstrumented(node: t.Node): boolean {
     return this.instrumentedNodes.has(node)
@@ -28,6 +34,15 @@ export class InstrumentationContext {
   markInstrumented<T extends t.Node>(node: T): T {
     this.instrumentedNodes.add(node)
     return node
+  }
+
+  createIntrinsicReference(
+    name: InstrumentationIntrinsicName
+  ): t.MemberExpression {
+    return t.memberExpression(
+      t.identifier(this.intrinsicsIdentifier.name),
+      t.identifier(name)
+    )
   }
 
   pushScope(names: string[] = []): void {

--- a/src/features/code-execution/lib/instrumentation/function-visitors.ts
+++ b/src/features/code-execution/lib/instrumentation/function-visitors.ts
@@ -25,8 +25,22 @@ const addImplicitReturnStep = (
   line: number
 ): void => {
   const returnLocation = `${functionName} line ${line}`
+  const completionIdentifier = context.getCurrentFrameCompletionIdentifier()
 
   body.body.push(
+    ...(completionIdentifier
+      ? [
+          context.markInstrumented(
+            t.expressionStatement(
+              t.assignmentExpression(
+                '=',
+                t.identifier(completionIdentifier.name),
+                t.booleanLiteral(true)
+              )
+            )
+          ),
+        ]
+      : []),
     createRecordStepStatement(
       STEP_TYPES.RETURN,
       line,
@@ -52,10 +66,13 @@ const wrapFunctionBodyWithThrowStep = (
   line: number,
   errorId: t.Identifier
 ): void => {
-  const entryStatement = body.body[0]
+  const completionIdentifier = context.getCurrentFrameCompletionIdentifier()
+  const preludeLength = completionIdentifier ? 2 : 1
+  const prelude = body.body.slice(0, preludeLength)
+  const entryStatement = prelude[0]
   if (!entryStatement) return
 
-  const functionBody = body.body.slice(1)
+  const functionBody = body.body.slice(preludeLength)
   const throwLocation = `${functionName} line ${line}`
   const throwStep = createRecordStepStatement(
     STEP_TYPES.FUNCTION_THROW,
@@ -66,14 +83,56 @@ const wrapFunctionBodyWithThrowStep = (
   const rethrow = context.markInstrumented(
     t.throwStatement(t.identifier(errorId.name))
   )
+  const catchBody = [
+    ...(completionIdentifier
+      ? [
+          context.markInstrumented(
+            t.expressionStatement(
+              t.assignmentExpression(
+                '=',
+                t.identifier(completionIdentifier.name),
+                t.booleanLiteral(true)
+              )
+            )
+          ),
+        ]
+      : []),
+    throwStep,
+    rethrow,
+  ]
+  const finalizer = completionIdentifier
+    ? t.blockStatement([
+        t.ifStatement(
+          t.unaryExpression('!', t.identifier(completionIdentifier.name)),
+          t.blockStatement([
+            context.markInstrumented(
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  t.identifier(completionIdentifier.name),
+                  t.booleanLiteral(true)
+                )
+              )
+            ),
+            createRecordStepStatement(
+              STEP_TYPES.GENERATOR_CLOSE,
+              line,
+              `Generator closed: ${functionName}`,
+              context.createFrameIdentityProperties()
+            ),
+          ])
+        ),
+      ])
+    : null
   const boundary = context.markInstrumented(
     t.tryStatement(
       t.blockStatement(functionBody),
-      t.catchClause(errorId, t.blockStatement([throwStep, rethrow]))
+      t.catchClause(errorId, t.blockStatement(catchBody)),
+      finalizer
     )
   )
 
-  body.body = [entryStatement, boundary]
+  body.body = [...prelude, boundary]
 }
 
 const finishFunction = (
@@ -88,17 +147,39 @@ const finishFunction = (
   context.exitFunction()
 }
 
+const getGeneratorOptions = (
+  path: NodePath<
+    | t.FunctionDeclaration
+    | t.FunctionExpression
+    | t.ObjectMethod
+    | t.ClassMethod
+  >
+): [t.Identifier | undefined, boolean] => {
+  const traceGeneratorYields = Boolean(path.node.generator && !path.node.async)
+  return [
+    traceGeneratorYields
+      ? path.scope.generateUidIdentifier('algorithmVisualizerFrameCompleted')
+      : undefined,
+    traceGeneratorYields,
+  ]
+}
+
 export const createFunctionVisitors = (context: InstrumentationContext) => ({
   FunctionDeclaration: {
     enter(path: NodePath<t.FunctionDeclaration>) {
       const functionName = path.node.id?.name ?? 'anonymous'
+      const [completionIdentifier, traceGeneratorYields] =
+        getGeneratorOptions(path)
       context.enterFunction(
         path.node.body,
         functionName,
         getLineNumber(path.node),
         `Entering function: ${functionName}`,
         getParameterNames(path.node.params),
-        path.scope.generateUidIdentifier('algorithmVisualizerFrameId')
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameId'),
+        false,
+        completionIdentifier,
+        traceGeneratorYields
       )
     },
     exit(path: NodePath<t.FunctionDeclaration>) {
@@ -121,13 +202,19 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
       }
       if (skipArrayCallbackTraversal(path)) return
 
+      const [completionIdentifier, traceGeneratorYields] =
+        getGeneratorOptions(path)
+
       context.enterFunction(
         path.node.body,
         'anonymous function',
         getLineNumber(path.node),
         'Entering anonymous function',
         getParameterNames(path.node.params),
-        path.scope.generateUidIdentifier('algorithmVisualizerFrameId')
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameId'),
+        false,
+        completionIdentifier,
+        traceGeneratorYields
       )
     },
     exit(path: NodePath<t.FunctionExpression>) {
@@ -183,13 +270,18 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
   ObjectMethod: {
     enter(path: NodePath<t.ObjectMethod>) {
       const methodName = getMethodName(path.node)
+      const [completionIdentifier, traceGeneratorYields] =
+        getGeneratorOptions(path)
       context.enterFunction(
         path.node.body,
         methodName,
         getLineNumber(path.node),
         `Entering method: ${methodName}`,
         getParameterNames(path.node.params),
-        path.scope.generateUidIdentifier('algorithmVisualizerFrameId')
+        path.scope.generateUidIdentifier('algorithmVisualizerFrameId'),
+        false,
+        completionIdentifier,
+        traceGeneratorYields
       )
     },
     exit(path: NodePath<t.ObjectMethod>) {
@@ -212,6 +304,8 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
         path.node.kind === 'constructor' &&
         (t.isClassDeclaration(classNode) || t.isClassExpression(classNode)) &&
         Boolean(classNode.superClass)
+      const [completionIdentifier, traceGeneratorYields] =
+        getGeneratorOptions(path)
 
       // Any receiver read can throw before a derived constructor reaches super().
       context.enterFunction(
@@ -221,7 +315,9 @@ export const createFunctionVisitors = (context: InstrumentationContext) => ({
         `Entering method: ${methodName}`,
         getParameterNames(path.node.params),
         path.scope.generateUidIdentifier('algorithmVisualizerFrameId'),
-        !isDerivedConstructor
+        !isDerivedConstructor,
+        completionIdentifier,
+        traceGeneratorYields
       )
     },
     exit(path: NodePath<t.ClassMethod>) {

--- a/src/features/code-execution/lib/instrumentation/intrinsics.ts
+++ b/src/features/code-execution/lib/instrumentation/intrinsics.ts
@@ -1,0 +1,18 @@
+export const INSTRUMENTATION_INTRINSICS_KEY =
+  '__algorithmVisualizerIntrinsics'
+
+const instrumentationIntrinsics = Object.freeze({
+  apply: Reflect.apply,
+  iterator: Symbol.iterator,
+  TypeError,
+})
+
+export type InstrumentationIntrinsicName =
+  keyof typeof instrumentationIntrinsics
+
+/** Makes captured host intrinsics available to generated instrumentation. */
+export function attachInstrumentationIntrinsics(target: object): void {
+  Object.defineProperty(target, INSTRUMENTATION_INTRINSICS_KEY, {
+    value: instrumentationIntrinsics,
+  })
+}

--- a/src/features/code-execution/lib/instrumentation/return-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/return-visitor.ts
@@ -40,6 +40,19 @@ export const createReturnVisitor = (context: InstrumentationContext) => {
 
         const line = getLineNumber(path.node)
         const returnLocation = `${context.getCurrentFunctionName()} line ${line}`
+        const completionIdentifier =
+          context.getCurrentFrameCompletionIdentifier()
+        const markFrameCompleted = completionIdentifier
+          ? context.markInstrumented(
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  t.identifier(completionIdentifier.name),
+                  t.booleanLiteral(true)
+                )
+              )
+            )
+          : undefined
 
         if (path.node.argument) {
           const tempId = path.scope.generateUidIdentifier(RETURN_TEMP_NAME)
@@ -63,11 +76,17 @@ export const createReturnVisitor = (context: InstrumentationContext) => {
           const returnStatement = context.markInstrumented(
             t.returnStatement(tempId)
           )
-          path.replaceWithMultiple([declaration, recordStep, returnStatement])
+          path.replaceWithMultiple([
+            declaration,
+            ...(markFrameCompleted ? [markFrameCompleted] : []),
+            recordStep,
+            returnStatement,
+          ])
           return
         }
 
-        path.insertBefore(
+        path.insertBefore([
+          ...(markFrameCompleted ? [markFrameCompleted] : []),
           createRecordStepStatement(
             STEP_TYPES.RETURN,
             line,
@@ -82,8 +101,8 @@ export const createReturnVisitor = (context: InstrumentationContext) => {
                 t.stringLiteral(returnLocation)
               ),
             ])
-          )
-        )
+          ),
+        ])
         context.markInstrumented(path.node)
       },
     },

--- a/src/features/code-execution/lib/instrumentation/return-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/return-visitor.ts
@@ -46,12 +46,35 @@ const deferTerminalStepUntilFinalizer = (
   context: InstrumentationContext,
   path: NodePath<t.ReturnStatement>,
   finalizer: t.BlockStatement,
+  finalizerRecorders: WeakMap<t.BlockStatement, t.Identifier>,
   terminalStatements: t.Statement[]
 ): t.Statement[] => {
-  const recorderId = path.scope.generateUidIdentifier(RETURN_RECORDER_NAME)
-  const recorderDeclaration = context.markInstrumented(
-    t.variableDeclaration('var', [t.variableDeclarator(recorderId)])
-  )
+  const existingRecorderId = finalizerRecorders.get(finalizer)
+  const recorderId =
+    existingRecorderId ??
+    path.scope.generateUidIdentifier(RETURN_RECORDER_NAME)
+  const setupStatements: t.Statement[] = []
+
+  if (!existingRecorderId) {
+    finalizerRecorders.set(finalizer, recorderId)
+    setupStatements.push(
+      context.markInstrumented(
+        t.variableDeclaration('var', [t.variableDeclarator(recorderId)])
+      )
+    )
+    const invokeRecorder = context.markInstrumented(
+      t.callExpression(recorderId, [])
+    )
+    finalizer.body.push(
+      context.markInstrumented(
+        t.ifStatement(
+          recorderId,
+          t.blockStatement([t.expressionStatement(invokeRecorder)])
+        )
+      )
+    )
+  }
+
   const recorderAssignment = context.markInstrumented(
     t.expressionStatement(
       context.markInstrumented(
@@ -68,23 +91,13 @@ const deferTerminalStepUntilFinalizer = (
       )
     )
   )
-  const invokeRecorder = context.markInstrumented(
-    t.callExpression(recorderId, [])
-  )
-  finalizer.body.push(
-    context.markInstrumented(
-      t.ifStatement(
-        recorderId,
-        t.blockStatement([t.expressionStatement(invokeRecorder)])
-      )
-    )
-  )
 
-  return [recorderDeclaration, recorderAssignment]
+  return [...setupStatements, recorderAssignment]
 }
 
 export const createReturnVisitor = (context: InstrumentationContext) => {
   const argumentDescriptions = new WeakMap<t.ReturnStatement, string>()
+  const finalizerRecorders = new WeakMap<t.BlockStatement, t.Identifier>()
 
   return {
     ReturnStatement: {
@@ -149,6 +162,7 @@ export const createReturnVisitor = (context: InstrumentationContext) => {
                 context,
                 path,
                 pendingFinalizer,
+                finalizerRecorders,
                 terminalStatements
               )
             : terminalStatements
@@ -184,6 +198,7 @@ export const createReturnVisitor = (context: InstrumentationContext) => {
                 context,
                 path,
                 pendingFinalizer,
+                finalizerRecorders,
                 terminalStatements
               )
             : terminalStatements

--- a/src/features/code-execution/lib/instrumentation/return-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/return-visitor.ts
@@ -11,6 +11,7 @@ import { InstrumentationContext } from './context'
 import { createRecordStepStatement } from './step-factory'
 
 const RETURN_TEMP_NAME = 'algorithmVisualizerReturnValue'
+const RETURN_RECORDER_NAME = 'algorithmVisualizerReturnRecorder'
 
 const getReturnArgumentDescription = (argument: t.Expression): string => {
   if (
@@ -20,6 +21,66 @@ const getReturnArgumentDescription = (argument: t.Expression): string => {
     return 'function'
   }
   return safeGenerate(argument)
+}
+
+const getOutermostPendingFinalizer = (
+  path: NodePath<t.ReturnStatement>
+): t.BlockStatement | undefined => {
+  const ancestry = path.getAncestry()
+  const containingNodes = new Set(ancestry.map((ancestor) => ancestor.node))
+  let finalizer: t.BlockStatement | undefined
+
+  for (const ancestor of ancestry) {
+    if (ancestor.isFunction()) break
+    if (!ancestor.isTryStatement()) continue
+
+    const candidate = ancestor.node.finalizer
+    if (!candidate || containingNodes.has(candidate)) continue
+    finalizer = candidate
+  }
+
+  return finalizer
+}
+
+const deferTerminalStepUntilFinalizer = (
+  context: InstrumentationContext,
+  path: NodePath<t.ReturnStatement>,
+  finalizer: t.BlockStatement,
+  terminalStatements: t.Statement[]
+): t.Statement[] => {
+  const recorderId = path.scope.generateUidIdentifier(RETURN_RECORDER_NAME)
+  const recorderDeclaration = context.markInstrumented(
+    t.variableDeclaration('var', [t.variableDeclarator(recorderId)])
+  )
+  const recorderAssignment = context.markInstrumented(
+    t.expressionStatement(
+      context.markInstrumented(
+        t.assignmentExpression(
+          '=',
+          recorderId,
+          context.markInstrumented(
+            t.arrowFunctionExpression(
+              [],
+              t.blockStatement(terminalStatements)
+            )
+          )
+        )
+      )
+    )
+  )
+  const invokeRecorder = context.markInstrumented(
+    t.callExpression(recorderId, [])
+  )
+  finalizer.body.push(
+    context.markInstrumented(
+      t.ifStatement(
+        recorderId,
+        t.blockStatement([t.expressionStatement(invokeRecorder)])
+      )
+    )
+  )
+
+  return [recorderDeclaration, recorderAssignment]
 }
 
 export const createReturnVisitor = (context: InstrumentationContext) => {
@@ -42,6 +103,9 @@ export const createReturnVisitor = (context: InstrumentationContext) => {
         const returnLocation = `${context.getCurrentFunctionName()} line ${line}`
         const completionIdentifier =
           context.getCurrentFrameCompletionIdentifier()
+        const pendingFinalizer = completionIdentifier
+          ? getOutermostPendingFinalizer(path)
+          : undefined
         const markFrameCompleted = completionIdentifier
           ? context.markInstrumented(
               t.expressionStatement(
@@ -76,16 +140,27 @@ export const createReturnVisitor = (context: InstrumentationContext) => {
           const returnStatement = context.markInstrumented(
             t.returnStatement(tempId)
           )
-          path.replaceWithMultiple([
-            declaration,
+          const terminalStatements = [
             ...(markFrameCompleted ? [markFrameCompleted] : []),
             recordStep,
+          ]
+          const deferredStatements = pendingFinalizer
+            ? deferTerminalStepUntilFinalizer(
+                context,
+                path,
+                pendingFinalizer,
+                terminalStatements
+              )
+            : terminalStatements
+          path.replaceWithMultiple([
+            declaration,
+            ...deferredStatements,
             returnStatement,
           ])
           return
         }
 
-        path.insertBefore([
+        const terminalStatements = [
           ...(markFrameCompleted ? [markFrameCompleted] : []),
           createRecordStepStatement(
             STEP_TYPES.RETURN,
@@ -102,7 +177,17 @@ export const createReturnVisitor = (context: InstrumentationContext) => {
               ),
             ])
           ),
-        ])
+        ]
+        path.insertBefore(
+          pendingFinalizer
+            ? deferTerminalStepUntilFinalizer(
+                context,
+                path,
+                pendingFinalizer,
+                terminalStatements
+              )
+            : terminalStatements
+        )
         context.markInstrumented(path.node)
       },
     },

--- a/src/features/code-execution/lib/instrumentation/visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/visitor.ts
@@ -6,14 +6,13 @@ import { createMutationVisitors } from './mutation-visitors'
 import { createReturnVisitor } from './return-visitor'
 import { createYieldVisitor } from './yield-visitor'
 
-export const createInstrumentationVisitor = () => {
-  const context = new InstrumentationContext()
-  return {
-    ...createFunctionVisitors(context),
-    ...createAwaitVisitor(context),
-    ...createYieldVisitor(context),
-    ...createMutationVisitors(context),
-    ...createLoopVisitors(context),
-    ...createReturnVisitor(context),
-  }
-}
+export const createInstrumentationVisitor = (
+  context: InstrumentationContext
+) => ({
+  ...createFunctionVisitors(context),
+  ...createAwaitVisitor(context),
+  ...createYieldVisitor(context),
+  ...createMutationVisitors(context),
+  ...createLoopVisitors(context),
+  ...createReturnVisitor(context),
+})

--- a/src/features/code-execution/lib/instrumentation/visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/visitor.ts
@@ -4,12 +4,14 @@ import { createFunctionVisitors } from './function-visitors'
 import { createLoopVisitors } from './loop-visitors'
 import { createMutationVisitors } from './mutation-visitors'
 import { createReturnVisitor } from './return-visitor'
+import { createYieldVisitor } from './yield-visitor'
 
 export const createInstrumentationVisitor = () => {
   const context = new InstrumentationContext()
   return {
     ...createFunctionVisitors(context),
     ...createAwaitVisitor(context),
+    ...createYieldVisitor(context),
     ...createMutationVisitors(context),
     ...createLoopVisitors(context),
     ...createReturnVisitor(context),

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -480,7 +480,15 @@ export const createYieldVisitor = (context: InstrumentationContext) => ({
       path.replaceWith(
         context.markInstrumented(
           t.yieldExpression(
-            context.markInstrumented(t.callExpression(wrapper, [argument])),
+            context.markInstrumented(
+              t.callExpression(
+                t.memberExpression(
+                  t.identifier('Reflect'),
+                  t.identifier('apply')
+                ),
+                [wrapper, t.thisExpression(), t.arrayExpression([argument])]
+              )
+            ),
             true
           )
         )

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -89,6 +89,14 @@ const createDelegatedYield = (
         t.objectProperty(t.stringLiteral(YIELD_INPUT_LABEL), valueId),
       ])
     )
+  const createDelegatedMethodCall = (
+    methodId: t.Identifier,
+    args: t.Expression[]
+  ) =>
+    t.callExpression(
+      t.memberExpression(t.identifier('Reflect'), t.identifier('apply')),
+      [methodId, iteratorId, t.arrayExpression(args)]
+    )
   const createIteratorResultValidation = (resultId: t.Identifier) =>
     t.ifStatement(
       t.logicalExpression(
@@ -173,14 +181,8 @@ const createDelegatedYield = (
         nextResultId,
         t.conditionalExpression(
           wasStartedId,
-          t.callExpression(
-            t.memberExpression(nextMethodId, t.identifier('call')),
-            [iteratorId, inputId]
-          ),
-          t.callExpression(
-            t.memberExpression(nextMethodId, t.identifier('call')),
-            [iteratorId]
-          )
+          createDelegatedMethodCall(nextMethodId, [inputId]),
+          createDelegatedMethodCall(nextMethodId, [])
         )
       ),
     ]),
@@ -250,13 +252,7 @@ const createDelegatedYield = (
             t.variableDeclaration('const', [
               t.variableDeclarator(
                 fallbackReturnResultId,
-                t.callExpression(
-                  t.memberExpression(
-                    fallbackReturnMethodId,
-                    t.identifier('call')
-                  ),
-                  [iteratorId]
-                )
+                createDelegatedMethodCall(fallbackReturnMethodId, [])
               )
             ]),
             createIteratorResultValidation(fallbackReturnResultId),
@@ -288,10 +284,7 @@ const createDelegatedYield = (
     t.variableDeclaration('const', [
       t.variableDeclarator(
         throwResultId,
-        t.callExpression(
-          t.memberExpression(throwMethodId, t.identifier('call')),
-          [iteratorId, errorId]
-        )
+        createDelegatedMethodCall(throwMethodId, [errorId])
       ),
     ]),
     ...createNormalizedResultStatements(throwResultId),
@@ -341,10 +334,7 @@ const createDelegatedYield = (
     t.variableDeclaration('const', [
       t.variableDeclarator(
         returnResultId,
-        t.callExpression(
-          t.memberExpression(returnMethodId, t.identifier('call')),
-          [iteratorId, returnValueId]
-        )
+        createDelegatedMethodCall(returnMethodId, [returnValueId])
       ),
     ]),
     ...createNormalizedResultStatements(returnResultId),

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -407,7 +407,9 @@ export const createYieldVisitor = (context: InstrumentationContext) => ({
       }
 
       const line = getLineNumber(path.node)
-      const argument = path.node.argument ?? t.identifier('undefined')
+      const argument =
+        path.node.argument ??
+        t.unaryExpression('void', t.numericLiteral(0), true)
       const source = path.node.argument
         ? safeGenerate(path.node.argument)
         : 'undefined'

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -50,6 +50,9 @@ const createDelegatedYield = (
   const returnValueId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldReturnValue'
   )
+  const throwMethodId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldThrowMethod'
+  )
   const returnMethodId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldReturnMethod'
   )
@@ -182,14 +185,21 @@ const createDelegatedYield = (
       `Delegated generator resumed with throw: ${source}`,
       context.createScopeProperties()
     ),
+    t.variableDeclaration('const', [
+      t.variableDeclarator(
+        throwMethodId,
+        t.memberExpression(iteratorId, t.identifier('throw'))
+      ),
+    ]),
     t.ifStatement(
-      t.binaryExpression(
-        '!==',
-        t.unaryExpression(
-          'typeof',
-          t.memberExpression(iteratorId, t.identifier('throw'))
+      t.logicalExpression(
+        '||',
+        t.binaryExpression('===', throwMethodId, t.nullLiteral()),
+        t.binaryExpression(
+          '===',
+          throwMethodId,
+          t.unaryExpression('void', t.numericLiteral(0))
         ),
-        t.stringLiteral('function')
       ),
       t.blockStatement([
         t.ifStatement(
@@ -217,12 +227,28 @@ const createDelegatedYield = (
         ),
       ])
     ),
+    t.ifStatement(
+      t.binaryExpression(
+        '!==',
+        t.unaryExpression('typeof', throwMethodId),
+        t.stringLiteral('function')
+      ),
+      t.blockStatement([
+        t.throwStatement(
+          t.newExpression(t.identifier('TypeError'), [
+            t.stringLiteral(
+              'The delegated iterator throw method is not callable'
+            ),
+          ])
+        ),
+      ])
+    ),
     t.variableDeclaration('const', [
       t.variableDeclarator(
         throwResultId,
         t.callExpression(
-          t.memberExpression(iteratorId, t.identifier('throw')),
-          [errorId]
+          t.memberExpression(throwMethodId, t.identifier('call')),
+          [iteratorId, errorId]
         )
       ),
     ]),

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -35,6 +35,9 @@ const createDelegatedYield = (
   const startedId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldStarted'
   )
+  const wasStartedId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldWasStarted'
+  )
   const inputId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldInput'
   )
@@ -90,8 +93,11 @@ const createDelegatedYield = (
     )
   )
   const nextMethod = createIteratorMethod(context, inputId, [
+    t.variableDeclaration('const', [
+      t.variableDeclarator(wasStartedId, startedId),
+    ]),
     t.ifStatement(
-      startedId,
+      wasStartedId,
       t.blockStatement([createResumeStep(inputId)]),
       t.blockStatement([
         t.expressionStatement(
@@ -102,9 +108,17 @@ const createDelegatedYield = (
     t.variableDeclaration('const', [
       t.variableDeclarator(
         nextResultId,
-        t.callExpression(t.memberExpression(iteratorId, t.identifier('next')), [
-          inputId,
-        ])
+        t.conditionalExpression(
+          wasStartedId,
+          t.callExpression(
+            t.memberExpression(iteratorId, t.identifier('next')),
+            [inputId]
+          ),
+          t.callExpression(
+            t.memberExpression(iteratorId, t.identifier('next')),
+            []
+          )
+        )
       ),
     ]),
     recordSuspendWhenPending(nextResultId),

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -32,6 +32,9 @@ const createDelegatedYield = (
   const iteratorId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldIterator'
   )
+  const nextMethodId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldNext'
+  )
   const startedId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldStarted'
   )
@@ -111,12 +114,12 @@ const createDelegatedYield = (
         t.conditionalExpression(
           wasStartedId,
           t.callExpression(
-            t.memberExpression(iteratorId, t.identifier('next')),
-            [inputId]
+            t.memberExpression(nextMethodId, t.identifier('call')),
+            [iteratorId, inputId]
           ),
           t.callExpression(
-            t.memberExpression(iteratorId, t.identifier('next')),
-            []
+            t.memberExpression(nextMethodId, t.identifier('call')),
+            [iteratorId]
           )
         )
       ),
@@ -231,6 +234,12 @@ const createDelegatedYield = (
         ]),
         t.variableDeclaration('let', [
           t.variableDeclarator(startedId, t.booleanLiteral(false)),
+        ]),
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            nextMethodId,
+            t.memberExpression(iteratorId, t.identifier('next'))
+          ),
         ]),
         t.returnStatement(
           t.objectExpression([

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -94,7 +94,7 @@ const createDelegatedYield = (
     args: t.Expression[]
   ) =>
     t.callExpression(
-      t.memberExpression(t.identifier('Reflect'), t.identifier('apply')),
+      context.createIntrinsicReference('apply'),
       [methodId, iteratorId, t.arrayExpression(args)]
     )
   const createIteratorResultValidation = (resultId: t.Identifier) =>
@@ -118,7 +118,7 @@ const createDelegatedYield = (
       ),
       t.blockStatement([
         t.throwStatement(
-          t.newExpression(t.identifier('TypeError'), [
+          t.newExpression(context.createIntrinsicReference('TypeError'), [
             t.stringLiteral('Iterator result is not an object'),
           ])
         ),
@@ -241,11 +241,14 @@ const createDelegatedYield = (
               ),
               t.blockStatement([
                 t.throwStatement(
-                  t.newExpression(t.identifier('TypeError'), [
-                    t.stringLiteral(
-                      'The delegated iterator return method is not callable'
-                    ),
-                  ])
+                  t.newExpression(
+                    context.createIntrinsicReference('TypeError'),
+                    [
+                      t.stringLiteral(
+                        'The delegated iterator return method is not callable'
+                      ),
+                    ]
+                  )
                 ),
               ])
             ),
@@ -259,7 +262,7 @@ const createDelegatedYield = (
           ])
         ),
         t.throwStatement(
-          t.newExpression(t.identifier('TypeError'), [
+          t.newExpression(context.createIntrinsicReference('TypeError'), [
             t.stringLiteral('The delegated iterator has no throw method'),
           ])
         ),
@@ -273,7 +276,7 @@ const createDelegatedYield = (
       ),
       t.blockStatement([
         t.throwStatement(
-          t.newExpression(t.identifier('TypeError'), [
+          t.newExpression(context.createIntrinsicReference('TypeError'), [
             t.stringLiteral(
               'The delegated iterator throw method is not callable'
             ),
@@ -323,7 +326,7 @@ const createDelegatedYield = (
       ),
       t.blockStatement([
         t.throwStatement(
-          t.newExpression(t.identifier('TypeError'), [
+          t.newExpression(context.createIntrinsicReference('TypeError'), [
             t.stringLiteral(
               'The delegated iterator return method is not callable'
             ),
@@ -349,10 +352,7 @@ const createDelegatedYield = (
             t.callExpression(
               t.memberExpression(
                 iterableId,
-                t.memberExpression(
-                  t.identifier('Symbol'),
-                  t.identifier('iterator')
-                ),
+                context.createIntrinsicReference('iterator'),
                 true
               ),
               []
@@ -371,10 +371,7 @@ const createDelegatedYield = (
         t.returnStatement(
           t.objectExpression([
             t.objectProperty(
-              t.memberExpression(
-                t.identifier('Symbol'),
-                t.identifier('iterator')
-              ),
+              context.createIntrinsicReference('iterator'),
               iteratorMethod,
               true
             ),
@@ -484,10 +481,7 @@ export const createYieldVisitor = (context: InstrumentationContext) => ({
           t.yieldExpression(
             context.markInstrumented(
               t.callExpression(
-                t.memberExpression(
-                  t.identifier('Reflect'),
-                  t.identifier('apply')
-                ),
+                context.createIntrinsicReference('apply'),
                 [wrapper, t.thisExpression(), t.arrayExpression([argument])]
               )
             ),

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -50,6 +50,9 @@ const createDelegatedYield = (
   const returnValueId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldReturnValue'
   )
+  const returnMethodId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldReturnMethod'
+  )
   const nextResultId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldResult'
   )
@@ -182,14 +185,21 @@ const createDelegatedYield = (
     t.returnStatement(throwResultId),
   ])
   const returnMethod = createIteratorMethod(context, returnValueId, [
+    t.variableDeclaration('const', [
+      t.variableDeclarator(
+        returnMethodId,
+        t.memberExpression(iteratorId, t.identifier('return'))
+      ),
+    ]),
     t.ifStatement(
-      t.binaryExpression(
-        '!==',
-        t.unaryExpression(
-          'typeof',
-          t.memberExpression(iteratorId, t.identifier('return'))
-        ),
-        t.stringLiteral('function')
+      t.logicalExpression(
+        '||',
+        t.binaryExpression('===', returnMethodId, t.nullLiteral()),
+        t.binaryExpression(
+          '===',
+          returnMethodId,
+          t.unaryExpression('void', t.numericLiteral(0))
+        )
       ),
       t.blockStatement([
         t.returnStatement(
@@ -200,12 +210,28 @@ const createDelegatedYield = (
         ),
       ])
     ),
+    t.ifStatement(
+      t.binaryExpression(
+        '!==',
+        t.unaryExpression('typeof', returnMethodId),
+        t.stringLiteral('function')
+      ),
+      t.blockStatement([
+        t.throwStatement(
+          t.newExpression(t.identifier('TypeError'), [
+            t.stringLiteral(
+              'The delegated iterator return method is not callable'
+            ),
+          ])
+        ),
+      ])
+    ),
     t.variableDeclaration('const', [
       t.variableDeclarator(
         returnResultId,
         t.callExpression(
-          t.memberExpression(iteratorId, t.identifier('return')),
-          [returnValueId]
+          t.memberExpression(returnMethodId, t.identifier('call')),
+          [iteratorId, returnValueId]
         )
       ),
     ]),

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -293,6 +293,17 @@ const createDelegatedYield = (
     ...createNormalizedResultStatements(throwResultId),
   ])
   const returnMethod = createIteratorMethod(context, returnValueId, [
+    createRecordStepStatement(
+      STEP_TYPES.YIELD_RESUME,
+      line,
+      `Delegated generator resumed with return: ${source}`,
+      context.createScopeProperties([
+        t.objectProperty(
+          t.stringLiteral(YIELD_INPUT_LABEL),
+          returnValueId
+        ),
+      ])
+    ),
     t.variableDeclaration('const', [
       t.variableDeclarator(
         returnMethodId,

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -62,16 +62,13 @@ const createDelegatedYield = (
   const returnResultId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldReturnResult'
   )
-  const createSuspendStep = (resultId: t.Identifier) =>
+  const createSuspendStep = (valueId: t.Identifier) =>
     createRecordStepStatement(
       STEP_TYPES.YIELD_SUSPEND,
       line,
       `Yielded from delegate: ${source}`,
       context.createScopeProperties([
-        t.objectProperty(
-          t.stringLiteral(YIELD_VALUE_LABEL),
-          t.memberExpression(resultId, t.identifier('value'))
-        ),
+        t.objectProperty(t.stringLiteral(YIELD_VALUE_LABEL), valueId),
       ])
     )
   const createResumeStep = (valueId: t.Identifier) =>
@@ -83,14 +80,63 @@ const createDelegatedYield = (
         t.objectProperty(t.stringLiteral(YIELD_INPUT_LABEL), valueId),
       ])
     )
-  const recordSuspendWhenPending = (resultId: t.Identifier) =>
-    t.ifStatement(
-      t.unaryExpression(
-        '!',
-        t.memberExpression(resultId, t.identifier('done'))
-      ),
-      t.blockStatement([createSuspendStep(resultId)])
+  const createNormalizedResultStatements = (resultId: t.Identifier) => {
+    const doneId = path.scope.generateUidIdentifier(
+      'algorithmVisualizerYieldDone'
     )
+    const valueId = path.scope.generateUidIdentifier(
+      'algorithmVisualizerYieldValue'
+    )
+
+    return [
+      t.ifStatement(
+        t.logicalExpression(
+          '&&',
+          t.logicalExpression(
+            '||',
+            t.binaryExpression(
+              '!==',
+              t.unaryExpression('typeof', resultId),
+              t.stringLiteral('object')
+            ),
+            t.binaryExpression('===', resultId, t.nullLiteral())
+          ),
+          t.binaryExpression(
+            '!==',
+            t.unaryExpression('typeof', resultId),
+            t.stringLiteral('function')
+          )
+        ),
+        t.blockStatement([
+          t.throwStatement(
+            t.newExpression(t.identifier('TypeError'), [
+              t.stringLiteral('Iterator result is not an object'),
+            ])
+          ),
+        ])
+      ),
+      t.variableDeclaration('const', [
+        t.variableDeclarator(
+          doneId,
+          t.memberExpression(resultId, t.identifier('done'))
+        ),
+        t.variableDeclarator(
+          valueId,
+          t.memberExpression(resultId, t.identifier('value'))
+        ),
+      ]),
+      t.ifStatement(
+        t.unaryExpression('!', doneId),
+        t.blockStatement([createSuspendStep(valueId)])
+      ),
+      t.returnStatement(
+        t.objectExpression([
+          t.objectProperty(t.identifier('done'), doneId),
+          t.objectProperty(t.identifier('value'), valueId),
+        ])
+      ),
+    ]
+  }
   const iteratorMethod = context.markInstrumented(
     t.functionExpression(
       null,
@@ -127,8 +173,7 @@ const createDelegatedYield = (
         )
       ),
     ]),
-    recordSuspendWhenPending(nextResultId),
-    t.returnStatement(nextResultId),
+    ...createNormalizedResultStatements(nextResultId),
   ])
   const throwMethod = createIteratorMethod(context, errorId, [
     createRecordStepStatement(
@@ -181,8 +226,7 @@ const createDelegatedYield = (
         )
       ),
     ]),
-    recordSuspendWhenPending(throwResultId),
-    t.returnStatement(throwResultId),
+    ...createNormalizedResultStatements(throwResultId),
   ])
   const returnMethod = createIteratorMethod(context, returnValueId, [
     t.variableDeclaration('const', [
@@ -235,8 +279,7 @@ const createDelegatedYield = (
         )
       ),
     ]),
-    recordSuspendWhenPending(returnResultId),
-    t.returnStatement(returnResultId),
+    ...createNormalizedResultStatements(returnResultId),
   ])
   const wrapper = context.markInstrumented(
     t.arrowFunctionExpression(

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -1,0 +1,340 @@
+import { type NodePath } from '@babel/traverse'
+import * as t from '@babel/types'
+
+import {
+  STEP_TYPES,
+  YIELD_INPUT_LABEL,
+  YIELD_VALUE_LABEL,
+} from '@/entities/execution'
+import { getLineNumber, safeGenerate } from './ast-utils'
+import { InstrumentationContext } from './context'
+import { createRecordStepStatement } from './step-factory'
+
+const createIteratorMethod = (
+  context: InstrumentationContext,
+  parameter: t.Identifier,
+  statements: t.Statement[]
+): t.FunctionExpression =>
+  context.markInstrumented(
+    t.functionExpression(null, [parameter], t.blockStatement(statements))
+  )
+
+const createDelegatedYield = (
+  path: NodePath<t.YieldExpression>,
+  context: InstrumentationContext,
+  argument: t.Expression,
+  line: number,
+  source: string
+): t.YieldExpression => {
+  const iterableId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldIterable'
+  )
+  const iteratorId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldIterator'
+  )
+  const startedId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldStarted'
+  )
+  const inputId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldInput'
+  )
+  const errorId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldError'
+  )
+  const returnValueId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldReturnValue'
+  )
+  const nextResultId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldResult'
+  )
+  const throwResultId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldThrowResult'
+  )
+  const returnResultId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldReturnResult'
+  )
+  const createSuspendStep = (resultId: t.Identifier) =>
+    createRecordStepStatement(
+      STEP_TYPES.YIELD_SUSPEND,
+      line,
+      `Yielded from delegate: ${source}`,
+      context.createScopeProperties([
+        t.objectProperty(
+          t.stringLiteral(YIELD_VALUE_LABEL),
+          t.memberExpression(resultId, t.identifier('value'))
+        ),
+      ])
+    )
+  const createResumeStep = (valueId: t.Identifier) =>
+    createRecordStepStatement(
+      STEP_TYPES.YIELD_RESUME,
+      line,
+      `Resumed delegated yield: ${source}`,
+      context.createScopeProperties([
+        t.objectProperty(t.stringLiteral(YIELD_INPUT_LABEL), valueId),
+      ])
+    )
+  const recordSuspendWhenPending = (resultId: t.Identifier) =>
+    t.ifStatement(
+      t.unaryExpression(
+        '!',
+        t.memberExpression(resultId, t.identifier('done'))
+      ),
+      t.blockStatement([createSuspendStep(resultId)])
+    )
+  const iteratorMethod = context.markInstrumented(
+    t.functionExpression(
+      null,
+      [],
+      t.blockStatement([t.returnStatement(t.thisExpression())])
+    )
+  )
+  const nextMethod = createIteratorMethod(context, inputId, [
+    t.ifStatement(
+      startedId,
+      t.blockStatement([createResumeStep(inputId)]),
+      t.blockStatement([
+        t.expressionStatement(
+          t.assignmentExpression('=', startedId, t.booleanLiteral(true))
+        ),
+      ])
+    ),
+    t.variableDeclaration('const', [
+      t.variableDeclarator(
+        nextResultId,
+        t.callExpression(t.memberExpression(iteratorId, t.identifier('next')), [
+          inputId,
+        ])
+      ),
+    ]),
+    recordSuspendWhenPending(nextResultId),
+    t.returnStatement(nextResultId),
+  ])
+  const throwMethod = createIteratorMethod(context, errorId, [
+    createRecordStepStatement(
+      STEP_TYPES.YIELD_THROW,
+      line,
+      `Delegated generator resumed with throw: ${source}`,
+      context.createScopeProperties()
+    ),
+    t.ifStatement(
+      t.binaryExpression(
+        '!==',
+        t.unaryExpression(
+          'typeof',
+          t.memberExpression(iteratorId, t.identifier('throw'))
+        ),
+        t.stringLiteral('function')
+      ),
+      t.blockStatement([
+        t.ifStatement(
+          t.binaryExpression(
+            '===',
+            t.unaryExpression(
+              'typeof',
+              t.memberExpression(iteratorId, t.identifier('return'))
+            ),
+            t.stringLiteral('function')
+          ),
+          t.blockStatement([
+            t.expressionStatement(
+              t.callExpression(
+                t.memberExpression(iteratorId, t.identifier('return')),
+                []
+              )
+            ),
+          ])
+        ),
+        t.throwStatement(
+          t.newExpression(t.identifier('TypeError'), [
+            t.stringLiteral('The delegated iterator has no throw method'),
+          ])
+        ),
+      ])
+    ),
+    t.variableDeclaration('const', [
+      t.variableDeclarator(
+        throwResultId,
+        t.callExpression(
+          t.memberExpression(iteratorId, t.identifier('throw')),
+          [errorId]
+        )
+      ),
+    ]),
+    recordSuspendWhenPending(throwResultId),
+    t.returnStatement(throwResultId),
+  ])
+  const returnMethod = createIteratorMethod(context, returnValueId, [
+    t.ifStatement(
+      t.binaryExpression(
+        '!==',
+        t.unaryExpression(
+          'typeof',
+          t.memberExpression(iteratorId, t.identifier('return'))
+        ),
+        t.stringLiteral('function')
+      ),
+      t.blockStatement([
+        t.returnStatement(
+          t.objectExpression([
+            t.objectProperty(t.identifier('done'), t.booleanLiteral(true)),
+            t.objectProperty(t.identifier('value'), returnValueId),
+          ])
+        ),
+      ])
+    ),
+    t.variableDeclaration('const', [
+      t.variableDeclarator(
+        returnResultId,
+        t.callExpression(
+          t.memberExpression(iteratorId, t.identifier('return')),
+          [returnValueId]
+        )
+      ),
+    ]),
+    recordSuspendWhenPending(returnResultId),
+    t.returnStatement(returnResultId),
+  ])
+  const wrapper = context.markInstrumented(
+    t.arrowFunctionExpression(
+      [iterableId],
+      t.blockStatement([
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            iteratorId,
+            t.callExpression(
+              t.memberExpression(
+                iterableId,
+                t.memberExpression(
+                  t.identifier('Symbol'),
+                  t.identifier('iterator')
+                ),
+                true
+              ),
+              []
+            )
+          ),
+        ]),
+        t.variableDeclaration('let', [
+          t.variableDeclarator(startedId, t.booleanLiteral(false)),
+        ]),
+        t.returnStatement(
+          t.objectExpression([
+            t.objectProperty(
+              t.memberExpression(
+                t.identifier('Symbol'),
+                t.identifier('iterator')
+              ),
+              iteratorMethod,
+              true
+            ),
+            t.objectProperty(t.identifier('next'), nextMethod),
+            t.objectProperty(t.identifier('throw'), throwMethod),
+            t.objectProperty(t.identifier('return'), returnMethod),
+          ])
+        ),
+      ])
+    )
+  )
+
+  return context.markInstrumented(
+    t.yieldExpression(
+      context.markInstrumented(t.callExpression(wrapper, [argument])),
+      true
+    )
+  )
+}
+
+/** Records suspension and resumption around synchronous yield boundaries. */
+export const createYieldVisitor = (context: InstrumentationContext) => ({
+  YieldExpression: {
+    exit(path: NodePath<t.YieldExpression>) {
+      if (
+        context.isInstrumented(path.node) ||
+        !context.isCurrentFunctionTracedGenerator()
+      ) {
+        return
+      }
+
+      const line = getLineNumber(path.node)
+      const argument = path.node.argument ?? t.identifier('undefined')
+      const source = path.node.argument
+        ? safeGenerate(path.node.argument)
+        : 'undefined'
+
+      if (path.node.delegate) {
+        path.replaceWith(
+          createDelegatedYield(path, context, argument, line, source)
+        )
+        return
+      }
+      const operandId = path.scope.generateUidIdentifier(
+        'algorithmVisualizerYieldOperand'
+      )
+      const inputId = path.scope.generateUidIdentifier(
+        'algorithmVisualizerYieldInput'
+      )
+      const errorId = path.scope.generateUidIdentifier(
+        'algorithmVisualizerYieldError'
+      )
+      const innerYield = context.markInstrumented(t.yieldExpression(operandId))
+      const wrapper = context.markInstrumented(
+        t.functionExpression(
+          null,
+          [operandId],
+          t.blockStatement([
+            createRecordStepStatement(
+              STEP_TYPES.YIELD_SUSPEND,
+              line,
+              `Yielded: ${source}`,
+              context.createScopeProperties([
+                t.objectProperty(t.stringLiteral(YIELD_VALUE_LABEL), operandId),
+              ])
+            ),
+            t.tryStatement(
+              t.blockStatement([
+                t.variableDeclaration('const', [
+                  t.variableDeclarator(inputId, innerYield),
+                ]),
+                createRecordStepStatement(
+                  STEP_TYPES.YIELD_RESUME,
+                  line,
+                  `Resumed after yield: ${source}`,
+                  context.createScopeProperties([
+                    t.objectProperty(
+                      t.stringLiteral(YIELD_INPUT_LABEL),
+                      inputId
+                    ),
+                  ])
+                ),
+                t.returnStatement(inputId),
+              ]),
+              t.catchClause(
+                errorId,
+                t.blockStatement([
+                  createRecordStepStatement(
+                    STEP_TYPES.YIELD_THROW,
+                    line,
+                    `Generator resumed with throw: ${source}`,
+                    context.createScopeProperties()
+                  ),
+                  t.throwStatement(errorId),
+                ])
+              )
+            ),
+          ]),
+          true
+        )
+      )
+
+      path.replaceWith(
+        context.markInstrumented(
+          t.yieldExpression(
+            context.markInstrumented(t.callExpression(wrapper, [argument])),
+            true
+          )
+        )
+      )
+    },
+  },
+})

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -426,6 +426,15 @@ export const createYieldVisitor = (context: InstrumentationContext) => ({
       const errorId = path.scope.generateUidIdentifier(
         'algorithmVisualizerYieldError'
       )
+      const handledId = path.scope.generateUidIdentifier(
+        'algorithmVisualizerYieldHandled'
+      )
+      const markYieldHandled = () =>
+        context.markInstrumented(
+          t.expressionStatement(
+            t.assignmentExpression('=', handledId, t.booleanLiteral(true))
+          )
+        )
       const innerYield = context.markInstrumented(t.yieldExpression(operandId))
       const wrapper = context.markInstrumented(
         t.functionExpression(
@@ -440,11 +449,17 @@ export const createYieldVisitor = (context: InstrumentationContext) => ({
                 t.objectProperty(t.stringLiteral(YIELD_VALUE_LABEL), operandId),
               ])
             ),
+            context.markInstrumented(
+              t.variableDeclaration('let', [
+                t.variableDeclarator(handledId, t.booleanLiteral(false)),
+              ])
+            ),
             t.tryStatement(
               t.blockStatement([
                 t.variableDeclaration('const', [
                   t.variableDeclarator(inputId, innerYield),
                 ]),
+                markYieldHandled(),
                 createRecordStepStatement(
                   STEP_TYPES.YIELD_RESUME,
                   line,
@@ -461,6 +476,7 @@ export const createYieldVisitor = (context: InstrumentationContext) => ({
               t.catchClause(
                 errorId,
                 t.blockStatement([
+                  markYieldHandled(),
                   createRecordStepStatement(
                     STEP_TYPES.YIELD_THROW,
                     line,
@@ -469,7 +485,20 @@ export const createYieldVisitor = (context: InstrumentationContext) => ({
                   ),
                   t.throwStatement(errorId),
                 ])
-              )
+              ),
+              t.blockStatement([
+                t.ifStatement(
+                  t.unaryExpression('!', handledId),
+                  t.blockStatement([
+                    createRecordStepStatement(
+                      STEP_TYPES.YIELD_RESUME,
+                      line,
+                      `Generator resumed with return after yield: ${source}`,
+                      context.createScopeProperties()
+                    ),
+                  ])
+                ),
+              ])
             ),
           ]),
           true

--- a/src/features/code-execution/lib/instrumentation/yield-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/yield-visitor.ts
@@ -53,6 +53,9 @@ const createDelegatedYield = (
   const throwMethodId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldThrowMethod'
   )
+  const fallbackReturnMethodId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldFallbackReturnMethod'
+  )
   const returnMethodId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldReturnMethod'
   )
@@ -61,6 +64,9 @@ const createDelegatedYield = (
   )
   const throwResultId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldThrowResult'
+  )
+  const fallbackReturnResultId = path.scope.generateUidIdentifier(
+    'algorithmVisualizerYieldFallbackReturnResult'
   )
   const returnResultId = path.scope.generateUidIdentifier(
     'algorithmVisualizerYieldReturnResult'
@@ -83,6 +89,33 @@ const createDelegatedYield = (
         t.objectProperty(t.stringLiteral(YIELD_INPUT_LABEL), valueId),
       ])
     )
+  const createIteratorResultValidation = (resultId: t.Identifier) =>
+    t.ifStatement(
+      t.logicalExpression(
+        '&&',
+        t.logicalExpression(
+          '||',
+          t.binaryExpression(
+            '!==',
+            t.unaryExpression('typeof', resultId),
+            t.stringLiteral('object')
+          ),
+          t.binaryExpression('===', resultId, t.nullLiteral())
+        ),
+        t.binaryExpression(
+          '!==',
+          t.unaryExpression('typeof', resultId),
+          t.stringLiteral('function')
+        )
+      ),
+      t.blockStatement([
+        t.throwStatement(
+          t.newExpression(t.identifier('TypeError'), [
+            t.stringLiteral('Iterator result is not an object'),
+          ])
+        ),
+      ])
+    )
   const createNormalizedResultStatements = (resultId: t.Identifier) => {
     const doneId = path.scope.generateUidIdentifier(
       'algorithmVisualizerYieldDone'
@@ -92,32 +125,7 @@ const createDelegatedYield = (
     )
 
     return [
-      t.ifStatement(
-        t.logicalExpression(
-          '&&',
-          t.logicalExpression(
-            '||',
-            t.binaryExpression(
-              '!==',
-              t.unaryExpression('typeof', resultId),
-              t.stringLiteral('object')
-            ),
-            t.binaryExpression('===', resultId, t.nullLiteral())
-          ),
-          t.binaryExpression(
-            '!==',
-            t.unaryExpression('typeof', resultId),
-            t.stringLiteral('function')
-          )
-        ),
-        t.blockStatement([
-          t.throwStatement(
-            t.newExpression(t.identifier('TypeError'), [
-              t.stringLiteral('Iterator result is not an object'),
-            ])
-          ),
-        ])
-      ),
+      createIteratorResultValidation(resultId),
       t.variableDeclaration('const', [
         t.variableDeclarator(
           doneId,
@@ -202,22 +210,56 @@ const createDelegatedYield = (
         ),
       ),
       t.blockStatement([
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            fallbackReturnMethodId,
+            t.memberExpression(iteratorId, t.identifier('return'))
+          ),
+        ]),
         t.ifStatement(
-          t.binaryExpression(
-            '===',
-            t.unaryExpression(
-              'typeof',
-              t.memberExpression(iteratorId, t.identifier('return'))
+          t.logicalExpression(
+            '&&',
+            t.binaryExpression(
+              '!==',
+              fallbackReturnMethodId,
+              t.nullLiteral()
             ),
-            t.stringLiteral('function')
+            t.binaryExpression(
+              '!==',
+              fallbackReturnMethodId,
+              t.unaryExpression('void', t.numericLiteral(0))
+            )
           ),
           t.blockStatement([
-            t.expressionStatement(
-              t.callExpression(
-                t.memberExpression(iteratorId, t.identifier('return')),
-                []
-              )
+            t.ifStatement(
+              t.binaryExpression(
+                '!==',
+                t.unaryExpression('typeof', fallbackReturnMethodId),
+                t.stringLiteral('function')
+              ),
+              t.blockStatement([
+                t.throwStatement(
+                  t.newExpression(t.identifier('TypeError'), [
+                    t.stringLiteral(
+                      'The delegated iterator return method is not callable'
+                    ),
+                  ])
+                ),
+              ])
             ),
+            t.variableDeclaration('const', [
+              t.variableDeclarator(
+                fallbackReturnResultId,
+                t.callExpression(
+                  t.memberExpression(
+                    fallbackReturnMethodId,
+                    t.identifier('call')
+                  ),
+                  [iteratorId]
+                )
+              )
+            ]),
+            createIteratorResultValidation(fallbackReturnResultId),
           ])
         ),
         t.throwStatement(

--- a/src/features/code-execution/lib/instrumenter.ts
+++ b/src/features/code-execution/lib/instrumenter.ts
@@ -1,8 +1,28 @@
 import { parse } from '@babel/parser'
+import * as t from '@babel/types'
 
 import { isError } from '@/shared/lib/guards'
 import { generate, traverse } from './instrumentation/babel-compat'
+import { InstrumentationContext } from './instrumentation/context'
+import { INSTRUMENTATION_INTRINSICS_KEY } from './instrumentation/intrinsics'
 import { createInstrumentationVisitor } from './instrumentation/visitor'
+
+const INTRINSICS_IDENTIFIER_BASE = '__algorithmVisualizerIntrinsics'
+
+function createIntrinsicsIdentifier(ast: t.File): t.Identifier {
+  const identifierNames = new Set<string>()
+  t.traverseFast(ast, (node) => {
+    if (t.isIdentifier(node)) identifierNames.add(node.name)
+  })
+
+  let candidate = INTRINSICS_IDENTIFIER_BASE
+  let suffix = 2
+  while (identifierNames.has(candidate)) {
+    candidate = `${INTRINSICS_IDENTIFIER_BASE}${suffix++}`
+  }
+
+  return t.identifier(candidate)
+}
 
 /** Instruments JavaScript code to record execution steps. */
 export function instrumentCode(code: string): string {
@@ -11,8 +31,24 @@ export function instrumentCode(code: string): string {
       sourceType: 'module',
       plugins: ['typescript'],
     })
+    const intrinsicsIdentifier = createIntrinsicsIdentifier(ast)
+    const context = new InstrumentationContext(intrinsicsIdentifier)
+    ast.program.body.unshift(
+      context.markInstrumented(
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            intrinsicsIdentifier,
+            t.memberExpression(
+              t.identifier('recordStep'),
+              t.stringLiteral(INSTRUMENTATION_INTRINSICS_KEY),
+              true
+            )
+          ),
+        ])
+      )
+    )
 
-    traverse(ast, createInstrumentationVisitor())
+    traverse(ast, createInstrumentationVisitor(context))
 
     return generate(ast, {
       retainLines: true,

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -339,6 +339,39 @@ function run(): unknown[] {
     ).toBe(false)
   })
 
+  it('records only the latest return through an outer yielding finally', () => {
+    const state = executeCode(
+      `function* values(): Generator<number, number, void> {
+  try {
+    try {
+      return 1
+    } finally {
+      return 2
+    }
+  } finally {
+    yield 3
+  }
+}`,
+      {},
+      'values'
+    )
+    const suspendIndex = state.steps.findIndex(
+      (step) => step.type === 'yield-suspend'
+    )
+    const generatorReturns = state.steps.filter(
+      (step) =>
+        step.type === 'return' &&
+        step.metadata?.callFrame?.functionName === 'values'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(2)
+    expect(
+      generatorReturns.map((step) => step.variables[RETURN_VALUE_LABEL])
+    ).toEqual([2])
+    expect(generatorReturns[0]?.stepNumber).toBeGreaterThan(suspendIndex)
+  })
+
   it('reactivates the same frame when iterator.throw is handled', () => {
     const state = executeCode(
       `function* recover(): Generator<number | string, string, void> {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -353,6 +353,46 @@ function run(): unknown[] {
     expect(state.returnValue).toEqual([['get'], 'first', 'resume'])
   })
 
+  it('reads delegated iterator-result accessors once', () => {
+    const accesses: string[] = []
+    const iterator: IterableIterator<string> = {
+      [Symbol.iterator]() {
+        return this
+      },
+      next() {
+        let doneReads = 0
+        return {
+          get done() {
+            accesses.push('done')
+            doneReads += 1
+            return doneReads > 1
+          },
+          get value() {
+            accesses.push('value')
+            return 'first'
+          },
+        }
+      },
+    }
+    const state = executeCode(
+      `function* values(iterator: Iterable<string>): Generator<string, void, void> {
+  yield* iterator
+}
+
+function run(delegate: Iterable<string>): unknown[] {
+  const valuesIterator = values(delegate)
+  const first = valuesIterator.next()
+  return [first.done, first.value]
+}`,
+      { iterator },
+      'run'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([false, 'first'])
+    expect(accesses).toEqual(['done', 'value'])
+  })
+
   it('rejects a non-callable delegated iterator return method', () => {
     const state = executeCode(
       `function* values(): Generator<number, void, void> {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -296,6 +296,45 @@ function run(): unknown[] {
     expect(state.returnValue).toEqual([[0, 1], 'first', 'resume'])
   })
 
+  it('caches a delegated iterator next method with its receiver', () => {
+    const state = executeCode(
+      `function* values(accesses: string[]): Generator<string, string, string> {
+  const iterator = {
+    step: 0,
+    [Symbol.iterator]() {
+      return this
+    },
+  }
+  Object.defineProperty(iterator, 'next', {
+    enumerable: false,
+    get() {
+      const access = accesses.push('get')
+      return function (this: { step: number }, value?: string) {
+        if (access > 1) return { done: true, value: 'replacement' }
+        this.step += 1
+        if (this.step === 1) return { done: false, value: 'first' }
+        return { done: true, value: value ?? 'missing' }
+      }
+    },
+  })
+  return yield* (iterator as Iterable<string>)
+}
+
+function run(): unknown[] {
+  const accesses: string[] = []
+  const iterator = values(accesses)
+  const first = iterator.next()
+  const second = iterator.next('resume')
+  return [accesses, first.value, second.value]
+}`,
+      {},
+      'run'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([['get'], 'first', 'resume'])
+  })
+
   it('keeps nested yield* frames and parent relationships separate', () => {
     const state = executeCode(
       `function* child(): Generator<number, string, void> {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -64,6 +64,28 @@ describe('runner - generator execution', () => {
     ).toEqual([undefined, undefined])
   })
 
+  it('yields intrinsic undefined when the name is shadowed', () => {
+    const state = executeCode(
+      `function* values(undefined: string): Generator<undefined, void, void> {
+  yield
+}
+
+function run(): unknown[] {
+  const yielded = values('shadowed').next().value
+  return [yielded, yielded === void 0]
+}`,
+      {},
+      'run'
+    )
+    const suspend = state.steps.find(
+      (step) => step.type === 'yield-suspend'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([undefined, true])
+    expect(suspend?.variables[YIELD_VALUE_LABEL]).toBeUndefined()
+  })
+
   it('evaluates synchronous yield operand work before suspension', () => {
     const state = executeCode(
       `function helper(): number {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -335,6 +335,39 @@ function run(): unknown[] {
     expect(state.returnValue).toEqual([['get'], 'first', 'resume'])
   })
 
+  it('rejects a non-callable delegated iterator return method', () => {
+    const state = executeCode(
+      `function* values(): Generator<number, void, void> {
+  const iterator = {
+    next() {
+      return { done: false, value: 1 }
+    },
+    return: 1,
+    [Symbol.iterator]() {
+      return this
+    },
+  }
+  yield* (iterator as Iterable<number>)
+}
+
+function run(): string {
+  const iterator = values()
+  iterator.next()
+  try {
+    iterator.return()
+    return 'completed'
+  } catch (error) {
+    return error instanceof TypeError ? 'type-error' : 'other-error'
+  }
+}`,
+      {},
+      'run'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe('type-error')
+  })
+
   it('keeps nested yield* frames and parent relationships separate', () => {
     const state = executeCode(
       `function* child(): Generator<number, string, void> {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -759,6 +759,51 @@ function* parent(): Generator<number | string, string, void> {
     )
   })
 
+  it('preserves class heap state across yield suspension and resumption', () => {
+    const state = executeCode(
+      `class MinHeapLocal {
+  values: number[] = []
+
+  push(value: number): void {
+    this.values.push(value)
+  }
+}
+
+class GeneratorOwner {
+  *values(): Generator<number, void, void> {
+    this.minHeap.push(2)
+    yield 2
+    this.minHeap.push(1)
+  }
+
+  private minHeap = new MinHeapLocal()
+}
+
+function run(): void {
+  const iterator = new GeneratorOwner().values()
+  iterator.next()
+  iterator.next()
+}`,
+      {},
+      'run'
+    )
+    const yieldSteps = state.steps.filter(
+      (step) =>
+        (step.type === 'yield-suspend' || step.type === 'yield-resume') &&
+        step.metadata?.callFrame?.functionName === 'values'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(yieldSteps.map((step) => step.type)).toEqual([
+      'yield-suspend',
+      'yield-resume',
+    ])
+    expect(yieldSteps.map((step) => step.metadata?.heapTrace?.heaps)).toEqual([
+      [{ name: 'minHeap', kind: 'min', values: [2] }],
+      [{ name: 'minHeap', kind: 'min', values: [2] }],
+    ])
+  })
+
   it('drives a synchronous generator through the async execution path', async () => {
     const state = await executeCodeAsync(
       `function* answer(): Generator<number, number, void> {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -86,6 +86,56 @@ function run(): unknown[] {
     expect(suspend?.variables[YIELD_VALUE_LABEL]).toBeUndefined()
   })
 
+  it('uses captured intrinsics when global names are shadowed', () => {
+    const state = executeCode(
+      `function* values(
+  Reflect: unknown,
+  Symbol: unknown,
+  TypeError: unknown,
+  __algorithmVisualizerIntrinsics: unknown,
+  delegate: Iterable<number>
+): Generator<number, void, void> {
+  yield 1
+  yield* delegate
+}
+
+function ShadowedTypeError() {}
+
+function run(): unknown[] {
+  const delegate = {
+    next() {
+      return { done: false, value: 2 }
+    },
+    return: 1,
+    [Symbol.iterator]() {
+      return this
+    },
+  }
+  const iterator = values(
+    { apply() { throw new Error('shadowed Reflect') } },
+    { iterator: Symbol('shadowed') },
+    ShadowedTypeError,
+    {},
+    delegate as Iterable<number>
+  )
+  const first = iterator.next()
+  const second = iterator.next()
+
+  try {
+    iterator.return()
+    return [first.value, second.value, false]
+  } catch (error) {
+    return [first.value, second.value, error instanceof TypeError]
+  }
+}`,
+      {},
+      'run'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([1, 2, true])
+  })
+
   it('evaluates synchronous yield operand work before suspension', () => {
     const state = executeCode(
       `function helper(): number {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -353,6 +353,63 @@ function run(): unknown[] {
     expect(state.returnValue).toEqual([['get'], 'first', 'resume'])
   })
 
+  it('invokes delegated methods without reading their call property', () => {
+    const state = executeCode(
+      `function createDelegate(method: 'next' | 'throw' | 'return') {
+  const iterator = {
+    step: 0,
+    next() {
+      this.step += 1
+      return { done: false, value: this.step }
+    },
+    throw(error: Error) {
+      return { done: true, value: String(this.step) + ':' + error.message }
+    },
+    return(value?: string) {
+      return { done: true, value: String(this.step) + ':' + (value ?? 'missing') }
+    },
+    [Symbol.iterator]() {
+      return this
+    },
+  }
+  const selectedMethod =
+    method === 'next'
+      ? iterator.next
+      : method === 'throw'
+        ? iterator.throw
+        : iterator.return
+  Object.defineProperty(selectedMethod, 'call', { value: undefined })
+  return iterator as Iterable<number>
+}
+
+function* values(
+  delegate: Iterable<number>
+): Generator<number, string, string> {
+  return yield* delegate
+}
+
+function run(): unknown[] {
+  const nextIterator = values(createDelegate('next'))
+  const first = nextIterator.next()
+
+  const throwIterator = values(createDelegate('throw'))
+  throwIterator.next()
+  const thrown = throwIterator.throw(new Error('boom'))
+
+  const returnIterator = values(createDelegate('return'))
+  returnIterator.next()
+  const returned = returnIterator.return('closed')
+
+  return [first.value, thrown.value, returned.value]
+}`,
+      {},
+      'run'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([1, '1:boom', '1:closed'])
+  })
+
   it('reads delegated iterator-result accessors once', () => {
     const accesses: string[] = []
     const iterator: IterableIterator<string> = {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { YIELD_INPUT_LABEL, YIELD_VALUE_LABEL } from '@/entities/execution'
+import { stepBackward, stepForward } from './execution-state'
+import { executeCode, executeCodeAsync } from './runner'
+import { getCallFrameInspectorState } from '@/features/visualization/lib/call-frame-inspector'
+
+describe('runner - generator execution', () => {
+  it('drives a generator entry through multiple yields and its final return', () => {
+    const state = executeCode(
+      `function* count(start: number): Generator<number, string, void> {
+  let current = start
+  yield current
+  current += 1
+  yield current
+  return \`done:${'${current}'}\`
+}`,
+      { start: 1 },
+      'count'
+    )
+    const yieldSteps = state.steps.filter((step) =>
+      step.type.startsWith('yield-')
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe('done:2')
+    expect(yieldSteps.map((step) => step.type)).toEqual([
+      'yield-suspend',
+      'yield-resume',
+      'yield-suspend',
+      'yield-resume',
+    ])
+    expect(
+      yieldSteps
+        .filter((step) => step.type === 'yield-suspend')
+        .map((step) => step.variables[YIELD_VALUE_LABEL])
+    ).toEqual([1, 2])
+    expect(
+      yieldSteps
+        .filter((step) => step.type === 'yield-resume')
+        .map((step) => step.variables[YIELD_INPUT_LABEL])
+    ).toEqual([undefined, undefined])
+  })
+
+  it('evaluates synchronous yield operand work before suspension', () => {
+    const state = executeCode(
+      `function helper(): number {
+  const value = 3
+  return value
+}
+
+function* values(): Generator<number, void, void> {
+  yield helper()
+}`,
+      {},
+      'values'
+    )
+    const helperReturnIndex = state.steps.findIndex(
+      (step) =>
+        step.type === 'return' &&
+        step.metadata?.callFrame?.functionName === 'helper'
+    )
+    const suspendIndex = state.steps.findIndex(
+      (step) => step.type === 'yield-suspend'
+    )
+
+    expect(helperReturnIndex).toBeGreaterThan(-1)
+    expect(suspendIndex).toBeGreaterThan(helperReturnIndex)
+  })
+
+  it('feeds next(value) back into a manually consumed generator', () => {
+    const state = executeCode(
+      `function* exchange(): Generator<number, number, number> {
+  const received = yield 4
+  return received * 2
+}
+
+function run(): number[] {
+  const iterator = exchange()
+  const first = iterator.next()
+  const second = iterator.next(5)
+  return [first.value as number, second.value as number]
+}`,
+      {},
+      'run'
+    )
+    const resume = state.steps.find((step) => step.type === 'yield-resume')
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([4, 10])
+    expect(resume?.variables[YIELD_INPUT_LABEL]).toBe(5)
+    expect(
+      state.steps.some(
+        (step) =>
+          step.type === 'variable-declaration' && step.variables.received === 5
+      )
+    ).toBe(true)
+  })
+
+  it('closes the correct frame after iterator.return and runs cleanup first', () => {
+    const state = executeCode(
+      `function* values(log: string[]): Generator<number, number, void> {
+  try {
+    yield 1
+    log.push('after')
+  } finally {
+    log.push('cleanup')
+  }
+  return 0
+}
+
+function run(): string[] {
+  const log: string[] = []
+  const iterator = values(log)
+  iterator.next()
+  const closed = iterator.return(9)
+  log.push(\`done:${'${closed.value}'}\`)
+  return log
+}`,
+      {},
+      'run'
+    )
+    const generatorEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'values'
+    )
+    const close = state.steps.find((step) => step.type === 'generator-close')
+    const cleanupIndex = state.steps.findIndex((step) =>
+      step.description.startsWith("log.push('cleanup')")
+    )
+    const closeIndex = state.steps.findIndex(
+      (step) => step.type === 'generator-close'
+    )
+    const atClose = getCallFrameInspectorState({
+      ...state,
+      currentStep: closeIndex,
+    })
+    const afterClose = getCallFrameInspectorState({
+      ...state,
+      currentStep: closeIndex + 1,
+    })
+    const generatorFrameId = generatorEntry?.metadata?.callFrame?.frameId
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual(['cleanup', 'done:9'])
+    expect(close?.metadata?.callFrame).toEqual(
+      expect.objectContaining({
+        frameId: generatorEntry?.metadata?.callFrame?.frameId,
+        phase: 'close',
+      })
+    )
+    expect(closeIndex).toBeGreaterThan(cleanupIndex)
+    expect(
+      atClose.frames.find((frame) => frame.id === generatorFrameId)?.status
+    ).toBe('closing')
+    expect(
+      afterClose.frames.find((frame) => frame.id === generatorFrameId)?.status
+    ).toBe('completed')
+  })
+
+  it('reactivates the same frame when iterator.throw is handled', () => {
+    const state = executeCode(
+      `function* recover(): Generator<number | string, string, void> {
+  try {
+    yield 1
+  } catch (error) {
+    const message = (error as Error).message
+    yield message
+  }
+  return 'done'
+}
+
+function run(): unknown[] {
+  const iterator = recover()
+  iterator.next()
+  const recovered = iterator.throw(new Error('boom'))
+  const completed = iterator.next()
+  return [recovered.value, completed.value]
+}`,
+      {},
+      'run'
+    )
+    const generatorFrameIds = state.steps
+      .filter(
+        (step) =>
+          step.metadata?.callFrame?.functionName === 'recover' &&
+          step.type.startsWith('yield-')
+      )
+      .map((step) => step.metadata?.callFrame?.frameId)
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual(['boom', 'done'])
+    expect(state.steps.some((step) => step.type === 'yield-throw')).toBe(true)
+    expect(new Set(generatorFrameIds).size).toBe(1)
+  })
+
+  it('keeps repeated manually consumed generator frames independent', () => {
+    const state = executeCode(
+      `function* child(label: string): Generator<string, string, void> {
+  yield label
+  return \`${'${label}'}!\`
+}
+
+function run(): unknown[] {
+  const first = child('first')
+  const second = child('second')
+  const values = [
+    first.next().value,
+    second.next().value,
+    second.next().value,
+    first.next().value,
+  ]
+  return values
+}`,
+      {},
+      'run'
+    )
+    const entries = state.steps.filter(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'child'
+    )
+    const returns = state.steps.filter(
+      (step) =>
+        step.type === 'return' &&
+        step.metadata?.callFrame?.functionName === 'child'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual(['first', 'second', 'second!', 'first!'])
+    expect(entries).toHaveLength(2)
+    expect(entries[0]?.metadata?.callFrame?.frameId).not.toBe(
+      entries[1]?.metadata?.callFrame?.frameId
+    )
+    expect(returns.map((step) => step.metadata?.callFrame?.frameId)).toEqual([
+      entries[1]?.metadata?.callFrame?.frameId,
+      entries[0]?.metadata?.callFrame?.frameId,
+    ])
+  })
+
+  it('traces values delegated with yield*', () => {
+    const state = executeCode(
+      `function* values(): Generator<number, number, void> {
+  yield* [1, 2]
+  return 3
+}`,
+      {},
+      'values'
+    )
+    const yieldedValues = state.steps
+      .filter((step) => step.type === 'yield-suspend')
+      .map((step) => step.variables[YIELD_VALUE_LABEL])
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(3)
+    expect(yieldedValues).toEqual([1, 2])
+  })
+
+  it('keeps nested yield* frames and parent relationships separate', () => {
+    const state = executeCode(
+      `function* child(): Generator<number, string, void> {
+  yield 1
+  return 'child done'
+}
+
+function* parent(): Generator<number | string, string, void> {
+  const childResult = yield* child()
+  yield childResult
+  return 'parent done'
+}`,
+      {},
+      'parent'
+    )
+    const parentEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'parent'
+    )
+    const childEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'child'
+    )
+    const childFrameId = childEntry?.metadata?.callFrame?.frameId
+    const childSteps = state.steps.filter(
+      (step) => step.metadata?.callFrame?.frameId === childFrameId
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe('parent done')
+    expect(childEntry?.metadata?.callFrame?.parentFrameId).toBe(
+      parentEntry?.metadata?.callFrame?.frameId
+    )
+    expect(
+      childSteps.every(
+        (step) => step.metadata?.callFrame?.functionName === 'child'
+      )
+    ).toBe(true)
+    expect(
+      state.steps
+        .filter(
+          (step) =>
+            step.type === 'yield-suspend' &&
+            step.metadata?.callFrame?.functionName === 'parent'
+        )
+        .map((step) => step.variables[YIELD_VALUE_LABEL])
+    ).toEqual([1, 'child done'])
+  })
+
+  it('rewinds and resumes across a yield boundary', () => {
+    const state = executeCode(
+      `function* value(): Generator<number, void, void> {
+  yield 7
+}`,
+      {},
+      'value'
+    )
+    const resumeIndex = state.steps.findIndex(
+      (step) => step.type === 'yield-resume'
+    )
+    const atResume = { ...state, currentStep: resumeIndex }
+    const atSuspend = stepBackward(atResume)
+
+    expect(atSuspend.steps[atSuspend.currentStep]?.type).toBe('yield-suspend')
+    expect(
+      atSuspend.steps[atSuspend.currentStep]?.variables[YIELD_VALUE_LABEL]
+    ).toBe(7)
+    expect(stepForward(atSuspend).currentStep).toBe(resumeIndex)
+  })
+
+  it('reconstructs a suspended generator frame at a yield step', () => {
+    const state = executeCode(
+      `function* value(): Generator<number, void, void> {
+  const local = 7
+  yield local
+}`,
+      {},
+      'value'
+    )
+    const suspendIndex = state.steps.findIndex(
+      (step) => step.type === 'yield-suspend'
+    )
+    const inspector = getCallFrameInspectorState({
+      ...state,
+      currentStep: suspendIndex,
+    })
+    const frame = inspector.frames.find(
+      (candidate) => candidate.functionName === 'value'
+    )
+
+    expect(inspector.currentFrameId).toBeUndefined()
+    expect(frame).toEqual(
+      expect.objectContaining({
+        status: 'suspended',
+        visibleVariableNames: expect.arrayContaining(['local']),
+      })
+    )
+  })
+
+  it('drives a synchronous generator through the async execution path', async () => {
+    const state = await executeCodeAsync(
+      `function* answer(): Generator<number, number, void> {
+  yield 1
+  return 42
+}`,
+      {},
+      'answer'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(42)
+  })
+})

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -253,6 +253,55 @@ function run(): string[] {
     ).toBe('completed')
   })
 
+  it('reactivates a generator frame before return-driven cleanup', () => {
+    const state = executeCode(
+      `function cleanup(): void {
+  const completed = true
+}
+
+function* values(): Generator<number, void, void> {
+  try {
+    yield 1
+  } finally {
+    cleanup()
+  }
+}
+
+function run(): void {
+  const iterator = values()
+  iterator.next()
+  iterator.return()
+}`,
+      {},
+      'run'
+    )
+    const generatorEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'values'
+    )
+    const cleanupEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'cleanup'
+    )
+    const returnResumeIndex = state.steps.findIndex(
+      (step) =>
+        step.type === 'yield-resume' &&
+        step.description.startsWith('Generator resumed with return')
+    )
+    const cleanupIndex = state.steps.findIndex((step) => step === cleanupEntry)
+
+    expect(state.error).toBeUndefined()
+    expect(generatorEntry).toBeDefined()
+    expect(cleanupEntry).toBeDefined()
+    expect(returnResumeIndex).toBeGreaterThan(-1)
+    expect(cleanupIndex).toBeGreaterThan(returnResumeIndex)
+    expect(cleanupEntry?.metadata?.callFrame?.parentFrameId).toBe(
+      generatorEntry?.metadata?.callFrame?.frameId
+    )
+  })
+
   it('defers generator completion until a yielding finally finishes', () => {
     const state = executeCode(
       `function* values(): Generator<number, string, void> {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -6,6 +6,24 @@ import { executeCode, executeCodeAsync } from './runner'
 import { getCallFrameInspectorState } from '@/features/visualization/lib/call-frame-inspector'
 
 describe('runner - generator execution', () => {
+  it('preserves iterators returned by non-generator entries', async () => {
+    const code = `function values(): IterableIterator<number> {
+  return [1, 2].values()
+}`
+    const states = [
+      executeCode(code, {}, 'values'),
+      await executeCodeAsync(code, {}, 'values'),
+    ]
+
+    for (const state of states) {
+      expect(state.error).toBeUndefined()
+
+      const iterator = state.returnValue as Iterator<number>
+      expect(iterator.next()).toEqual({ value: 1, done: false })
+      expect(iterator.next()).toEqual({ value: 2, done: false })
+    }
+  })
+
   it('drives a generator entry through multiple yields and its final return', () => {
     const state = executeCode(
       `function* count(start: number): Generator<number, string, void> {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { YIELD_INPUT_LABEL, YIELD_VALUE_LABEL } from '@/entities/execution'
+import {
+  RETURN_VALUE_LABEL,
+  YIELD_INPUT_LABEL,
+  YIELD_VALUE_LABEL,
+} from '@/entities/execution'
 import { stepBackward, stepForward } from './execution-state'
 import { executeCode, executeCodeAsync } from './runner'
 import { getCallFrameInspectorState } from '@/features/visualization/lib/call-frame-inspector'
@@ -175,6 +179,92 @@ function run(): string[] {
     expect(
       afterClose.frames.find((frame) => frame.id === generatorFrameId)?.status
     ).toBe('completed')
+  })
+
+  it('defers generator completion until a yielding finally finishes', () => {
+    const state = executeCode(
+      `function* values(): Generator<number, string, void> {
+  try {
+    return 'original'
+  } finally {
+    yield 1
+  }
+}
+
+function run(): unknown[] {
+  const iterator = values()
+  const suspended = iterator.next()
+  const closed = iterator.return('replacement')
+  return [suspended.value, suspended.done, closed.value, closed.done]
+}`,
+      {},
+      'run'
+    )
+    const generatorEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'values'
+    )
+    const generatorFrameId = generatorEntry?.metadata?.callFrame?.frameId
+    const suspendIndex = state.steps.findIndex(
+      (step) =>
+        step.type === 'yield-suspend' &&
+        step.metadata?.callFrame?.frameId === generatorFrameId
+    )
+    const closeIndex = state.steps.findIndex(
+      (step) =>
+        step.type === 'generator-close' &&
+        step.metadata?.callFrame?.frameId === generatorFrameId
+    )
+    const generatorReturns = state.steps.filter(
+      (step) =>
+        step.type === 'return' &&
+        step.metadata?.callFrame?.frameId === generatorFrameId
+    )
+    const atSuspend = getCallFrameInspectorState({
+      ...state,
+      currentStep: suspendIndex,
+    })
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([1, false, 'replacement', true])
+    expect(generatorReturns).toEqual([])
+    expect(closeIndex).toBeGreaterThan(suspendIndex)
+    expect(
+      atSuspend.frames.find((frame) => frame.id === generatorFrameId)?.status
+    ).toBe('suspended')
+  })
+
+  it('records a pending return after a yielding finally resumes', () => {
+    const state = executeCode(
+      `function* values(): Generator<number, string, void> {
+  try {
+    return 'original'
+  } finally {
+    yield 1
+  }
+}`,
+      {},
+      'values'
+    )
+    const suspendIndex = state.steps.findIndex(
+      (step) => step.type === 'yield-suspend'
+    )
+    const returnIndex = state.steps.findIndex(
+      (step) =>
+        step.type === 'return' &&
+        step.metadata?.callFrame?.functionName === 'values'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe('original')
+    expect(returnIndex).toBeGreaterThan(suspendIndex)
+    expect(state.steps[returnIndex]?.variables[RETURN_VALUE_LABEL]).toBe(
+      'original'
+    )
+    expect(
+      state.steps.some((step) => step.type === 'generator-close')
+    ).toBe(false)
   })
 
   it('reactivates the same frame when iterator.throw is handled', () => {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -579,4 +579,32 @@ function* parent(): Generator<number | string, string, void> {
     expect(state.error).toBeUndefined()
     expect(state.returnValue).toBe(42)
   })
+
+  it('consumes a synchronous generator before awaiting inherited then', async () => {
+    const effects: string[] = []
+    const state = await executeCodeAsync(
+      `function* answer(effects: string[]): Generator<number, number, void> {
+  yield 1
+  return 42
+}
+
+Object.defineProperty(answer.prototype, 'then', {
+  value(resolve: (value: string) => void) {
+    effects.push('then')
+    resolve('assimilated')
+  },
+})`,
+      { effects },
+      'answer'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(42)
+    expect(effects).toEqual([])
+    expect(
+      state.steps
+        .filter((step) => step.type === 'yield-suspend')
+        .map((step) => step.variables[YIELD_VALUE_LABEL])
+    ).toEqual([1])
+  })
 })

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -465,6 +465,52 @@ function run(): unknown[] {
     expect(state.returnValue).toEqual(['type-error', []])
   })
 
+  it('caches the fallback delegated iterator return method', () => {
+    const state = executeCode(
+      `function* values(accesses: string[]): Generator<number, void, void> {
+  let returnAccesses = 0
+  const iterator = {
+    next() {
+      return { done: false, value: 1 }
+    },
+    [Symbol.iterator]() {
+      return this
+    },
+  }
+  Object.defineProperty(iterator, 'return', {
+    get() {
+      accesses.push('get')
+      returnAccesses += 1
+      if (returnAccesses > 1) throw new Error('second access')
+      return function () {
+        accesses.push('call')
+        return { done: true, value: undefined }
+      }
+    },
+  })
+  yield* (iterator as Iterable<number>)
+}
+
+function run(): unknown[] {
+  const accesses: string[] = []
+  const iterator = values(accesses)
+  iterator.next()
+  try {
+    iterator.throw(new Error('boom'))
+    return ['completed', accesses]
+  } catch (error) {
+    const result = error instanceof TypeError ? 'type-error' : 'other-error'
+    return [result, accesses]
+  }
+}`,
+      {},
+      'run'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual(['type-error', ['get', 'call']])
+  })
+
   it('keeps nested yield* frames and parent relationships separate', () => {
     const state = executeCode(
       `function* child(): Generator<number, string, void> {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -654,6 +654,77 @@ function run(): unknown[] {
     expect(state.returnValue).toEqual([1, '1:boom', '1:closed'])
   })
 
+  it('reactivates a delegated generator before reading its return method', () => {
+    const state = executeCode(
+      `function cleanup(value?: unknown): IteratorResult<number, unknown> {
+  return { done: true, value }
+}
+
+function* values(): Generator<number, unknown, void> {
+  const iterator = {
+    next() {
+      return { done: false, value: 1 }
+    },
+    [Symbol.iterator]() {
+      return this
+    },
+  }
+  Object.defineProperty(iterator, 'return', {
+    get() {
+      return cleanup
+    },
+  })
+  return yield* (iterator as Iterable<number>)
+}
+
+function run(): unknown[] {
+  const iterator = values()
+  const first = iterator.next()
+  const closed = iterator.return('closed')
+  return [first.value, closed.value]
+}`,
+      {},
+      'run'
+    )
+    const generatorEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'values'
+    )
+    const returnGetterEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'get'
+    )
+    const cleanupEntry = state.steps.find(
+      (step) =>
+        step.type === 'function-entry' &&
+        step.metadata?.callFrame?.functionName === 'cleanup'
+    )
+    const returnResumeIndex = state.steps.findIndex(
+      (step) =>
+        step.type === 'yield-resume' &&
+        step.description.startsWith('Delegated generator resumed with return')
+    )
+    const returnGetterIndex = state.steps.findIndex(
+      (step) => step === returnGetterEntry
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([1, 'closed'])
+    expect(generatorEntry).toBeDefined()
+    expect(returnGetterEntry).toBeDefined()
+    expect(cleanupEntry).toBeDefined()
+    expect(returnResumeIndex).toBeGreaterThan(-1)
+    expect(returnGetterIndex).toBeGreaterThan(returnResumeIndex)
+    expect(returnGetterEntry?.metadata?.callFrame?.parentFrameId).toBe(
+      generatorEntry?.metadata?.callFrame?.frameId
+    )
+    expect(cleanupEntry?.metadata?.callFrame?.parentFrameId).toBe(
+      generatorEntry?.metadata?.callFrame?.frameId
+    )
+  })
+
   it('reads delegated iterator-result accessors once', () => {
     const accesses: string[] = []
     const iterator: IterableIterator<string> = {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -426,6 +426,45 @@ function run(): string {
     expect(state.returnValue).toBe('type-error')
   })
 
+  it('rejects a non-callable delegated throw method without cleanup', () => {
+    const state = executeCode(
+      `function* values(effects: string[]): Generator<number, void, void> {
+  const iterator = {
+    next() {
+      return { done: false, value: 1 }
+    },
+    throw: 1,
+    return() {
+      effects.push('return')
+      return { done: true, value: undefined }
+    },
+    [Symbol.iterator]() {
+      return this
+    },
+  }
+  yield* (iterator as Iterable<number>)
+}
+
+function run(): unknown[] {
+  const effects: string[] = []
+  const iterator = values(effects)
+  iterator.next()
+  try {
+    iterator.throw(new Error('boom'))
+    return ['completed', effects]
+  } catch (error) {
+    const result = error instanceof TypeError ? 'type-error' : 'other-error'
+    return [result, effects]
+  }
+}`,
+      {},
+      'run'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual(['type-error', []])
+  })
+
   it('keeps nested yield* frames and parent relationships separate', () => {
     const state = executeCode(
       `function* child(): Generator<number, string, void> {

--- a/src/features/code-execution/lib/runner.generator.test.ts
+++ b/src/features/code-execution/lib/runner.generator.test.ts
@@ -257,6 +257,45 @@ function run(): unknown[] {
     expect(yieldedValues).toEqual([1, 2])
   })
 
+  it('calls a delegated iterator first with no argument', () => {
+    const state = executeCode(
+      `function* values(counts: number[]): Generator<string, string, string> {
+  const delegated = {
+    [Symbol.iterator](): Iterator<string, string, string> {
+      let started = false
+      return {
+        next(value?: string): IteratorResult<string, string> {
+          counts.push(arguments.length)
+          if (!started) {
+            started = true
+            return {
+              done: false,
+              value: arguments.length === 0 ? 'first' : 'unexpected',
+            }
+          }
+          return { done: true, value: value ?? 'missing' }
+        },
+      }
+    },
+  }
+  return yield* delegated
+}
+
+function run(): unknown[] {
+  const counts: number[] = []
+  const iterator = values(counts)
+  const first = iterator.next()
+  const second = iterator.next('resume')
+  return [counts, first.value, second.value]
+}`,
+      {},
+      'run'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([[0, 1], 'first', 'resume'])
+  })
+
   it('keeps nested yield* frames and parent relationships separate', () => {
     const state = executeCode(
       `function* child(): Generator<number, string, void> {

--- a/src/features/code-execution/lib/step-recorder.ts
+++ b/src/features/code-execution/lib/step-recorder.ts
@@ -101,7 +101,9 @@ function getCallFrameMetadata({
   if (!frame) return undefined
 
   const retainedVariableNames =
-    type === STEP_TYPES.FUNCTION_THROW && visibleVariableNames.length === 0
+    (type === STEP_TYPES.FUNCTION_THROW ||
+      type === STEP_TYPES.GENERATOR_CLOSE) &&
+    visibleVariableNames.length === 0
       ? frame.visibleVariableNames
       : visibleVariableNames
   if (visibleVariableNames.length > 0) {
@@ -117,7 +119,17 @@ function getCallFrameMetadata({
         ? 'return'
         : type === STEP_TYPES.FUNCTION_THROW
           ? 'throw'
-          : 'update',
+          : type === STEP_TYPES.GENERATOR_CLOSE
+            ? 'close'
+            : type === STEP_TYPES.AWAIT_SUSPEND ||
+                type === STEP_TYPES.YIELD_SUSPEND
+              ? 'suspend'
+              : type === STEP_TYPES.AWAIT_RESUME ||
+                  type === STEP_TYPES.AWAIT_REJECT ||
+                  type === STEP_TYPES.YIELD_RESUME ||
+                  type === STEP_TYPES.YIELD_THROW
+                ? 'resume'
+                : 'update',
     visibleVariableNames: retainedVariableNames,
   }
 }
@@ -132,7 +144,7 @@ function updateActiveFrame(
   const frame = context.frames.get(callFrame.frameId)
   if (!frame) return
 
-  if (type === STEP_TYPES.AWAIT_SUSPEND) {
+  if (type === STEP_TYPES.AWAIT_SUSPEND || type === STEP_TYPES.YIELD_SUSPEND) {
     frame.status = 'suspended'
     const parentFrame = isInteger(frame.parentFrameId)
       ? context.frames.get(frame.parentFrameId)
@@ -142,7 +154,11 @@ function updateActiveFrame(
     return
   }
 
-  if (type === STEP_TYPES.RETURN || type === STEP_TYPES.FUNCTION_THROW) {
+  if (
+    type === STEP_TYPES.RETURN ||
+    type === STEP_TYPES.FUNCTION_THROW ||
+    type === STEP_TYPES.GENERATOR_CLOSE
+  ) {
     frame.status = 'completed'
     const parentFrame = isInteger(frame.parentFrameId)
       ? context.frames.get(frame.parentFrameId)
@@ -257,8 +273,13 @@ export function recordExecutionStep(
   const variableDelta = deepClone(variablesForStep)
 
   updateActiveFrame(context, type, callFrame)
+  if (callFrame) {
+    callFrame.activeFrameIdAfterStep = context.activeFrameId
+  }
   const callStackFrameId =
-    type === STEP_TYPES.RETURN || type === STEP_TYPES.FUNCTION_THROW
+    type === STEP_TYPES.RETURN ||
+    type === STEP_TYPES.FUNCTION_THROW ||
+    type === STEP_TYPES.GENERATOR_CLOSE
       ? callFrame?.parentFrameId
       : (callFrame?.frameId ?? context.activeFrameId)
 

--- a/src/features/code-execution/lib/typescript-runner.ts
+++ b/src/features/code-execution/lib/typescript-runner.ts
@@ -200,12 +200,11 @@ export async function* createAsyncTypeScriptExecutionRunner(
 
     try {
       const invocationResult = func(...Object.values(inputs), recordStep)
-      const awaitedResult = await invocationResult
       result =
         preparedExecution.shouldConsumeGenerator &&
-        isSyncGeneratorIterator(awaitedResult)
-        ? consumeGenerator(awaitedResult)
-        : awaitedResult
+        isSyncGeneratorIterator(invocationResult)
+          ? consumeGenerator(invocationResult)
+          : await invocationResult
     } catch (err) {
       if (isStepLimitError(err)) {
         stepLimitReached = true

--- a/src/features/code-execution/lib/typescript-runner.ts
+++ b/src/features/code-execution/lib/typescript-runner.ts
@@ -12,6 +12,7 @@ import { isError, isInstanceOf } from '@/shared/lib/guards'
 import { safeStringify } from '@/shared/lib/safe-stringify'
 
 import { instrumentCode } from './instrumenter'
+import { attachInstrumentationIntrinsics } from './instrumentation/intrinsics'
 import {
   getStepLimitMessage,
   MAX_STEPS,
@@ -106,6 +107,7 @@ export function* createTypeScriptExecutionRunner(
     stepVariables: Record<string, unknown>
   ): ExecutionStep =>
     recordExecutionStep(context, type, line, description, stepVariables)
+  attachInstrumentationIntrinsics(recordStep)
 
   try {
     yield recordStep(
@@ -180,6 +182,7 @@ export async function* createAsyncTypeScriptExecutionRunner(
     stepVariables: Record<string, unknown>
   ): ExecutionStep =>
     recordExecutionStep(context, type, line, description, stepVariables)
+  attachInstrumentationIntrinsics(recordStep)
 
   try {
     yield recordStep(

--- a/src/features/code-execution/lib/typescript-runner.ts
+++ b/src/features/code-execution/lib/typescript-runner.ts
@@ -24,12 +24,14 @@ import {
 } from './execution-wrapper'
 import {
   consumeGenerator,
+  isSyncGeneratorEntry,
   isSyncGeneratorIterator,
 } from './generator-execution'
 
 type PreparedExecution = {
   wrapperCode: string
   inputNames: string[]
+  shouldConsumeGenerator: boolean
 }
 
 const isStepLimitError = isInstanceOf(
@@ -64,6 +66,9 @@ function prepareExecution(
       entryFunctionName
     ),
     inputNames: Object.keys(inputs),
+    shouldConsumeGenerator: entryFunctionName
+      ? isSyncGeneratorEntry(code, entryFunctionName)
+      : false,
   }
 }
 
@@ -121,7 +126,9 @@ export function* createTypeScriptExecutionRunner(
 
     try {
       const invocationResult = func(...Object.values(inputs), recordStep)
-      result = isSyncGeneratorIterator(invocationResult)
+      result =
+        preparedExecution.shouldConsumeGenerator &&
+        isSyncGeneratorIterator(invocationResult)
         ? consumeGenerator(invocationResult)
         : invocationResult
     } catch (err) {
@@ -194,7 +201,9 @@ export async function* createAsyncTypeScriptExecutionRunner(
     try {
       const invocationResult = func(...Object.values(inputs), recordStep)
       const awaitedResult = await invocationResult
-      result = isSyncGeneratorIterator(awaitedResult)
+      result =
+        preparedExecution.shouldConsumeGenerator &&
+        isSyncGeneratorIterator(awaitedResult)
         ? consumeGenerator(awaitedResult)
         : awaitedResult
     } catch (err) {

--- a/src/features/code-execution/lib/typescript-runner.ts
+++ b/src/features/code-execution/lib/typescript-runner.ts
@@ -22,6 +22,10 @@ import {
   buildExecutionWrapperCode,
   createExecutionFunction,
 } from './execution-wrapper'
+import {
+  consumeGenerator,
+  isSyncGeneratorIterator,
+} from './generator-execution'
 
 type PreparedExecution = {
   wrapperCode: string
@@ -116,7 +120,10 @@ export function* createTypeScriptExecutionRunner(
     let stepLimitReached = false
 
     try {
-      result = func(...Object.values(inputs), recordStep)
+      const invocationResult = func(...Object.values(inputs), recordStep)
+      result = isSyncGeneratorIterator(invocationResult)
+        ? consumeGenerator(invocationResult)
+        : invocationResult
     } catch (err) {
       if (isStepLimitError(err)) {
         stepLimitReached = true
@@ -185,7 +192,11 @@ export async function* createAsyncTypeScriptExecutionRunner(
     let stepLimitReached = false
 
     try {
-      result = await func(...Object.values(inputs), recordStep)
+      const invocationResult = func(...Object.values(inputs), recordStep)
+      const awaitedResult = await invocationResult
+      result = isSyncGeneratorIterator(awaitedResult)
+        ? consumeGenerator(awaitedResult)
+        : awaitedResult
     } catch (err) {
       if (isStepLimitError(err)) {
         stepLimitReached = true

--- a/src/features/visualization/lib/call-frame-inspector.ts
+++ b/src/features/visualization/lib/call-frame-inspector.ts
@@ -2,6 +2,8 @@ import {
   FUNCTION_ARGUMENTS_LABEL,
   RETURN_LOCATION_LABEL,
   RETURN_VALUE_LABEL,
+  YIELD_INPUT_LABEL,
+  YIELD_VALUE_LABEL,
   type ExecutionState,
 } from '@/entities/execution'
 import { isNonArrayObject, isUndefined } from '@/shared/lib/guards'
@@ -11,6 +13,7 @@ export type CallFrameStatus =
   | 'suspended'
   | 'returning'
   | 'throwing'
+  | 'closing'
   | 'completed'
 
 export type InspectedCallFrame = {
@@ -35,7 +38,7 @@ export type InspectedCallFrame = {
   /** Whether a successful return event has been recorded. */
   hasReturnValue: boolean
   /** How this invocation completed, when it has finished. */
-  completionPhase?: 'return' | 'throw'
+  completionPhase?: 'return' | 'throw' | 'close'
 }
 
 export type CallFrameDetails = {
@@ -71,6 +74,8 @@ const SPECIAL_VARIABLE_NAMES = new Set([
   FUNCTION_ARGUMENTS_LABEL,
   RETURN_LOCATION_LABEL,
   RETURN_VALUE_LABEL,
+  YIELD_INPUT_LABEL,
+  YIELD_VALUE_LABEL,
 ])
 
 function getCallFrameStatus({
@@ -82,12 +87,14 @@ function getCallFrameStatus({
 }: {
   frameId: number
   terminalFrameId?: number
-  terminalPhase?: 'return' | 'throw'
+  terminalPhase?: 'return' | 'throw' | 'close'
   currentFrameId?: number
   activeFrameIds: number[]
 }): CallFrameStatus {
   if (frameId === terminalFrameId) {
-    return terminalPhase === 'throw' ? 'throwing' : 'returning'
+    if (terminalPhase === 'throw') return 'throwing'
+    if (terminalPhase === 'close') return 'closing'
+    return 'returning'
   }
   if (frameId === currentFrameId) return 'current'
   if (activeFrameIds.includes(frameId)) return 'suspended'
@@ -228,12 +235,16 @@ export function getCallFrameInspectorState(
 
     const frame = frames.get(callFrame.frameId)
     if (!frame) continue
-    if (callFrame.phase !== 'throw') {
+    if (callFrame.phase !== 'throw' && callFrame.phase !== 'close') {
       frame.lastObservedStepIndex = stepIndex
       frame.visibleVariableNames = callFrame.visibleVariableNames
     }
 
-    if (callFrame.phase === 'return' || callFrame.phase === 'throw') {
+    if (
+      callFrame.phase === 'return' ||
+      callFrame.phase === 'throw' ||
+      callFrame.phase === 'close'
+    ) {
       frame.endStepIndex = stepIndex
       frame.completionPhase = callFrame.phase
       const activeIndex = activeFrameIds.lastIndexOf(callFrame.frameId)
@@ -245,12 +256,18 @@ export function getCallFrameInspectorState(
     executionState.steps[lastStepIndex]?.metadata?.callFrame
   const terminalPhase =
     selectedCallFrame?.phase === 'return' ||
-    selectedCallFrame?.phase === 'throw'
+    selectedCallFrame?.phase === 'throw' ||
+    selectedCallFrame?.phase === 'close'
       ? selectedCallFrame.phase
       : undefined
   const terminalFrameId = terminalPhase ? selectedCallFrame?.frameId : undefined
-  const currentFrameId =
-    selectedCallFrame?.frameId ?? activeFrameIds[activeFrameIds.length - 1]
+  const currentFrameId = terminalFrameId
+    ? terminalFrameId
+    : selectedCallFrame?.phase === 'suspend'
+      ? selectedCallFrame.activeFrameIdAfterStep
+      : (selectedCallFrame?.activeFrameIdAfterStep ??
+        selectedCallFrame?.frameId ??
+        activeFrameIds[activeFrameIds.length - 1])
 
   return {
     activeFrameIds,

--- a/src/features/visualization/ui/call-frame-inspector.tsx
+++ b/src/features/visualization/ui/call-frame-inspector.tsx
@@ -21,6 +21,7 @@ const STATUS_LABELS: Record<CallFrameStatus, string> = {
   suspended: 'Suspended',
   returning: 'Returning',
   throwing: 'Throwing',
+  closing: 'Closing',
   completed: 'Completed',
 }
 
@@ -36,7 +37,8 @@ function FrameButton({
   const isExecuting =
     frame.status === 'current' ||
     frame.status === 'returning' ||
-    frame.status === 'throwing'
+    frame.status === 'throwing' ||
+    frame.status === 'closing'
 
   return (
     <button
@@ -167,7 +169,8 @@ export function CallFrameInspector({
       (frame) =>
         activeFrameIds.has(frame.id) ||
         frame.status === 'returning' ||
-        frame.status === 'throwing'
+        frame.status === 'throwing' ||
+        frame.status === 'closing'
     )
     .sort((left, right) => {
       if (left.id === inspectorState.currentFrameId) return -1


### PR DESCRIPTION
Closes #48

## Summary
Adds first class synchronous generator execution tracing.

<!-- A brief summary of the changes -->

## Description

- Records generator suspension and resumption across `yield` and `yield*`
- Preserves call frames and local variables while generators are suspended
- Supports `next(value)`, `throw()`, `return()`, nested generators, and final return values
- Keeps frame state consistent when navigating backward and forward
- Fixes Monaco diagnostics conflicting with DOM global names such as `parent`


<!-- A detailed explanation of the changes, including why they are needed -->
