### PR TITLE
refactor: stock profit types and UI

### DIFF
--- a/src/features/visualization/lib/stock-profit-view.ts
+++ b/src/features/visualization/lib/stock-profit-view.ts
@@ -5,8 +5,6 @@ import {
   isNumber,
 } from '@/shared/lib/guards'
 
-type StockProfitMode = 'single-transaction' | 'multiple-transactions'
-
 type StockProfitProgress = {
   stepIndex: number
   currentIndex: number
@@ -21,32 +19,41 @@ type StockProfitProgress = {
 type ExpectedStockProfitProgress = Omit<StockProfitProgress, 'stepIndex'>
 type NameTriple = readonly [string, string, string]
 
-/** Variable mapping inferred from a stock-profit execution trace. */
-export type StockProfitTraceCandidate = {
+type StockProfitTraceCandidateBase = {
   /** Numeric price-array variable. */
   name: string
   /** First step containing a completed price update. */
   stepIndex: number
-  /** Stock-profit strategy represented by the trace. */
-  mode: StockProfitMode
   /** Variable holding accumulated or best profit. */
   profitName: string
-  /** Loop index variable for adjacent-difference strategies. */
-  indexName?: string
-  /** Current price variable for for-of strategies. */
-  priceName?: string
-  /** Running minimum-price variable for one-transaction strategies. */
-  minimumName?: string
-  /** Adjacent price-difference variable for multi-transaction strategies. */
-  differenceName?: string
 }
 
-/** Values displayed by the stock-profit visualization. */
-export type StockProfitVisualizationState = {
+type SingleTransactionTraceCandidate = StockProfitTraceCandidateBase & {
+  /** Single buy-and-sell strategy. */
+  mode: 'single-transaction'
+  /** Current price variable for for-of strategies. */
+  priceName: string
+  /** Running minimum-price variable. */
+  minimumName: string
+}
+
+type MultipleTransactionTraceCandidate = StockProfitTraceCandidateBase & {
+  /** Repeated adjacent-gain strategy. */
+  mode: 'multiple-transactions'
+  /** Loop index variable. */
+  indexName: string
+  /** Adjacent price-difference variable. */
+  differenceName: string
+}
+
+/** Variable mapping inferred from a stock-profit execution trace. */
+export type StockProfitTraceCandidate =
+  | SingleTransactionTraceCandidate
+  | MultipleTransactionTraceCandidate
+
+type StockProfitVisualizationStateBase = {
   /** Numeric source prices. */
   data: number[]
-  /** Stock-profit strategy represented by the trace. */
-  mode: StockProfitMode
   /** Current price-array index. */
   currentIndex: number
   /** Price at the current index. */
@@ -57,13 +64,32 @@ export type StockProfitVisualizationState = {
   buyIndex: number
   /** Sell index for the current best transaction or adjacent trade. */
   sellIndex: number
-  /** Running minimum price for one-transaction strategies. */
-  minimumPrice?: number
-  /** Current adjacent difference for multi-transaction strategies. */
-  difference?: number
-  /** Runtime variable names shown alongside semantic labels. */
-  variableNames: Omit<StockProfitTraceCandidate, 'name' | 'stepIndex' | 'mode'>
 }
+
+/** Values displayed by the stock-profit visualization. */
+export type StockProfitVisualizationState =
+  | (StockProfitVisualizationStateBase & {
+      /** Single buy-and-sell strategy. */
+      mode: 'single-transaction'
+      /** Running minimum price. */
+      minimumPrice: number
+      /** Runtime variable names shown alongside semantic labels. */
+      variableNames: Pick<
+        SingleTransactionTraceCandidate,
+        'profitName' | 'priceName' | 'minimumName'
+      >
+    })
+  | (StockProfitVisualizationStateBase & {
+      /** Repeated adjacent-gain strategy. */
+      mode: 'multiple-transactions'
+      /** Current adjacent price difference. */
+      difference: number
+      /** Runtime variable names shown alongside semantic labels. */
+      variableNames: Pick<
+        MultipleTransactionTraceCandidate,
+        'profitName' | 'indexName' | 'differenceName'
+      >
+    })
 
 type IndexedStockProfitCandidate = {
   candidate: StockProfitTraceCandidate
@@ -445,21 +471,39 @@ export function getStockProfitVisualizationState({
   if (!progress) return undefined
 
   const { candidate } = analysis
-  return {
+  const visualizationState = {
     data: analysis.data,
-    mode: candidate.mode,
     currentIndex: progress.currentIndex,
     currentPrice: progress.currentPrice,
     profit: progress.profit,
     buyIndex: progress.buyIndex,
     sellIndex: progress.sellIndex,
-    minimumPrice: progress.minimumPrice,
+  }
+
+  if (candidate.mode === 'single-transaction') {
+    if (!isNumber(progress.minimumPrice)) return undefined
+
+    return {
+      ...visualizationState,
+      mode: candidate.mode,
+      minimumPrice: progress.minimumPrice,
+      variableNames: {
+        profitName: candidate.profitName,
+        priceName: candidate.priceName,
+        minimumName: candidate.minimumName,
+      },
+    }
+  }
+
+  if (!isNumber(progress.difference)) return undefined
+
+  return {
+    ...visualizationState,
+    mode: candidate.mode,
     difference: progress.difference,
     variableNames: {
       profitName: candidate.profitName,
       indexName: candidate.indexName,
-      priceName: candidate.priceName,
-      minimumName: candidate.minimumName,
       differenceName: candidate.differenceName,
     },
   }

--- a/src/features/visualization/ui/stock-profit-visualizer.tsx
+++ b/src/features/visualization/ui/stock-profit-visualizer.tsx
@@ -26,6 +26,15 @@ type StockProfitVisualizerProps = {
   state: StockProfitVisualizationState
 }
 
+type PriceProgressItemProps = {
+  /** Price value shown for this day. */
+  price: number
+  /** Zero-based day index. */
+  index: number
+  /** Strategy state used to derive the day's status. */
+  state: StockProfitVisualizationState
+}
+
 function Metric({
   label,
   variableName,
@@ -60,7 +69,7 @@ function Metric({
 function hasExecutedTrade(state: StockProfitVisualizationState): boolean {
   return state.mode === 'single-transaction'
     ? state.profit > 0
-    : (state.difference ?? 0) > 0
+    : state.difference > 0
 }
 
 function getStrategySummary(state: StockProfitVisualizationState): string {
@@ -117,12 +126,46 @@ function getPriceClass(status: PriceStatus): string {
   }
 }
 
+function PriceProgressItem({ price, index, state }: PriceProgressItemProps) {
+  const status = getPriceStatus({ index, state })
+
+  return (
+    <li
+      aria-current={isCurrentPriceStatus(status) ? 'step' : undefined}
+      aria-label={`Day ${index}: price ${price}, ${getAccessiblePriceStatus(status)}`}
+      className="relative flex flex-col items-center gap-1"
+    >
+      {isLabeledPriceStatus(status) && (
+        <span
+          className={[
+            'absolute -top-6 font-mono text-xs font-semibold',
+            status === 'sell' ? 'text-secondary-foreground' : 'text-primary',
+          ].join(' ')}
+        >
+          {getPriceStatusLabel(status)}
+        </span>
+      )}
+      <div
+        className={[
+          'flex h-14 w-14 items-center justify-center rounded-md border-2 font-mono text-base transition-colors',
+          getPriceClass(status),
+        ].join(' ')}
+      >
+        {price}
+      </div>
+      <span className="font-mono text-xs text-muted-foreground">{index}</span>
+    </li>
+  )
+}
+
 export function StockProfitVisualizer({
   name,
   state,
 }: StockProfitVisualizerProps) {
   const isSingleTransaction = state.mode === 'single-transaction'
-  const indexVariable = state.variableNames.indexName ?? 'day'
+  const indexVariable = isSingleTransaction
+    ? 'day'
+    : state.variableNames.indexName
 
   return (
     <Card className="w-full border-0 shadow-none">
@@ -140,7 +183,9 @@ export function StockProfitVisualizer({
           <Metric
             label="Current price"
             variableName={
-              state.variableNames.priceName ?? `${name}[${indexVariable}]`
+              isSingleTransaction
+                ? state.variableNames.priceName
+                : `${name}[${indexVariable}]`
             }
           >
             {state.currentPrice}
@@ -148,14 +193,14 @@ export function StockProfitVisualizer({
           {isSingleTransaction ? (
             <Metric
               label="Lowest price"
-              variableName={state.variableNames.minimumName ?? 'minimum'}
+              variableName={state.variableNames.minimumName}
             >
               {state.minimumPrice}
             </Metric>
           ) : (
             <Metric
               label="Daily change"
-              variableName={state.variableNames.differenceName ?? 'difference'}
+              variableName={state.variableNames.differenceName}
             >
               {state.difference}
             </Metric>
@@ -174,44 +219,14 @@ export function StockProfitVisualizer({
             aria-label={`${name} stock profit progress`}
             className="flex min-w-max gap-2 pt-6"
           >
-            {state.data.map((price, index) => {
-              const status = getPriceStatus({ index, state })
-
-              return (
-                <li
-                  key={index}
-                  aria-current={
-                    isCurrentPriceStatus(status) ? 'step' : undefined
-                  }
-                  aria-label={`Day ${index}: price ${price}, ${getAccessiblePriceStatus(status)}`}
-                  className="relative flex flex-col items-center gap-1"
-                >
-                  {isLabeledPriceStatus(status) && (
-                    <span
-                      className={[
-                        'absolute -top-6 font-mono text-xs font-semibold',
-                        status === 'sell'
-                          ? 'text-secondary-foreground'
-                          : 'text-primary',
-                      ].join(' ')}
-                    >
-                      {getPriceStatusLabel(status)}
-                    </span>
-                  )}
-                  <div
-                    className={[
-                      'flex h-14 w-14 items-center justify-center rounded-md border-2 font-mono text-base transition-colors',
-                      getPriceClass(status),
-                    ].join(' ')}
-                  >
-                    {price}
-                  </div>
-                  <span className="font-mono text-xs text-muted-foreground">
-                    {index}
-                  </span>
-                </li>
-              )
-            })}
+            {state.data.map((price, index) => (
+              <PriceProgressItem
+                key={index}
+                price={price}
+                index={index}
+                state={state}
+              />
+            ))}
           </ol>
         </div>
 


### PR DESCRIPTION
## Summary

Refactor stock profit types and UI.

<!-- A brief summary of the changes -->

## Description

- model stock-profit candidates and visualization states as discriminated unions
- make strategy-specific fields required instead of optional

<!-- A detailed explanation of the changes, including why they are needed -->
