### PR TITLE
fix: suppress unused entry function warnings

### DIFF
--- a/src/features/code-editing/lib/monaco-editor-helpers.test.ts
+++ b/src/features/code-editing/lib/monaco-editor-helpers.test.ts
@@ -316,6 +316,54 @@ function helper(): void {
     expect(onValidate).toHaveBeenCalledWith([])
   })
 
+  it('ignores unused hints for every entry function overload', () => {
+    const model = {
+      uri: 'file:///source.ts',
+      getValue: () => `function solve(value: number): number;
+function solve(value: string): string;
+function solve(value: number | string): number | string {
+  return value
+}
+
+function helper(): void {}`,
+    }
+    const { editor } = createEditorWithModel(model)
+    const monaco = createMonacoMock()
+    const onValidate = vi.fn()
+
+    monaco.editor.getModelMarkers.mockReturnValue([
+      ...[1, 2, 3].map((line) => ({
+        startLineNumber: line,
+        startColumn: 10,
+        message: "'solve' is declared but its value is never read.",
+        severity: monaco.MarkerSeverity.Hint,
+        code: '6133',
+      })),
+      {
+        startLineNumber: 7,
+        startColumn: 10,
+        message: "'helper' is declared but its value is never read.",
+        severity: monaco.MarkerSeverity.Hint,
+        code: '6133',
+      },
+    ])
+    monaco.editor.onDidChangeMarkers.mockReturnValue({ dispose: vi.fn() })
+
+    subscribeToValidationMarkers(editor, monaco.api, {
+      current: onValidate,
+    })
+    getMarkerChangeHandler(monaco)()
+
+    expect(onValidate).toHaveBeenCalledWith([
+      {
+        line: 7,
+        column: 10,
+        message: "'helper' is declared but its value is never read.",
+        severity: 'warning',
+      },
+    ])
+  })
+
   it('does not map validation markers without a model or callback', () => {
     const monaco = createMonacoMock()
     monaco.editor.onDidChangeMarkers.mockReturnValue({ dispose: vi.fn() })

--- a/src/features/code-editing/lib/monaco-editor-helpers.test.ts
+++ b/src/features/code-editing/lib/monaco-editor-helpers.test.ts
@@ -287,6 +287,35 @@ function helper(): void {
     ])
   })
 
+  it('ignores an unused arrow function entry hint', () => {
+    const model = {
+      uri: 'file:///source.ts',
+      getValue: () =>
+        'const canVisit = (value: number): boolean => value > 0',
+    }
+    const { editor } = createEditorWithModel(model)
+    const monaco = createMonacoMock()
+    const onValidate = vi.fn()
+
+    monaco.editor.getModelMarkers.mockReturnValue([
+      {
+        startLineNumber: 1,
+        startColumn: 7,
+        message: "'canVisit' is declared but its value is never read.",
+        severity: monaco.MarkerSeverity.Hint,
+        code: '6133',
+      },
+    ])
+    monaco.editor.onDidChangeMarkers.mockReturnValue({ dispose: vi.fn() })
+
+    subscribeToValidationMarkers(editor, monaco.api, {
+      current: onValidate,
+    })
+    getMarkerChangeHandler(monaco)()
+
+    expect(onValidate).toHaveBeenCalledWith([])
+  })
+
   it('does not map validation markers without a model or callback', () => {
     const monaco = createMonacoMock()
     monaco.editor.onDidChangeMarkers.mockReturnValue({ dispose: vi.fn() })

--- a/src/features/code-editing/lib/monaco-editor-helpers.test.ts
+++ b/src/features/code-editing/lib/monaco-editor-helpers.test.ts
@@ -46,6 +46,7 @@ const createMonacoMock = () => {
     MarkerSeverity: {
       Error: 8,
       Warning: 4,
+      Hint: 1,
     },
     Range,
     editor: {
@@ -191,8 +192,13 @@ describe('monaco editor helpers', () => {
     ])
   })
 
-  it('subscribes to validation markers and maps them to compilation errors', () => {
-    const model = { uri: 'file:///source.ts' }
+  it('ignores unused top-level function hints but keeps unused locals', () => {
+    const model = {
+      uri: 'file:///source.ts',
+      getValue: () => `function trap(): void {
+  const unused = 1
+}`,
+    }
     const { editor } = createEditorWithModel(model)
     const monaco = createMonacoMock()
     const onValidate = vi.fn()
@@ -210,6 +216,20 @@ describe('monaco editor helpers', () => {
         startColumn: 2,
         message: 'Suspicious value',
         severity: monaco.MarkerSeverity.Warning,
+      },
+      {
+        startLineNumber: 1,
+        startColumn: 10,
+        message: "'trap' is declared but its value is never read.",
+        severity: monaco.MarkerSeverity.Hint,
+        code: '6133',
+      },
+      {
+        startLineNumber: 2,
+        startColumn: 9,
+        message: "'unused' is declared but its value is never read.",
+        severity: monaco.MarkerSeverity.Hint,
+        code: '6133',
       },
     ])
     monaco.editor.onDidChangeMarkers.mockReturnValue(disposable)
@@ -240,6 +260,12 @@ describe('monaco editor helpers', () => {
         line: 9,
         column: 2,
         message: 'Suspicious value',
+        severity: 'warning',
+      },
+      {
+        line: 2,
+        column: 9,
+        message: "'unused' is declared but its value is never read.",
         severity: 'warning',
       },
     ])

--- a/src/features/code-editing/lib/monaco-editor-helpers.test.ts
+++ b/src/features/code-editing/lib/monaco-editor-helpers.test.ts
@@ -192,11 +192,14 @@ describe('monaco editor helpers', () => {
     ])
   })
 
-  it('ignores unused top-level function hints but keeps unused locals', () => {
+  it('ignores the entry function hint but keeps unused helpers and locals', () => {
     const model = {
       uri: 'file:///source.ts',
-      getValue: () => `function trap(): void {
+      getValue: () => `function solve(): void {
   const unused = 1
+}
+
+function helper(): void {
 }`,
     }
     const { editor } = createEditorWithModel(model)
@@ -220,7 +223,7 @@ describe('monaco editor helpers', () => {
       {
         startLineNumber: 1,
         startColumn: 10,
-        message: "'trap' is declared but its value is never read.",
+        message: "'solve' is declared but its value is never read.",
         severity: monaco.MarkerSeverity.Hint,
         code: '6133',
       },
@@ -228,6 +231,13 @@ describe('monaco editor helpers', () => {
         startLineNumber: 2,
         startColumn: 9,
         message: "'unused' is declared but its value is never read.",
+        severity: monaco.MarkerSeverity.Hint,
+        code: '6133',
+      },
+      {
+        startLineNumber: 5,
+        startColumn: 10,
+        message: "'helper' is declared but its value is never read.",
         severity: monaco.MarkerSeverity.Hint,
         code: '6133',
       },
@@ -266,6 +276,12 @@ describe('monaco editor helpers', () => {
         line: 2,
         column: 9,
         message: "'unused' is declared but its value is never read.",
+        severity: 'warning',
+      },
+      {
+        line: 5,
+        column: 10,
+        message: "'helper' is declared but its value is never read.",
         severity: 'warning',
       },
     ])

--- a/src/features/code-editing/lib/monaco-editor-helpers.ts
+++ b/src/features/code-editing/lib/monaco-editor-helpers.ts
@@ -1,5 +1,6 @@
 import type { Monaco, OnMount } from '@monaco-editor/react'
 import { parse } from '@babel/parser'
+import type { Node } from '@babel/types'
 import type { CompilationError } from '@/entities/code'
 import { getPreparedTypeScriptEditorClassSource } from '@/entities/code/compiler'
 import { define, equals, isObject } from '@/shared/lib/guards'
@@ -57,6 +58,30 @@ const mapMarkerToCompilationError = (
 const getPositionKey = (line: number, column: number): string =>
   `${line}:${column}`
 
+const getEntryIdentifier = (
+  declaration: Node,
+  entryFunctionName: string
+) => {
+  if (
+    declaration.type === 'FunctionDeclaration' &&
+    declaration.id?.name === entryFunctionName
+  ) {
+    return declaration.id
+  }
+
+  if (declaration.type !== 'VariableDeclaration') {
+    return undefined
+  }
+
+  return declaration.declarations.find(
+    (declarator) =>
+      declarator.id.type === 'Identifier' &&
+      declarator.id.name === entryFunctionName &&
+      (declarator.init?.type === 'ArrowFunctionExpression' ||
+        declarator.init?.type === 'FunctionExpression')
+  )?.id
+}
+
 const getEntryFunctionNamePositions = (code: string): ReadonlySet<string> => {
   const positions = new Set<string>()
 
@@ -77,19 +102,18 @@ const getEntryFunctionNamePositions = (code: string): ReadonlySet<string> => {
         node.type === 'ExportDefaultDeclaration'
           ? node.declaration
           : node
+      const entryIdentifier = declaration
+        ? getEntryIdentifier(declaration, entryFunctionName)
+        : undefined
 
-      if (
-        declaration?.type !== 'FunctionDeclaration' ||
-        declaration.id?.name !== entryFunctionName ||
-        !declaration.id?.loc
-      ) {
+      if (!entryIdentifier?.loc) {
         continue
       }
 
       positions.add(
         getPositionKey(
-          declaration.id.loc.start.line,
-          declaration.id.loc.start.column + 1
+          entryIdentifier.loc.start.line,
+          entryIdentifier.loc.start.column + 1
         )
       )
       break
@@ -101,7 +125,7 @@ const getEntryFunctionNamePositions = (code: string): ReadonlySet<string> => {
   return positions
 }
 
-const isUnusedTopLevelFunctionHint = (
+const isUnusedEntryFunctionHint = (
   marker: MonacoMarker,
   monaco: Monaco,
   functionNamePositions: ReadonlySet<string>
@@ -181,7 +205,7 @@ export const subscribeToValidationMarkers = (
       markers
         .filter(
           (marker: MonacoMarker) =>
-            !isUnusedTopLevelFunctionHint(
+            !isUnusedEntryFunctionHint(
               marker,
               monaco,
               functionNamePositions

--- a/src/features/code-editing/lib/monaco-editor-helpers.ts
+++ b/src/features/code-editing/lib/monaco-editor-helpers.ts
@@ -3,6 +3,7 @@ import { parse } from '@babel/parser'
 import type { CompilationError } from '@/entities/code'
 import { getPreparedTypeScriptEditorClassSource } from '@/entities/code/compiler'
 import { define, equals, isObject } from '@/shared/lib/guards'
+import { extractTypeScriptFunctionSignature } from './typescript-parser'
 
 export type MonacoEditor = Parameters<OnMount>[0]
 export type MonacoHandle = {
@@ -56,7 +57,7 @@ const mapMarkerToCompilationError = (
 const getPositionKey = (line: number, column: number): string =>
   `${line}:${column}`
 
-const getTopLevelFunctionNamePositions = (code: string): ReadonlySet<string> => {
+const getEntryFunctionNamePositions = (code: string): ReadonlySet<string> => {
   const positions = new Set<string>()
 
   try {
@@ -64,6 +65,11 @@ const getTopLevelFunctionNamePositions = (code: string): ReadonlySet<string> => 
       sourceType: 'module',
       plugins: ['typescript'],
     })
+    const entryFunctionName = extractTypeScriptFunctionSignature(code)?.name
+
+    if (!entryFunctionName) {
+      return positions
+    }
 
     for (const node of ast.program.body) {
       const declaration =
@@ -74,6 +80,7 @@ const getTopLevelFunctionNamePositions = (code: string): ReadonlySet<string> => 
 
       if (
         declaration?.type !== 'FunctionDeclaration' ||
+        declaration.id?.name !== entryFunctionName ||
         !declaration.id?.loc
       ) {
         continue
@@ -85,6 +92,7 @@ const getTopLevelFunctionNamePositions = (code: string): ReadonlySet<string> => 
           declaration.id.loc.start.column + 1
         )
       )
+      break
     }
   } catch {
     return positions
@@ -166,7 +174,7 @@ export const subscribeToValidationMarkers = (
     const markers = monaco.editor.getModelMarkers({
       resource: model.uri,
     })
-    const functionNamePositions = getTopLevelFunctionNamePositions(
+    const functionNamePositions = getEntryFunctionNamePositions(
       model.getValue()
     )
     onValidateRef.current(

--- a/src/features/code-editing/lib/monaco-editor-helpers.ts
+++ b/src/features/code-editing/lib/monaco-editor-helpers.ts
@@ -63,7 +63,8 @@ const getEntryIdentifier = (
   entryFunctionName: string
 ) => {
   if (
-    declaration.type === 'FunctionDeclaration' &&
+    (declaration.type === 'FunctionDeclaration' ||
+      declaration.type === 'TSDeclareFunction') &&
     declaration.id?.name === entryFunctionName
   ) {
     return declaration.id
@@ -116,7 +117,6 @@ const getEntryFunctionNamePositions = (code: string): ReadonlySet<string> => {
           entryIdentifier.loc.start.column + 1
         )
       )
-      break
     }
   } catch {
     return positions

--- a/src/features/code-editing/lib/monaco-editor-helpers.ts
+++ b/src/features/code-editing/lib/monaco-editor-helpers.ts
@@ -1,4 +1,5 @@
 import type { Monaco, OnMount } from '@monaco-editor/react'
+import { parse } from '@babel/parser'
 import type { CompilationError } from '@/entities/code'
 import { getPreparedTypeScriptEditorClassSource } from '@/entities/code/compiler'
 import { define, equals, isObject } from '@/shared/lib/guards'
@@ -20,6 +21,7 @@ const PREPARED_CLASSES_LIB_PATH = 'ts:algorithm-visualizer-prepared-classes.ts'
 const EXTERNAL_MARKER_OWNER = 'owner'
 const DEFAULT_EDITOR_FONT_SIZE = 14
 const DEFAULT_EXTERNAL_MARKER_WIDTH = 10
+const UNUSED_DECLARATION_DIAGNOSTIC_CODE = '6133'
 
 export const DEFAULT_EDITOR_OPTIONS = {
   minimap: { enabled: false },
@@ -50,6 +52,57 @@ const mapMarkerToCompilationError = (
   severity:
     marker.severity === monaco.MarkerSeverity.Error ? 'error' : 'warning',
 })
+
+const getPositionKey = (line: number, column: number): string =>
+  `${line}:${column}`
+
+const getTopLevelFunctionNamePositions = (code: string): ReadonlySet<string> => {
+  const positions = new Set<string>()
+
+  try {
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['typescript'],
+    })
+
+    for (const node of ast.program.body) {
+      const declaration =
+        node.type === 'ExportNamedDeclaration' ||
+        node.type === 'ExportDefaultDeclaration'
+          ? node.declaration
+          : node
+
+      if (
+        declaration?.type !== 'FunctionDeclaration' ||
+        !declaration.id?.loc
+      ) {
+        continue
+      }
+
+      positions.add(
+        getPositionKey(
+          declaration.id.loc.start.line,
+          declaration.id.loc.start.column + 1
+        )
+      )
+    }
+  } catch {
+    return positions
+  }
+
+  return positions
+}
+
+const isUnusedTopLevelFunctionHint = (
+  marker: MonacoMarker,
+  monaco: Monaco,
+  functionNamePositions: ReadonlySet<string>
+): boolean =>
+  marker.severity === monaco.MarkerSeverity.Hint &&
+  marker.code === UNUSED_DECLARATION_DIAGNOSTIC_CODE &&
+  functionNamePositions.has(
+    getPositionKey(marker.startLineNumber, marker.startColumn)
+  )
 
 const setPreparedClassesLibContent = (
   monaco: Monaco,
@@ -113,10 +166,22 @@ export const subscribeToValidationMarkers = (
     const markers = monaco.editor.getModelMarkers({
       resource: model.uri,
     })
+    const functionNamePositions = getTopLevelFunctionNamePositions(
+      model.getValue()
+    )
     onValidateRef.current(
-      markers.map((marker: MonacoMarker) =>
-        mapMarkerToCompilationError(marker, monaco)
-      )
+      markers
+        .filter(
+          (marker: MonacoMarker) =>
+            !isUnusedTopLevelFunctionHint(
+              marker,
+              monaco,
+              functionNamePositions
+            )
+        )
+        .map((marker: MonacoMarker) =>
+          mapMarkerToCompilationError(marker, monaco)
+        )
     )
   })
 


### PR DESCRIPTION
## Summary

Suppress unused entry function warnings.

<!-- A brief summary of the changes -->

## Description

- Ignore unused declaration hints for top-level function declarations used as execution entries
- Preserve unused variable warnings inside functions
- Add regression coverage for both cases

<!-- A detailed explanation of the changes, including why they are needed -->
