### PR TITLE
feat: improve mobile visualization modal

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -92,20 +92,51 @@ test('loads, compiles, runs a demo, and opens core dialogs', async ({
   await executionWorkerStarted
   await expect(page.getByText('All execution steps')).toBeVisible()
 
+  const visualizationDialog = page
+    .getByRole('dialog')
+    .filter({ has: page.getByRole('heading', { name: 'Bar Chart: nums' }) })
+  const openDialog = page.getByRole('dialog')
+  await expect(openDialog).toBeVisible()
+
+  if (isMobile) {
+    const viewport = page.viewportSize()
+    const dialogBox = await openDialog.boundingBox()
+    const playbackBox = await openDialog
+      .getByRole('group', {
+        name: 'Visualization playback controls',
+      })
+      .boundingBox()
+
+    expect(viewport).not.toBeNull()
+    expect(dialogBox).not.toBeNull()
+    expect(playbackBox).not.toBeNull()
+    expect(dialogBox?.x).toBeCloseTo(4, 0)
+    expect(dialogBox?.y).toBeCloseTo(8, 0)
+    expect(dialogBox?.width).toBeCloseTo((viewport?.width ?? 0) - 8, 0)
+    expect(dialogBox?.height).toBeCloseTo((viewport?.height ?? 0) - 16, 0)
+    expect(playbackBox?.x).toBeGreaterThan(dialogBox?.x ?? 0)
+    expect((playbackBox?.x ?? 0) + (playbackBox?.width ?? 0)).toBeLessThan(
+      (dialogBox?.x ?? 0) + (dialogBox?.width ?? 0)
+    )
+    expect((playbackBox?.y ?? 0) + (playbackBox?.height ?? 0)).toBeLessThan(
+      (dialogBox?.y ?? 0) + (dialogBox?.height ?? 0)
+    )
+    await expect(
+      openDialog.getByRole('group', {
+        name: 'Visualization playback controls',
+      })
+    ).toBeVisible()
+  }
+
+  await openDialog.getByRole('button', { name: 'Close' }).click()
+  await expect(openDialog).toBeHidden()
+
   if (isMobile) {
     await expect(page.getByRole('button', { name: 'Runtime' })).toHaveClass(
       /bg-primary/
     )
   }
 
-  const visualizationDialog = page
-    .getByRole('dialog')
-    .filter({ has: page.getByRole('heading', { name: 'Bar Chart: nums' }) })
-  const openDialog = page.getByRole('dialog')
-  if (await openDialog.isVisible()) {
-    await openDialog.getByRole('button', { name: 'Close' }).click()
-    await expect(openDialog).toBeHidden()
-  }
   await page.getByTitle('Visualize as bar chart').click()
   await expect(visualizationDialog).toBeVisible()
   await visualizationDialog.getByRole('button', { name: 'Close' }).click()
@@ -122,10 +153,7 @@ test('loads, compiles, runs a demo, and opens core dialogs', async ({
   }
 })
 
-test('visualizes Product Except Self answer growth', async ({
-  page,
-  isMobile,
-}) => {
+test('visualizes Product Except Self answer growth', async ({ page }) => {
   await page.goto('/')
 
   await page.getByRole('combobox', { name: 'Example' }).click()
@@ -147,21 +175,14 @@ test('visualizes Product Except Self answer growth', async ({
     page.getByText('Worker returned an invalid response.')
   ).toHaveCount(0)
 
+  const stackDialog = page.getByRole('dialog').filter({
+    has: page.getByRole('heading', { name: 'Stack Visualization: answer' }),
+  })
   await page.getByTitle('Skip to End').first().click()
-  if (isMobile) {
-    const answerRow = page.getByText('answer', { exact: true }).locator('../..')
-    await answerRow.getByTitle('Visualize as stack').click()
-  }
-
-  await expect(
-    page.getByRole('heading', { name: 'Stack Visualization: answer' })
-  ).toBeVisible()
+  await expect(stackDialog).toBeVisible()
 })
 
-test('visualizes trapped rain water between height bars', async ({
-  page,
-  isMobile,
-}) => {
+test('visualizes trapped rain water between height bars', async ({ page }) => {
   await page.goto('/')
 
   await page.getByRole('combobox', { name: 'Example' }).click()
@@ -177,13 +198,9 @@ test('visualizes trapped rain water between height bars', async ({
   const areaDialog = page
     .getByRole('dialog')
     .filter({ has: page.getByRole('heading', { name: 'Area View: height' }) })
-  if (isMobile) {
-    await page.getByTitle('Skip to End').first().click()
-    await page.getByRole('button', { name: 'Area View' }).click()
-  } else {
-    await areaDialog.getByTitle('Skip to End').click()
-    await expect(areaDialog.getByTitle('Skip to End')).toBeDisabled()
-  }
+  await expect(areaDialog).toBeVisible()
+  await areaDialog.getByTitle('Skip to End').click()
+  await expect(areaDialog.getByTitle('Skip to End')).toBeDisabled()
 
   await expect(
     page.getByRole('heading', { name: 'Area View: height' })
@@ -194,7 +211,6 @@ test('visualizes trapped rain water between height bars', async ({
 
 test('tracks maximum-subarray state at each array position', async ({
   page,
-  isMobile,
 }) => {
   await page.goto('/')
 
@@ -213,14 +229,8 @@ test('tracks maximum-subarray state at each array position', async ({
       name: 'Maximum Subarray View: nums',
     }),
   })
-  if (isMobile) {
-    await page.getByTitle('Skip to End').first().click()
-    await page.getByRole('button', { name: 'Max Subarray View' }).click()
-  } else {
-    await maxSubarrayDialog.getByTitle('Skip to End').click()
-  }
-
   await expect(maxSubarrayDialog).toBeVisible()
+  await maxSubarrayDialog.getByTitle('Skip to End').click()
   await expect(maxSubarrayDialog.getByText('Best ending here')).toBeVisible()
   await expect(maxSubarrayDialog.getByText('Best so far')).toBeVisible()
   await expect(
@@ -262,14 +272,10 @@ test('visualizes array and rolling DP examples', async ({ page, isMobile }) => {
         name: `DP View: ${example.variable}`,
       }),
     })
-    if (isMobile) {
-      await page.getByTitle('Skip to End').first().click()
-      await page.getByRole('button', { name: 'DP View' }).click()
-    } else if (await dpDialog.isVisible()) {
+    if (await dpDialog.isVisible()) {
       await dpDialog.getByTitle('Skip to End').click()
     } else {
       await page.getByTitle('Skip to End').first().click()
-      await expect(dpDialog).toBeVisible()
     }
 
     await expect(dpDialog).toBeVisible()
@@ -297,7 +303,7 @@ test('visualizes array and rolling DP examples', async ({ page, isMobile }) => {
   }
 })
 
-test('visualizes semantic Map updates', async ({ page, isMobile }) => {
+test('visualizes semantic Map updates', async ({ page }) => {
   const examples = [
     { label: 'Two Sum', map: 'seen', table: 'seen: lookup table' },
     {
@@ -323,10 +329,7 @@ test('visualizes semantic Map updates', async ({ page, isMobile }) => {
         name: `Map View: ${example.map}`,
       }),
     })
-    if (isMobile) {
-      await page.getByTitle('Skip to End').first().click()
-      await page.getByRole('button', { name: 'Map View' }).click()
-    } else if (await mapDialog.isVisible()) {
+    if (await mapDialog.isVisible()) {
       await mapDialog.getByTitle('Skip to End').click()
     } else {
       await page.getByTitle('Skip to End').first().click()
@@ -339,7 +342,6 @@ test('visualizes semantic Map updates', async ({ page, isMobile }) => {
 
 test('shows Top K result growth instead of buckets Matrix View', async ({
   page,
-  isMobile,
 }) => {
   await page.goto('/')
 
@@ -353,23 +355,17 @@ test('shows Top K result growth instead of buckets Matrix View', async ({
   await page.getByRole('button', { name: 'Run', exact: true }).click()
   await expect(page.getByText('All execution steps')).toBeVisible()
 
-  await page.getByTitle('Skip to End').first().click()
-
   await expect(page.getByText('Graph View')).toHaveCount(0)
   await expect(page.getByText('Matrix View')).toHaveCount(0)
-  if (isMobile) {
-    const resultRow = page.getByText('result', { exact: true }).locator('../..')
-    await resultRow.getByTitle('Visualize as stack').click()
-  }
-
-  await expect(
-    page.getByRole('heading', { name: 'Stack Visualization: result' })
-  ).toBeVisible()
+  const stackDialog = page.getByRole('dialog').filter({
+    has: page.getByRole('heading', { name: 'Stack Visualization: result' }),
+  })
+  await page.getByTitle('Skip to End').first().click()
+  await expect(stackDialog).toBeVisible()
 })
 
 test('returns cyclic clone graphs across the worker boundary', async ({
   page,
-  isMobile,
 }) => {
   await page.goto('/')
 
@@ -390,11 +386,25 @@ test('returns cyclic clone graphs across the worker boundary', async ({
     page.getByText('Execution produced a value that cannot leave the worker.')
   ).toHaveCount(0)
 
-  if (isMobile) {
-    await page.getByRole('button', { name: 'Graph View' }).click()
-  }
+  const graphDialog = page.getByRole('dialog').filter({
+    has: page.getByRole('heading', { name: 'Graph: return value' }),
+  })
+  await expect(graphDialog).toBeVisible()
+  await expect(graphDialog).toHaveCSS('opacity', '1')
 
-  await expect(
-    page.getByRole('heading', { name: 'Graph: return value' })
-  ).toBeVisible()
+  const dialogBox = await graphDialog.boundingBox()
+  const graphBox = await graphDialog
+    .getByRole('img', { name: 'return value graph' })
+    .boundingBox()
+
+  expect(dialogBox).not.toBeNull()
+  expect(graphBox).not.toBeNull()
+  expect(graphBox?.x).toBeGreaterThanOrEqual(dialogBox?.x ?? 0)
+  expect(graphBox?.y).toBeGreaterThanOrEqual(dialogBox?.y ?? 0)
+  expect((graphBox?.x ?? 0) + (graphBox?.width ?? 0)).toBeLessThanOrEqual(
+    (dialogBox?.x ?? 0) + (dialogBox?.width ?? 0)
+  )
+  expect((graphBox?.y ?? 0) + (graphBox?.height ?? 0)).toBeLessThanOrEqual(
+    (dialogBox?.y ?? 0) + (dialogBox?.height ?? 0)
+  )
 })

--- a/src/features/visualization/ui/graph-visualizer.tsx
+++ b/src/features/visualization/ui/graph-visualizer.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { isArray, isObject } from '@/shared/lib/guards'
-import { pxToRem } from '@/shared/lib/units'
 import { GRAPH_CONFIG } from '../constants/constants'
 
 /**
@@ -129,8 +128,8 @@ export function GraphVisualizer({
   }
 
   return (
-    <div className="flex flex-col items-center w-full">
-      <div className="mb-4 text-center">
+    <div className="flex h-full min-h-0 min-w-0 w-full flex-col items-center">
+      <div className="mb-4 shrink-0 text-center">
         <h3 className="text-lg font-semibold">{name} (Graph)</h3>
         {nodeStates && (
           <div className="flex gap-4 mt-2 justify-center">
@@ -159,13 +158,12 @@ export function GraphVisualizer({
         )}
       </div>
 
-      <div
-        className="relative border rounded-xl overflow-hidden bg-muted/20"
-        style={{ width: pxToRem(CANVAS_SIZE), height: pxToRem(CANVAS_SIZE) }}
-      >
+      <div className="relative min-h-0 min-w-0 w-full max-w-[31.25rem] flex-1 overflow-hidden rounded-xl border bg-muted/20">
         <svg
           viewBox={`0 0 ${CANVAS_SIZE} ${CANVAS_SIZE}`}
           className="w-full h-full"
+          role="img"
+          aria-label={`${name} graph`}
         >
           <defs>
             <marker

--- a/src/features/visualization/ui/playback-controls.tsx
+++ b/src/features/visualization/ui/playback-controls.tsx
@@ -43,7 +43,11 @@ export function PlaybackControls({
   className,
 }: PlaybackControlsProps) {
   return (
-    <div className={cn('flex gap-1', className)}>
+    <div
+      role="group"
+      aria-label="Visualization playback controls"
+      className={cn('flex gap-1', className)}
+    >
       <Button
         variant="outline"
         size="sm"

--- a/src/features/visualization/ui/return-value-card.tsx
+++ b/src/features/visualization/ui/return-value-card.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronLeft, ChevronUp } from 'lucide-react'
 import { Button, Card, CardContent, CardHeader, CardTitle } from '@/shared/ui'
+import { cn } from '@/shared/lib/class-names'
 import { isInlineReturnValue, stringifyValue } from '../lib/value-formatting'
 import type { RefObject } from 'react'
 
@@ -17,6 +18,8 @@ type ReturnValueCardProps = {
   onExpandedChange: (isExpanded: boolean) => void
   /** Moves playback to the previous step when step review is available. */
   onStepBackward?: () => void
+  /** Uses a compact layout on small screens while preserving the desktop card. */
+  compactOnMobile?: boolean
 }
 
 export function ReturnValueCard({
@@ -25,12 +28,18 @@ export function ReturnValueCard({
   returnValueRef,
   onExpandedChange,
   onStepBackward,
+  compactOnMobile = false,
 }: ReturnValueCardProps) {
   const shouldInlineReturnValue = isInlineReturnValue(returnValue)
 
   return (
     <Card ref={returnValueRef} className="border-primary">
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader
+        className={cn(
+          'flex flex-row items-center justify-between',
+          compactOnMobile && 'p-3 sm:p-6'
+        )}
+      >
         <CardTitle className="text-primary">Return Value</CardTitle>
         {!shouldInlineReturnValue && (
           <Button
@@ -48,7 +57,12 @@ export function ReturnValueCard({
           </Button>
         )}
       </CardHeader>
-      <CardContent className="space-y-4">
+      <CardContent
+        className={cn(
+          'space-y-4',
+          compactOnMobile && 'px-3 pb-3 sm:px-6 sm:pb-6'
+        )}
+      >
         <div>
           {shouldInlineReturnValue ? (
             <code className="font-mono text-sm">
@@ -65,7 +79,12 @@ export function ReturnValueCard({
           )}
         </div>
         {onStepBackward && (
-          <div className="flex flex-col gap-3 rounded-md border border-primary/25 bg-primary/5 p-3 sm:flex-row sm:items-center sm:justify-between">
+          <div
+            className={cn(
+              'flex flex-col gap-3 rounded-md border border-primary/25 bg-primary/5 p-3 sm:flex-row sm:items-center sm:justify-between',
+              compactOnMobile && 'hidden sm:flex'
+            )}
+          >
             <div className="space-y-1">
               <p className="text-sm font-medium">
                 Want to see how this result was reached?

--- a/src/features/visualization/ui/visualization-modal.test.tsx
+++ b/src/features/visualization/ui/visualization-modal.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vite-plus/test'
 
 import type { ExecutionState } from '@/entities/execution'
@@ -50,13 +50,37 @@ function renderModal(type: VisualizationType) {
 }
 
 describe('VisualizationModal', () => {
+  it('uses the near-full mobile viewport and restores the desktop dialog layout', () => {
+    renderModal('matrix')
+
+    const dialog = screen.getByRole('dialog')
+
+    expect(dialog).toHaveClass(
+      'left-1',
+      'top-2',
+      'h-[calc(100dvh-1rem)]',
+      'w-[calc(100vw-0.5rem)]',
+      'max-w-none',
+      'p-1',
+      'sm:left-[50%]',
+      'sm:top-[50%]',
+      'sm:max-w-3xl'
+    )
+    const playbackControls = screen.getByRole('group', {
+      name: 'Visualization playback controls',
+    })
+
+    expect(playbackControls).toBeInTheDocument()
+    expect(playbackControls).not.toHaveClass('border-t', 'bg-background')
+  })
+
   it('keeps body scrolling for non-tree visualizations with call frames', () => {
     const { container } = renderModal('matrix')
     const scrollContainer = container.ownerDocument.querySelector(
       '[data-tree-scroll-container]'
     )
 
-    expect(scrollContainer).toHaveClass('overflow-y-auto')
+    expect(scrollContainer).toHaveClass('min-h-0', 'min-w-0', 'overflow-auto')
     expect(scrollContainer).not.toHaveClass('lg:overflow-hidden')
   })
 

--- a/src/features/visualization/ui/visualization-modal.tsx
+++ b/src/features/visualization/ui/visualization-modal.tsx
@@ -219,16 +219,20 @@ export function VisualizationModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="top-4 h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] translate-y-0 flex flex-col bg-background sm:top-[50%] sm:h-[min(80vh,calc(100dvh-2rem))] sm:max-w-3xl sm:translate-y-[-50%]">
-        <DialogHeader className="shrink-0">
+      <DialogContent className="left-1 top-2 flex h-[calc(100dvh-1rem)] w-[calc(100vw-0.5rem)] max-w-none translate-x-0 translate-y-0 flex-col gap-0 bg-background p-1 sm:left-[50%] sm:top-[50%] sm:h-[min(80vh,calc(100dvh-2rem))] sm:w-[calc(100vw-2rem)] sm:max-w-3xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:gap-4 sm:p-6">
+        <DialogHeader className="shrink-0 px-4 pb-3 pt-4 pr-14 text-left sm:p-0">
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>{description}</DialogDescription>
+          <DialogDescription className="hidden sm:block">
+            {description}
+          </DialogDescription>
         </DialogHeader>
 
         <div
           className={cn(
-            'py-4 flex-1 min-h-0 overflow-y-auto overscroll-contain',
+            'min-h-0 min-w-0 flex-1 overflow-auto overscroll-contain px-4 py-3 sm:px-0 sm:py-4',
             showsCallFrameInspector && 'lg:overflow-hidden',
+            type === 'graph' &&
+              'flex items-center justify-center overflow-hidden',
             (type === 'matrix' ||
               type === 'expression' ||
               type === 'list-graph' ||
@@ -246,12 +250,13 @@ export function VisualizationModal({
 
         {executionState.isComplete &&
           !isUndefined(executionState.returnValue) && (
-            <div className="shrink-0">
+            <div className="shrink-0 px-4 pb-3 sm:px-0 sm:pb-0">
               <ReturnValueCard
                 returnValue={executionState.returnValue}
                 isExpanded={isReturnValueExpanded}
                 returnValueRef={returnValueRef}
                 onExpandedChange={setIsReturnValueExpanded}
+                compactOnMobile
                 onStepBackward={
                   executionState.totalSteps > 1 ? onStepBackward : undefined
                 }
@@ -268,7 +273,7 @@ export function VisualizationModal({
           onStepForward={onStepForward}
           onStepBackward={onStepBackward}
           onSkipToEnd={onSkipToEnd}
-          className="shrink-0 justify-center gap-2 pt-4 border-t mt-auto"
+          className="mt-auto shrink-0 justify-center gap-2 px-4 py-3 sm:px-0 sm:pb-0 sm:pt-4"
         />
       </DialogContent>
     </Dialog>

--- a/src/pages/main/ui/main-page.tsx
+++ b/src/pages/main/ui/main-page.tsx
@@ -157,7 +157,7 @@ export function MainPage() {
             viewViewAnimationSrc={viewViewAnimation.src}
             onViewViewAnimationLoad={viewViewAnimation.onAnimationLoad}
             showViewViewMonitor={isLargeScreen}
-            autoOpenPrimaryVisualization={isLargeScreen}
+            autoOpenPrimaryVisualization
             onModeChange={setMode}
             onExampleChange={handleExampleChange}
             onCompile={handleCompile}


### PR DESCRIPTION
## Summary

Improve mobile visualization modal,

<!-- A brief summary of the changes -->

## Description

- automatically open the primary visualization on mobile after execution
- use a near-fullscreen mobile modal with consistent outer spacing

<!-- A detailed explanation of the changes, including why they are needed -->
