### PR TITLE
feat: capacity search view

### DIFF
--- a/src/features/code-execution/lib/capacity-search-visualization.integration.test.ts
+++ b/src/features/code-execution/lib/capacity-search-visualization.integration.test.ts
@@ -128,7 +128,7 @@ describe('Capacity-search visualization integration', () => {
   it('tracks duplicate weights by call-frame iteration order', () => {
     const state = executeCode(
       shipWithinDaysCode,
-      { weights: [3, 3, 3, 3], days: 2 },
+      { weights: [1, 1, 1, 1], days: 2 },
       'shipWithinDays'
     )
     const loopStepIndexes = state.steps.flatMap((step, stepIndex) =>
@@ -148,7 +148,11 @@ describe('Capacity-search visualization integration', () => {
         })?.currentIndex
     )
 
-    expect(state.returnValue).toBe(6)
+    const detection = detectVisualizationState(state)
+
+    expect(state.returnValue).toBe(2)
     expect(indexes).toEqual([0, 1, 2, 3])
+    expect(detection.primaryCapacitySearchArrayName).toBe('weights')
+    expect(detection.primaryBinarySearchArrayName).toBeUndefined()
   })
 })

--- a/src/features/code-execution/lib/capacity-search-visualization.integration.test.ts
+++ b/src/features/code-execution/lib/capacity-search-visualization.integration.test.ts
@@ -79,6 +79,7 @@ describe('Capacity-search visualization integration', () => {
       right: 55,
       mid: 32,
       capacity: 32,
+      isConverged: false,
       totalWeight: 55,
       targetDays: 5,
       currentIndex: 4,
@@ -111,6 +112,9 @@ describe('Capacity-search visualization integration', () => {
       mid: 14,
       capacity: 15,
       isConverged: true,
+      currentIndex: 9,
+      currentWeight: 10,
+      currentLoad: 10,
       requiredDays: 5,
       canShip: true,
     })

--- a/src/features/code-execution/lib/capacity-search-visualization.integration.test.ts
+++ b/src/features/code-execution/lib/capacity-search-visualization.integration.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vite-plus/test'
+import {
+  getCapacitySearchTraceCandidate,
+  getCapacitySearchVisualizationState,
+} from '@/features/visualization/lib/capacity-search-view'
+import { detectVisualizationState } from '@/features/visualization/model/use-visualization-detection'
+import { getPrimaryVisualization } from '@/features/visualization/model/primary-visualization'
+import { executeCode } from './runner'
+
+const shipWithinDaysCode = `
+function shipWithinDays(weights: number[], days: number): number {
+  let left = Math.max(...weights)
+  let right = weights.reduce((a, b) => a + b, 0)
+
+  const canShip = (capacity: number): boolean => {
+    let requiredDays = 1
+    let current = 0
+
+    for (const weight of weights) {
+      if (current + weight > capacity) {
+        requiredDays++
+        current = weight
+        if (requiredDays > days) return false
+      } else {
+        current += weight
+      }
+    }
+    return true
+  }
+
+  while (left < right) {
+    const mid = Math.floor((left + right) / 2)
+
+    if (canShip(mid)) {
+      right = mid
+    } else {
+      left = mid + 1
+    }
+  }
+
+  return left
+}
+`
+
+describe('Capacity-search visualization integration', () => {
+  it('treats the bounds as capacities and advances package indexes', () => {
+    const state = executeCode(
+      shipWithinDaysCode,
+      { weights: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], days: 5 },
+      'shipWithinDays'
+    )
+    const candidate = getCapacitySearchTraceCandidate(state)
+    const firstLoopStepIndex = state.steps.findIndex(
+      (step) => step.description === 'for (... of weights)'
+    )
+    const firstFrameId =
+      state.steps[firstLoopStepIndex].metadata?.callFrame?.frameId
+    const firstPassIndexes = state.steps.flatMap((step, stepIndex) =>
+      step.description === 'for (... of weights)' &&
+      step.metadata?.callFrame?.frameId === firstFrameId
+        ? [stepIndex]
+        : []
+    )
+    const view = getCapacitySearchVisualizationState({
+      executionState: { ...state, currentStep: firstPassIndexes[4] },
+      variableName: 'weights',
+    })
+    const detection = detectVisualizationState(state)
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(15)
+    expect(firstPassIndexes).toHaveLength(10)
+    expect(candidate).toEqual({
+      name: 'weights',
+      stepIndex: firstLoopStepIndex,
+    })
+    expect(view).toMatchObject({
+      left: 10,
+      right: 55,
+      mid: 32,
+      capacity: 32,
+      totalWeight: 55,
+      targetDays: 5,
+      currentIndex: 4,
+      currentLoad: 15,
+      requiredDays: 1,
+      canShip: true,
+    })
+    expect(detection).toMatchObject({
+      primaryCapacitySearchArrayName: 'weights',
+      primaryCapacitySearchStepIndex: firstLoopStepIndex,
+      primaryBinarySearchArrayName: undefined,
+    })
+    expect(getPrimaryVisualization(detection)).toEqual({
+      type: 'capacity-search',
+      targetVariable: 'weights',
+      targetStepIndex: firstLoopStepIndex,
+    })
+
+    const finalView = getCapacitySearchVisualizationState({
+      executionState: {
+        ...state,
+        currentStep: state.steps.length - 1,
+      },
+      variableName: 'weights',
+    })
+
+    expect(finalView).toMatchObject({
+      left: 15,
+      right: 15,
+      mid: 14,
+      capacity: 15,
+      isConverged: true,
+      requiredDays: 5,
+      canShip: true,
+    })
+    expect(
+      finalView?.packages
+        .filter((packageState) => packageState.day === 1)
+        .map((packageState) => packageState.weight)
+    ).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('tracks duplicate weights by call-frame iteration order', () => {
+    const state = executeCode(
+      shipWithinDaysCode,
+      { weights: [3, 3, 3, 3], days: 2 },
+      'shipWithinDays'
+    )
+    const loopStepIndexes = state.steps.flatMap((step, stepIndex) =>
+      step.description === 'for (... of weights)' ? [stepIndex] : []
+    )
+    const firstFrameId =
+      state.steps[loopStepIndexes[0]].metadata?.callFrame?.frameId
+    const firstPassIndexes = loopStepIndexes.filter(
+      (stepIndex) =>
+        state.steps[stepIndex].metadata?.callFrame?.frameId === firstFrameId
+    )
+    const indexes = firstPassIndexes.map(
+      (currentStep) =>
+        getCapacitySearchVisualizationState({
+          executionState: { ...state, currentStep },
+          variableName: 'weights',
+        })?.currentIndex
+    )
+
+    expect(state.returnValue).toBe(6)
+    expect(indexes).toEqual([0, 1, 2, 3])
+  })
+})

--- a/src/features/code-execution/lib/capacity-search-visualization.integration.test.ts
+++ b/src/features/code-execution/lib/capacity-search-visualization.integration.test.ts
@@ -80,6 +80,7 @@ describe('Capacity-search visualization integration', () => {
       mid: 32,
       capacity: 32,
       isConverged: false,
+      phase: 'checking',
       totalWeight: 55,
       targetDays: 5,
       currentIndex: 4,
@@ -98,6 +99,29 @@ describe('Capacity-search visualization integration', () => {
       targetStepIndex: firstLoopStepIndex,
     })
 
+    const nextMidStepIndex = state.steps.findIndex(
+      (step, stepIndex) =>
+        stepIndex > firstPassIndexes[firstPassIndexes.length - 1] &&
+        step.variables.left === 10 &&
+        step.variables.right === 32 &&
+        step.variables.mid === 21
+    )
+    const pendingView = getCapacitySearchVisualizationState({
+      executionState: { ...state, currentStep: nextMidStepIndex },
+      variableName: 'weights',
+    })
+
+    expect(nextMidStepIndex).toBeGreaterThan(
+      firstPassIndexes[firstPassIndexes.length - 1]
+    )
+    expect(pendingView).toMatchObject({
+      capacity: 21,
+      phase: 'pending',
+      requiredDays: 0,
+      currentLoad: 0,
+    })
+    expect(pendingView?.currentIndex).toBeUndefined()
+
     const finalView = getCapacitySearchVisualizationState({
       executionState: {
         ...state,
@@ -112,6 +136,7 @@ describe('Capacity-search visualization integration', () => {
       mid: 14,
       capacity: 15,
       isConverged: true,
+      phase: 'complete',
       currentIndex: 9,
       currentWeight: 10,
       currentLoad: 10,

--- a/src/features/visualization/lib/binary-search-view.test.ts
+++ b/src/features/visualization/lib/binary-search-view.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vite-plus/test'
+import type { ExecutionState } from '@/entities/execution'
+import {
+  getBinarySearchRangeMode,
+  isBinarySearchArrayCandidate,
+} from './binary-search-view'
+
+const values = [1, 3, 5, 7, 9, 11]
+
+function createState(
+  snapshots: Array<Record<string, unknown>>
+): ExecutionState {
+  return {
+    currentStep: snapshots.length - 1,
+    totalSteps: snapshots.length,
+    isComplete: false,
+    steps: snapshots.map((variables, stepNumber) => ({
+      stepNumber,
+      type: 'assignment',
+      line: stepNumber + 1,
+      description: 'binary-search update',
+      variables: { values, ...variables },
+      timestamp: stepNumber,
+    })),
+  }
+}
+
+describe('binary-search view', () => {
+  it('accepts the array length as a half-open right boundary', () => {
+    const variables = { values, left: 0, right: values.length, mid: 3 }
+
+    expect(isBinarySearchArrayCandidate('values', values, variables)).toBe(true)
+    expect(getBinarySearchRangeMode(createState([variables]), 'values')).toBe(
+      'half-open'
+    )
+  })
+
+  it('preserves half-open mode after the right boundary narrows', () => {
+    const state = createState([
+      { left: 0, right: values.length, mid: 3 },
+      { left: 0, right: 3, mid: 3 },
+    ])
+
+    expect(getBinarySearchRangeMode(state, 'values')).toBe('half-open')
+  })
+})

--- a/src/features/visualization/lib/binary-search-view.test.ts
+++ b/src/features/visualization/lib/binary-search-view.test.ts
@@ -8,7 +8,8 @@ import {
 const values = [1, 3, 5, 7, 9, 11]
 
 function createState(
-  snapshots: Array<Record<string, unknown>>
+  snapshots: Array<Record<string, unknown>>,
+  frameIds = snapshots.map(() => 1)
 ): ExecutionState {
   return {
     currentStep: snapshots.length - 1,
@@ -21,6 +22,14 @@ function createState(
       description: 'binary-search update',
       variables: { values, ...variables },
       timestamp: stepNumber,
+      metadata: {
+        callFrame: {
+          frameId: frameIds[stepNumber],
+          functionName: 'binarySearch',
+          phase: 'update',
+          visibleVariableNames: ['values', 'left', 'right', 'mid'],
+        },
+      },
     })),
   }
 }
@@ -30,9 +39,9 @@ describe('binary-search view', () => {
     const variables = { values, left: 0, right: values.length, mid: 3 }
 
     expect(isBinarySearchArrayCandidate('values', values, variables)).toBe(true)
-    expect(getBinarySearchRangeMode(createState([variables]), 'values')).toBe(
-      'half-open'
-    )
+    expect(
+      getBinarySearchRangeMode(createState([variables]), 'values', 0)
+    ).toBe('half-open')
   })
 
   it('preserves half-open mode after the right boundary narrows', () => {
@@ -41,6 +50,21 @@ describe('binary-search view', () => {
       { left: 0, right: 3, mid: 3 },
     ])
 
-    expect(getBinarySearchRangeMode(state, 'values')).toBe('half-open')
+    expect(getBinarySearchRangeMode(state, 'values', 1)).toBe('half-open')
+  })
+
+  it('does not inherit range mode from another call frame', () => {
+    const state = createState(
+      [
+        { left: 0, right: values.length, mid: 3 },
+        { left: 0, right: 3, mid: 3 },
+        { left: 0, right: values.length - 1, mid: 2 },
+        { left: 3, right: values.length - 1, mid: 2 },
+      ],
+      [1, 1, 2, 2]
+    )
+
+    expect(getBinarySearchRangeMode(state, 'values', 1)).toBe('half-open')
+    expect(getBinarySearchRangeMode(state, 'values', 3)).toBe('inclusive')
   })
 })

--- a/src/features/visualization/lib/binary-search-view.ts
+++ b/src/features/visualization/lib/binary-search-view.ts
@@ -14,7 +14,7 @@ const isResultVariableName = equals('result')
 export type BinarySearchIndexState = {
   /** Inclusive left boundary. */
   left: number
-  /** Inclusive right boundary. */
+  /** Current right boundary. */
   right: number
   /** Optional current midpoint. */
   mid?: number
@@ -76,16 +76,31 @@ function isIndexStateWithinArray(
   return isInclusiveRangeOrTerminalCrossing && isMidWithinArray
 }
 
-/** Detects whether a trace uses an inclusive or exclusive right boundary. */
+/** Detects the right-boundary convention used by the active binary search. */
 export function getBinarySearchRangeMode(
   executionState: ExecutionState,
-  variableName: string
+  variableName: string,
+  activeStepIndex: number
 ): BinarySearchRangeMode {
-  const usesExclusiveUpperBound = executionState.steps.some((step) => {
+  const activeStep = executionState.steps[activeStepIndex]
+  const activeFrameId = activeStep?.metadata?.callFrame?.frameId
+  const stepsInActiveSearch = isInteger(activeFrameId)
+    ? executionState.steps
+        .slice(0, activeStepIndex + 1)
+        .filter((step) => step.metadata?.callFrame?.frameId === activeFrameId)
+    : activeStep
+      ? [activeStep]
+      : []
+  const usesExclusiveUpperBound = stepsInActiveSearch.some((step) => {
+    const visibleVariableNames = step.metadata?.callFrame?.visibleVariableNames
     const data = step.variables[variableName]
     const indexState = getBinarySearchIndexState(step.variables)
 
     return (
+      (isUndefined(visibleVariableNames) ||
+        [variableName, ...BINARY_SEARCH_INDEX_NAMES].every((name) =>
+          visibleVariableNames.includes(name)
+        )) &&
       isNumericArray(data) &&
       !isNull(indexState) &&
       indexState.right === data.length

--- a/src/features/visualization/lib/binary-search-view.ts
+++ b/src/features/visualization/lib/binary-search-view.ts
@@ -1,5 +1,11 @@
 import type { ExecutionStep } from '@/entities/execution'
-import { equals, isInteger, isNull, isNumericArray } from '@/shared/lib/guards'
+import {
+  equals,
+  isInteger,
+  isNull,
+  isNumericArray,
+  isUndefined,
+} from '@/shared/lib/guards'
 
 const BINARY_SEARCH_INDEX_NAMES = ['left', 'right', 'mid'] as const
 const isResultVariableName = equals('result')
@@ -63,12 +69,19 @@ export function isBinarySearchArrayCandidate(
   value: unknown,
   variables: ExecutionStep['variables']
 ): boolean {
+  const indexState = getBinarySearchIndexState(variables)
+
   return (
     !isResultVariableName(name) &&
     isNumericArray(value) &&
     value.length > 0 &&
     hasBinarySearchIndexVariables(variables) &&
-    hasBinarySearchIndexState(variables)
+    !isNull(indexState) &&
+    indexState.left >= 0 &&
+    indexState.left <= indexState.right &&
+    indexState.right < value.length &&
+    (isUndefined(indexState.mid) ||
+      (indexState.mid >= indexState.left && indexState.mid <= indexState.right))
   )
 }
 

--- a/src/features/visualization/lib/binary-search-view.ts
+++ b/src/features/visualization/lib/binary-search-view.ts
@@ -56,6 +56,22 @@ export function hasBinarySearchIndexState(
   return !isNull(getBinarySearchIndexState(variables))
 }
 
+function isIndexStateWithinArray(
+  indexState: BinarySearchIndexState,
+  length: number
+): boolean {
+  const isMidWithinRange =
+    isUndefined(indexState.mid) ||
+    (indexState.mid >= indexState.left && indexState.mid <= indexState.right)
+
+  return (
+    indexState.left >= 0 &&
+    indexState.left <= indexState.right &&
+    indexState.right < length &&
+    isMidWithinRange
+  )
+}
+
 /**
  * Checks whether a value should use the binary-search visualization.
  *
@@ -77,11 +93,7 @@ export function isBinarySearchArrayCandidate(
     value.length > 0 &&
     hasBinarySearchIndexVariables(variables) &&
     !isNull(indexState) &&
-    indexState.left >= 0 &&
-    indexState.left <= indexState.right &&
-    indexState.right < value.length &&
-    (isUndefined(indexState.mid) ||
-      (indexState.mid >= indexState.left && indexState.mid <= indexState.right))
+    isIndexStateWithinArray(indexState, value.length)
   )
 }
 

--- a/src/features/visualization/lib/binary-search-view.ts
+++ b/src/features/visualization/lib/binary-search-view.ts
@@ -1,4 +1,4 @@
-import type { ExecutionStep } from '@/entities/execution'
+import type { ExecutionState, ExecutionStep } from '@/entities/execution'
 import {
   equals,
   isInteger,
@@ -19,6 +19,9 @@ export type BinarySearchIndexState = {
   /** Optional current midpoint. */
   mid?: number
 }
+
+/** Boundary convention used by a binary-search trace. */
+export type BinarySearchRangeMode = 'inclusive' | 'half-open'
 
 /**
  * Reads binary-search indexes from execution variables.
@@ -67,10 +70,29 @@ function isIndexStateWithinArray(
     indexState.left >= 0 &&
     indexState.left <= length &&
     indexState.right >= -1 &&
-    indexState.right < length &&
+    indexState.right <= length &&
     indexState.left <= indexState.right + 1
 
   return isInclusiveRangeOrTerminalCrossing && isMidWithinArray
+}
+
+/** Detects whether a trace uses an inclusive or exclusive right boundary. */
+export function getBinarySearchRangeMode(
+  executionState: ExecutionState,
+  variableName: string
+): BinarySearchRangeMode {
+  const usesExclusiveUpperBound = executionState.steps.some((step) => {
+    const data = step.variables[variableName]
+    const indexState = getBinarySearchIndexState(step.variables)
+
+    return (
+      isNumericArray(data) &&
+      !isNull(indexState) &&
+      indexState.right === data.length
+    )
+  })
+
+  return usesExclusiveUpperBound ? 'half-open' : 'inclusive'
 }
 
 /**

--- a/src/features/visualization/lib/binary-search-view.ts
+++ b/src/features/visualization/lib/binary-search-view.ts
@@ -60,16 +60,17 @@ function isIndexStateWithinArray(
   indexState: BinarySearchIndexState,
   length: number
 ): boolean {
-  const isMidWithinRange =
+  const isMidWithinArray =
     isUndefined(indexState.mid) ||
-    (indexState.mid >= indexState.left && indexState.mid <= indexState.right)
-
-  return (
+    (indexState.mid >= 0 && indexState.mid < length)
+  const isInclusiveRangeOrTerminalCrossing =
     indexState.left >= 0 &&
-    indexState.left <= indexState.right &&
+    indexState.left <= length &&
+    indexState.right >= -1 &&
     indexState.right < length &&
-    isMidWithinRange
-  )
+    indexState.left <= indexState.right + 1
+
+  return isInclusiveRangeOrTerminalCrossing && isMidWithinArray
 }
 
 /**

--- a/src/features/visualization/lib/capacity-search-view.ts
+++ b/src/features/visualization/lib/capacity-search-view.ts
@@ -1,0 +1,316 @@
+import type { ExecutionState, ExecutionStep } from '@/entities/execution'
+import {
+  isInteger,
+  isNonEmptyNumericArray,
+  isNumber,
+} from '@/shared/lib/guards'
+
+type CapacityBounds = {
+  left: number
+  right: number
+  mid: number
+}
+
+type CapacityProgress = {
+  stepIndex: number
+  frameId: number
+  capacity: number
+  currentIndex: number
+}
+
+type IndexedCapacityCandidate = {
+  candidate: CapacitySearchTraceCandidate
+  data: number[]
+  progress: CapacityProgress[]
+}
+
+/** Capacity-search trace inferred from a shipping feasibility check. */
+export type CapacitySearchTraceCandidate = {
+  /** Package-weight array variable. */
+  name: string
+  /** First step that checks one package against a candidate capacity. */
+  stepIndex: number
+}
+
+/** Package placement under the currently tested capacity. */
+export type CapacityPackageState = {
+  /** Source-array index. */
+  index: number
+  /** Package weight. */
+  weight: number
+  /** One-based shipping day assigned by the greedy check. */
+  day: number
+  /** Load on that day after adding this package. */
+  load: number
+}
+
+/** Values displayed by the capacity-search visualization. */
+export type CapacitySearchVisualizationState = {
+  /** Package weights in shipping order. */
+  data: number[]
+  /** Current lower capacity bound. */
+  left: number
+  /** Current upper capacity bound. */
+  right: number
+  /** Current binary-search candidate. */
+  mid: number
+  /** Capacity used by the active feasibility pass. */
+  capacity: number
+  /** Whether the binary search has converged on its result capacity. */
+  isConverged: boolean
+  /** Sum of all package weights. */
+  totalWeight: number
+  /** Maximum allowed shipping days. */
+  targetDays: number
+  /** Current package-array index. */
+  currentIndex: number
+  /** Greedy package placement for the active capacity. */
+  packages: CapacityPackageState[]
+  /** Number of days needed through the current package. */
+  requiredDays: number
+  /** Current day's load after the current package. */
+  currentLoad: number
+  /** Whether the active capacity can ship every package in time. */
+  canShip: boolean
+}
+
+const analysisCache = new WeakMap<
+  ExecutionState['steps'],
+  IndexedCapacityCandidate | null
+>()
+
+function getCapacityBounds(
+  variables: ExecutionStep['variables']
+): CapacityBounds | undefined {
+  const left = variables.left
+  const right = variables.right
+  const mid = variables.mid
+
+  if (!isInteger(left) || !isInteger(right) || !isInteger(mid)) {
+    return undefined
+  }
+
+  return { left, right, mid }
+}
+
+function getCapacityPackages(
+  data: number[],
+  capacity: number
+): CapacityPackageState[] {
+  let day = 1
+  let load = 0
+
+  return data.map((weight, index) => {
+    if (load + weight > capacity) {
+      day += 1
+      load = weight
+    } else {
+      load += weight
+    }
+
+    return { index, weight, day, load }
+  })
+}
+
+function findCandidate(
+  steps: ExecutionState['steps']
+): IndexedCapacityCandidate | undefined {
+  for (let stepIndex = 0; stepIndex < steps.length; stepIndex += 1) {
+    const step = steps[stepIndex]
+    const match = /^for \(\.\.\. of ([A-Za-z_$][\w$]*)\)$/.exec(
+      step.description
+    )
+    if (!match) continue
+
+    const name = match[1]
+    const source = step.variables[name]
+    const bounds = getCapacityBounds(step.variables)
+    const capacity = step.variables.capacity
+    const targetDays = step.variables.days
+    const requiredDays = step.variables.requiredDays
+    const currentLoad = step.variables.current
+    const currentWeight = step.variables.weight
+
+    if (
+      !isNonEmptyNumericArray(source) ||
+      !bounds ||
+      !isNumber(capacity) ||
+      !isInteger(targetDays) ||
+      !isInteger(requiredDays) ||
+      !isNumber(currentLoad) ||
+      !isNumber(currentWeight)
+    ) {
+      continue
+    }
+
+    const data = source.map(Number)
+    const totalWeight = data.reduce((sum, weight) => sum + weight, 0)
+    const maximumWeight = Math.max(...data)
+    const isInitialCapacityPass =
+      bounds.left === maximumWeight &&
+      bounds.right === totalWeight &&
+      bounds.mid === capacity
+
+    if (!isInitialCapacityPass || targetDays <= 0) continue
+
+    const loopDescription = step.description
+    const frameIndexes = new Map<number, number>()
+    const progress: CapacityProgress[] = []
+
+    for (let index = stepIndex; index < steps.length; index += 1) {
+      const loopStep = steps[index]
+      if (loopStep.description !== loopDescription) continue
+
+      const loopData = loopStep.variables[name]
+      const frameId = loopStep.metadata?.callFrame?.frameId
+      const loopCapacity = loopStep.variables.capacity
+      const loopWeight = loopStep.variables.weight
+
+      if (
+        !isNonEmptyNumericArray(loopData) ||
+        !isInteger(frameId) ||
+        !isNumber(loopCapacity) ||
+        !isNumber(loopWeight)
+      ) {
+        continue
+      }
+
+      const currentIndex = frameIndexes.get(frameId) ?? 0
+      if (currentIndex >= data.length || data[currentIndex] !== loopWeight) {
+        continue
+      }
+
+      progress.push({
+        stepIndex: index,
+        frameId,
+        capacity: loopCapacity,
+        currentIndex,
+      })
+      frameIndexes.set(frameId, currentIndex + 1)
+    }
+
+    if (progress.length === 0) continue
+
+    return {
+      candidate: { name, stepIndex: progress[0].stepIndex },
+      data,
+      progress,
+    }
+  }
+
+  return undefined
+}
+
+function analyzeCapacityTrace(
+  executionState: ExecutionState
+): IndexedCapacityCandidate | undefined {
+  const cached = analysisCache.get(executionState.steps)
+  if (cached !== undefined) return cached ?? undefined
+
+  const analysis = findCandidate(executionState.steps)
+  analysisCache.set(executionState.steps, analysis ?? null)
+  return analysis
+}
+
+function findBoundsAtStep(
+  steps: ExecutionState['steps'],
+  currentStep: number,
+  fallbackStep: number
+): CapacityBounds | undefined {
+  for (let index = currentStep; index >= 0; index -= 1) {
+    const bounds = getCapacityBounds(steps[index].variables)
+    if (bounds) return bounds
+  }
+
+  return getCapacityBounds(steps[fallbackStep].variables)
+}
+
+function getProgressAtStep({
+  steps,
+  progress,
+  currentStep,
+  mid,
+}: {
+  steps: ExecutionState['steps']
+  progress: CapacityProgress[]
+  currentStep: number
+  mid: number
+}): CapacityProgress | undefined {
+  const currentFrameId = steps[currentStep]?.metadata?.callFrame?.frameId
+  const frameProgress = isInteger(currentFrameId)
+    ? progress.filter((item) => item.frameId === currentFrameId)
+    : []
+  const matchingProgress =
+    frameProgress.length > 0
+      ? frameProgress
+      : progress.filter((item) => item.capacity === mid)
+
+  for (let index = matchingProgress.length - 1; index >= 0; index -= 1) {
+    if (matchingProgress[index].stepIndex <= currentStep) {
+      return matchingProgress[index]
+    }
+  }
+
+  return matchingProgress[0] ?? progress.at(-1)
+}
+
+/** Detects a capacity binary search with an inner package feasibility pass. */
+export function getCapacitySearchTraceCandidate(
+  executionState: ExecutionState
+): CapacitySearchTraceCandidate | undefined {
+  return analyzeCapacityTrace(executionState)?.candidate
+}
+
+/** Resolves capacity-search state nearest to the current playback step. */
+export function getCapacitySearchVisualizationState({
+  executionState,
+  variableName,
+}: {
+  executionState: ExecutionState
+  variableName: string
+}): CapacitySearchVisualizationState | undefined {
+  const analysis = analyzeCapacityTrace(executionState)
+  if (!analysis || analysis.candidate.name !== variableName) return undefined
+
+  const bounds = findBoundsAtStep(
+    executionState.steps,
+    executionState.currentStep,
+    analysis.candidate.stepIndex
+  )
+  if (!bounds) return undefined
+
+  const progress = getProgressAtStep({
+    steps: executionState.steps,
+    progress: analysis.progress,
+    currentStep: executionState.currentStep,
+    mid: bounds.mid,
+  })
+  if (!progress) return undefined
+
+  const fallbackStep = executionState.steps[analysis.candidate.stepIndex]
+  const currentStep = executionState.steps[executionState.currentStep]
+  const targetDaysValue =
+    currentStep?.variables.days ?? fallbackStep.variables.days
+  if (!isInteger(targetDaysValue)) return undefined
+
+  const isConverged = bounds.left === bounds.right
+  const capacity = isConverged ? bounds.left : progress.capacity
+  const packages = getCapacityPackages(analysis.data, capacity)
+  const currentPackage = packages[progress.currentIndex]
+  const finalPackage = packages.at(-1)
+  if (!currentPackage || !finalPackage) return undefined
+
+  return {
+    data: analysis.data,
+    ...bounds,
+    capacity,
+    isConverged,
+    totalWeight: analysis.data.reduce((sum, weight) => sum + weight, 0),
+    targetDays: targetDaysValue,
+    currentIndex: progress.currentIndex,
+    packages,
+    requiredDays: currentPackage.day,
+    currentLoad: currentPackage.load,
+    canShip: finalPackage.day <= targetDaysValue,
+  }
+}

--- a/src/features/visualization/lib/capacity-search-view.ts
+++ b/src/features/visualization/lib/capacity-search-view.ts
@@ -21,7 +21,17 @@ type CapacityProgress = {
 type IndexedCapacityCandidate = {
   candidate: CapacitySearchTraceCandidate
   data: number[]
+  totalWeight: number
+  targetDays: number
   progress: CapacityProgress[]
+}
+
+type InitialCapacityPass = {
+  name: string
+  data: number[]
+  totalWeight: number
+  targetDays: number
+  loopDescription: string
 }
 
 /** Capacity-search trace inferred from a shipping feasibility check. */
@@ -46,8 +56,6 @@ export type CapacityPackageState = {
 
 /** Values displayed by the capacity-search visualization. */
 export type CapacitySearchVisualizationState = {
-  /** Package weights in shipping order. */
-  data: number[]
   /** Current lower capacity bound. */
   left: number
   /** Current upper capacity bound. */
@@ -64,6 +72,8 @@ export type CapacitySearchVisualizationState = {
   targetDays: number
   /** Current package-array index. */
   currentIndex: number
+  /** Weight at the current package-array index. */
+  currentWeight: number
   /** Greedy package placement for the active capacity. */
   packages: CapacityPackageState[]
   /** Number of days needed through the current package. */
@@ -112,88 +122,127 @@ function getCapacityPackages(
   })
 }
 
-function findCandidate(
-  steps: ExecutionState['steps']
-): IndexedCapacityCandidate | undefined {
-  for (let stepIndex = 0; stepIndex < steps.length; stepIndex += 1) {
-    const step = steps[stepIndex]
-    const match = /^for \(\.\.\. of ([A-Za-z_$][\w$]*)\)$/.exec(
-      step.description
-    )
-    if (!match) continue
+function getInitialCapacityPass(
+  step: ExecutionStep
+): InitialCapacityPass | undefined {
+  const match = /^for \(\.\.\. of ([A-Za-z_$][\w$]*)\)$/.exec(step.description)
+  if (!match) return undefined
 
-    const name = match[1]
-    const source = step.variables[name]
-    const bounds = getCapacityBounds(step.variables)
+  const name = match[1]
+  const source = step.variables[name]
+  const bounds = getCapacityBounds(step.variables)
+  const capacity = step.variables.capacity
+  const targetDays = step.variables.days
+  const requiredDays = step.variables.requiredDays
+  const currentLoad = step.variables.current
+  const currentWeight = step.variables.weight
+
+  if (
+    !isNonEmptyNumericArray(source) ||
+    !bounds ||
+    !isNumber(capacity) ||
+    !isInteger(targetDays) ||
+    !isInteger(requiredDays) ||
+    !isNumber(currentLoad) ||
+    !isNumber(currentWeight) ||
+    targetDays <= 0
+  ) {
+    return undefined
+  }
+
+  const data = source.map(Number)
+  const totalWeight = data.reduce((sum, weight) => sum + weight, 0)
+  const maximumWeight = Math.max(...data)
+
+  if (
+    bounds.left !== maximumWeight ||
+    bounds.right !== totalWeight ||
+    bounds.mid !== capacity
+  ) {
+    return undefined
+  }
+
+  return {
+    name,
+    data,
+    totalWeight,
+    targetDays,
+    loopDescription: step.description,
+  }
+}
+
+function collectCapacityProgress({
+  steps,
+  initialStepIndex,
+  initialPass,
+}: {
+  steps: ExecutionState['steps']
+  initialStepIndex: number
+  initialPass: InitialCapacityPass
+}): CapacityProgress[] {
+  const frameIndexes = new Map<number, number>()
+  const progress: CapacityProgress[] = []
+
+  for (
+    let stepIndex = initialStepIndex;
+    stepIndex < steps.length;
+    stepIndex += 1
+  ) {
+    const step = steps[stepIndex]
+    if (step.description !== initialPass.loopDescription) continue
+
+    const loopData = step.variables[initialPass.name]
+    const frameId = step.metadata?.callFrame?.frameId
     const capacity = step.variables.capacity
-    const targetDays = step.variables.days
-    const requiredDays = step.variables.requiredDays
-    const currentLoad = step.variables.current
-    const currentWeight = step.variables.weight
+    const weight = step.variables.weight
 
     if (
-      !isNonEmptyNumericArray(source) ||
-      !bounds ||
+      !isNonEmptyNumericArray(loopData) ||
+      !isInteger(frameId) ||
       !isNumber(capacity) ||
-      !isInteger(targetDays) ||
-      !isInteger(requiredDays) ||
-      !isNumber(currentLoad) ||
-      !isNumber(currentWeight)
+      !isNumber(weight)
     ) {
       continue
     }
 
-    const data = source.map(Number)
-    const totalWeight = data.reduce((sum, weight) => sum + weight, 0)
-    const maximumWeight = Math.max(...data)
-    const isInitialCapacityPass =
-      bounds.left === maximumWeight &&
-      bounds.right === totalWeight &&
-      bounds.mid === capacity
-
-    if (!isInitialCapacityPass || targetDays <= 0) continue
-
-    const loopDescription = step.description
-    const frameIndexes = new Map<number, number>()
-    const progress: CapacityProgress[] = []
-
-    for (let index = stepIndex; index < steps.length; index += 1) {
-      const loopStep = steps[index]
-      if (loopStep.description !== loopDescription) continue
-
-      const loopData = loopStep.variables[name]
-      const frameId = loopStep.metadata?.callFrame?.frameId
-      const loopCapacity = loopStep.variables.capacity
-      const loopWeight = loopStep.variables.weight
-
-      if (
-        !isNonEmptyNumericArray(loopData) ||
-        !isInteger(frameId) ||
-        !isNumber(loopCapacity) ||
-        !isNumber(loopWeight)
-      ) {
-        continue
-      }
-
-      const currentIndex = frameIndexes.get(frameId) ?? 0
-      if (currentIndex >= data.length || data[currentIndex] !== loopWeight) {
-        continue
-      }
-
-      progress.push({
-        stepIndex: index,
-        frameId,
-        capacity: loopCapacity,
-        currentIndex,
-      })
-      frameIndexes.set(frameId, currentIndex + 1)
+    const currentIndex = frameIndexes.get(frameId) ?? 0
+    if (
+      currentIndex >= initialPass.data.length ||
+      initialPass.data[currentIndex] !== weight
+    ) {
+      continue
     }
+
+    progress.push({ stepIndex, frameId, capacity, currentIndex })
+    frameIndexes.set(frameId, currentIndex + 1)
+  }
+
+  return progress
+}
+
+function findCandidate(
+  steps: ExecutionState['steps']
+): IndexedCapacityCandidate | undefined {
+  for (let stepIndex = 0; stepIndex < steps.length; stepIndex += 1) {
+    const initialPass = getInitialCapacityPass(steps[stepIndex])
+    if (!initialPass) continue
+
+    const progress = collectCapacityProgress({
+      steps,
+      initialStepIndex: stepIndex,
+      initialPass,
+    })
 
     if (progress.length === 0) continue
 
     return {
-      candidate: { name, stepIndex: progress[0].stepIndex },
-      data,
+      candidate: {
+        name: initialPass.name,
+        stepIndex: progress[0].stepIndex,
+      },
+      data: initialPass.data,
+      totalWeight: initialPass.totalWeight,
+      targetDays: initialPass.targetDays,
       progress,
     }
   }
@@ -287,30 +336,27 @@ export function getCapacitySearchVisualizationState({
   })
   if (!progress) return undefined
 
-  const fallbackStep = executionState.steps[analysis.candidate.stepIndex]
-  const currentStep = executionState.steps[executionState.currentStep]
-  const targetDaysValue =
-    currentStep?.variables.days ?? fallbackStep.variables.days
-  if (!isInteger(targetDaysValue)) return undefined
-
   const isConverged = bounds.left === bounds.right
   const capacity = isConverged ? bounds.left : progress.capacity
+  const currentIndex = isConverged
+    ? analysis.data.length - 1
+    : progress.currentIndex
   const packages = getCapacityPackages(analysis.data, capacity)
-  const currentPackage = packages[progress.currentIndex]
+  const currentPackage = packages[currentIndex]
   const finalPackage = packages.at(-1)
   if (!currentPackage || !finalPackage) return undefined
 
   return {
-    data: analysis.data,
     ...bounds,
     capacity,
     isConverged,
-    totalWeight: analysis.data.reduce((sum, weight) => sum + weight, 0),
-    targetDays: targetDaysValue,
-    currentIndex: progress.currentIndex,
+    totalWeight: analysis.totalWeight,
+    targetDays: analysis.targetDays,
+    currentIndex,
+    currentWeight: currentPackage.weight,
     packages,
     requiredDays: currentPackage.day,
     currentLoad: currentPackage.load,
-    canShip: finalPackage.day <= targetDaysValue,
+    canShip: finalPackage.day <= analysis.targetDays,
   }
 }

--- a/src/features/visualization/lib/capacity-search-view.ts
+++ b/src/features/visualization/lib/capacity-search-view.ts
@@ -54,8 +54,7 @@ export type CapacityPackageState = {
   load: number
 }
 
-/** Values displayed by the capacity-search visualization. */
-export type CapacitySearchVisualizationState = {
+type CapacitySearchVisualizationStateBase = {
   /** Current lower capacity bound. */
   left: number
   /** Current upper capacity bound. */
@@ -70,19 +69,37 @@ export type CapacitySearchVisualizationState = {
   totalWeight: number
   /** Maximum allowed shipping days. */
   targetDays: number
-  /** Current package-array index. */
-  currentIndex: number
-  /** Weight at the current package-array index. */
-  currentWeight: number
   /** Greedy package placement for the active capacity. */
   packages: CapacityPackageState[]
-  /** Number of days needed through the current package. */
-  requiredDays: number
-  /** Current day's load after the current package. */
-  currentLoad: number
   /** Whether the active capacity can ship every package in time. */
   canShip: boolean
 }
+
+/** Values displayed by the capacity-search visualization. */
+export type CapacitySearchVisualizationState =
+  CapacitySearchVisualizationStateBase &
+    (
+      | {
+          /** No package iteration has executed for the candidate capacity. */
+          phase: 'pending'
+          currentIndex?: never
+          currentWeight?: never
+          requiredDays: 0
+          currentLoad: 0
+        }
+      | {
+          /** Package iterations are being evaluated or the search has converged. */
+          phase: 'checking' | 'complete'
+          /** Current package-array index. */
+          currentIndex: number
+          /** Weight at the current package-array index. */
+          currentWeight: number
+          /** Number of days needed through the current package. */
+          requiredDays: number
+          /** Current day's load after the current package. */
+          currentLoad: number
+        }
+    )
 
 const analysisCache = new WeakMap<
   ExecutionState['steps'],
@@ -300,7 +317,7 @@ function getProgressAtStep({
     }
   }
 
-  return matchingProgress[0] ?? progress.at(-1)
+  return undefined
 }
 
 /** Detects a capacity binary search with an inner package feasibility pass. */
@@ -334,29 +351,48 @@ export function getCapacitySearchVisualizationState({
     currentStep: executionState.currentStep,
     mid: bounds.mid,
   })
-  if (!progress) return undefined
 
   const isConverged = bounds.left === bounds.right
-  const capacity = isConverged ? bounds.left : progress.capacity
-  const currentIndex = isConverged
-    ? analysis.data.length - 1
-    : progress.currentIndex
+  const capacity = isConverged
+    ? bounds.left
+    : (progress?.capacity ?? bounds.mid)
   const packages = getCapacityPackages(analysis.data, capacity)
-  const currentPackage = packages[currentIndex]
   const finalPackage = packages.at(-1)
-  if (!currentPackage || !finalPackage) return undefined
+  if (!finalPackage) return undefined
 
-  return {
+  const baseState: CapacitySearchVisualizationStateBase = {
     ...bounds,
     capacity,
     isConverged,
     totalWeight: analysis.totalWeight,
     targetDays: analysis.targetDays,
+    packages,
+    canShip: finalPackage.day <= analysis.targetDays,
+  }
+
+  if (!progress && !isConverged) {
+    return {
+      ...baseState,
+      phase: 'pending',
+      requiredDays: 0,
+      currentLoad: 0,
+    }
+  }
+
+  const currentIndex = isConverged
+    ? analysis.data.length - 1
+    : progress?.currentIndex
+  if (!isInteger(currentIndex)) return undefined
+
+  const currentPackage = packages[currentIndex]
+  if (!currentPackage) return undefined
+
+  return {
+    ...baseState,
+    phase: isConverged ? 'complete' : 'checking',
     currentIndex,
     currentWeight: currentPackage.weight,
-    packages,
     requiredDays: currentPackage.day,
     currentLoad: currentPackage.load,
-    canShip: finalPackage.day <= analysis.targetDays,
   }
 }

--- a/src/features/visualization/model/primary-visualization.test.ts
+++ b/src/features/visualization/model/primary-visualization.test.ts
@@ -19,6 +19,8 @@ const emptyDetection: VisualizationDetection = {
   primaryMaxSubarrayStepIndex: undefined,
   primaryStockProfitArrayName: undefined,
   primaryStockProfitStepIndex: undefined,
+  primaryCapacitySearchArrayName: undefined,
+  primaryCapacitySearchStepIndex: undefined,
   primaryBinarySearchArrayName: undefined,
   primaryBinarySearchStepIndex: undefined,
   primarySlidingWindowStringName: undefined,
@@ -130,6 +132,22 @@ describe('getPrimaryVisualization', () => {
       type: 'stock-profit',
       targetVariable: 'prices',
       targetStepIndex: 4,
+    })
+  })
+
+  it('selects capacity-search state instead of a generic index view', () => {
+    expect(
+      getPrimaryVisualization({
+        ...emptyDetection,
+        primaryCapacitySearchArrayName: 'weights',
+        primaryCapacitySearchStepIndex: 5,
+        primaryBinarySearchArrayName: 'weights',
+        primaryBinarySearchStepIndex: 5,
+      })
+    ).toEqual({
+      type: 'capacity-search',
+      targetVariable: 'weights',
+      targetStepIndex: 5,
     })
   })
 

--- a/src/features/visualization/model/primary-visualization.ts
+++ b/src/features/visualization/model/primary-visualization.ts
@@ -62,6 +62,14 @@ export function getPrimaryVisualization(
     }
   }
 
+  if (detection.primaryCapacitySearchArrayName) {
+    return {
+      type: 'capacity-search',
+      targetVariable: detection.primaryCapacitySearchArrayName,
+      targetStepIndex: detection.primaryCapacitySearchStepIndex,
+    }
+  }
+
   if (detection.primaryBinarySearchArrayName) {
     return {
       type: 'binary-search',

--- a/src/features/visualization/model/types.ts
+++ b/src/features/visualization/model/types.ts
@@ -10,6 +10,7 @@ export type VisualizationType =
   | 'area'
   | 'max-subarray'
   | 'stock-profit'
+  | 'capacity-search'
   | 'binary-search'
   | 'sliding-window'
   | 'bar-chart'

--- a/src/features/visualization/model/visualization-detection/detect-visualization-state.ts
+++ b/src/features/visualization/model/visualization-detection/detect-visualization-state.ts
@@ -98,9 +98,12 @@ export function detectVisualizationState(
           metadata.mutatedNumericArrayNames
         )
       : undefined)
+  const primaryCapacitySearchCandidate =
+    getPrimaryCapacitySearchCandidate(executionState)
   const primaryBinarySearchCandidate = getPrimaryBinarySearchCandidate(
     executionState,
-    initialVariableNames
+    initialVariableNames,
+    primaryCapacitySearchCandidate?.name
   )
   const primaryAreaCandidate = getPrimaryAreaCandidate(
     executionState,
@@ -110,8 +113,6 @@ export function detectVisualizationState(
     getPrimaryMaxSubarrayCandidate(executionState)
   const primaryStockProfitCandidate =
     getPrimaryStockProfitCandidate(executionState)
-  const primaryCapacitySearchCandidate =
-    getPrimaryCapacitySearchCandidate(executionState)
   const primarySlidingWindowCandidate =
     getPrimarySlidingWindowCandidate(executionState)
   const primaryDpName =

--- a/src/features/visualization/model/visualization-detection/detect-visualization-state.ts
+++ b/src/features/visualization/model/visualization-detection/detect-visualization-state.ts
@@ -13,6 +13,7 @@ import {
 import {
   getPrimaryAreaCandidate,
   getPrimaryBinarySearchCandidate,
+  getPrimaryCapacitySearchCandidate,
   getPrimaryMaxSubarrayCandidate,
   getPrimaryRollingDpName,
   getPrimarySlidingWindowCandidate,
@@ -109,6 +110,8 @@ export function detectVisualizationState(
     getPrimaryMaxSubarrayCandidate(executionState)
   const primaryStockProfitCandidate =
     getPrimaryStockProfitCandidate(executionState)
+  const primaryCapacitySearchCandidate =
+    getPrimaryCapacitySearchCandidate(executionState)
   const primarySlidingWindowCandidate =
     getPrimarySlidingWindowCandidate(executionState)
   const primaryDpName =
@@ -169,6 +172,8 @@ export function detectVisualizationState(
     primaryMaxSubarrayStepIndex: primaryMaxSubarrayCandidate?.stepIndex,
     primaryStockProfitArrayName: primaryStockProfitCandidate?.name,
     primaryStockProfitStepIndex: primaryStockProfitCandidate?.stepIndex,
+    primaryCapacitySearchArrayName: primaryCapacitySearchCandidate?.name,
+    primaryCapacitySearchStepIndex: primaryCapacitySearchCandidate?.stepIndex,
     primaryBinarySearchArrayName: primaryBinarySearchCandidate?.name,
     primaryBinarySearchStepIndex: primaryBinarySearchCandidate?.stepIndex,
     primarySlidingWindowStringName: primarySlidingWindowCandidate?.name,

--- a/src/features/visualization/model/visualization-detection/indexed-candidates.ts
+++ b/src/features/visualization/model/visualization-detection/indexed-candidates.ts
@@ -1,5 +1,6 @@
 import type { ExecutionState } from '@/entities/execution'
 import { isBinarySearchArrayCandidate } from '../../lib/binary-search-view'
+import { getCapacitySearchTraceCandidate } from '../../lib/capacity-search-view'
 import {
   isAreaViewCandidate,
   isHistogramAreaCandidate,
@@ -45,6 +46,16 @@ export function getPrimaryStockProfitCandidate(
   executionState: ExecutionState
 ): IndexedVariableCandidate | undefined {
   const candidate = getStockProfitTraceCandidate(executionState)
+
+  return candidate
+    ? { name: candidate.name, stepIndex: candidate.stepIndex }
+    : undefined
+}
+
+export function getPrimaryCapacitySearchCandidate(
+  executionState: ExecutionState
+): IndexedVariableCandidate | undefined {
+  const candidate = getCapacitySearchTraceCandidate(executionState)
 
   return candidate
     ? { name: candidate.name, stepIndex: candidate.stepIndex }

--- a/src/features/visualization/model/visualization-detection/indexed-candidates.ts
+++ b/src/features/visualization/model/visualization-detection/indexed-candidates.ts
@@ -18,7 +18,8 @@ import {
 
 export function getPrimaryBinarySearchCandidate(
   executionState: ExecutionState,
-  initialVariableNames: Set<string>
+  initialVariableNames: Set<string>,
+  excludedArrayName?: string
 ): IndexedVariableCandidate | undefined {
   return findIndexedVariableCandidate(
     executionState,
@@ -27,6 +28,7 @@ export function getPrimaryBinarySearchCandidate(
       preferPastSteps: true,
     }),
     (name, value, variables) =>
+      name !== excludedArrayName &&
       initialVariableNames.has(name) &&
       isBinarySearchArrayCandidate(name, value, variables)
   )

--- a/src/features/visualization/model/visualization-detection/types.ts
+++ b/src/features/visualization/model/visualization-detection/types.ts
@@ -31,6 +31,10 @@ export type VisualizationDetection = {
   primaryStockProfitArrayName: string | undefined
   /** Step index where initialized stock-profit state is available. */
   primaryStockProfitStepIndex: number | undefined
+  /** Primary package-weight array used by a capacity binary search. */
+  primaryCapacitySearchArrayName: string | undefined
+  /** Step index where package-capacity state is first available. */
+  primaryCapacitySearchStepIndex: number | undefined
   /** Primary numeric array to show in binary-search index view. */
   primaryBinarySearchArrayName: string | undefined
   /** Step index where binary-search indexes are available. */

--- a/src/features/visualization/ui/binary-search-visualizer.test.tsx
+++ b/src/features/visualization/ui/binary-search-visualizer.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vite-plus/test'
+import { BinarySearchVisualizer } from './binary-search-visualizer'
+
+describe('BinarySearchVisualizer', () => {
+  it('excludes the right boundary from half-open search ranges', () => {
+    render(
+      <BinarySearchVisualizer
+        data={[1, 3, 5, 7, 9, 11]}
+        name="values"
+        indexState={{ left: 1, right: 4, mid: 2 }}
+        rangeMode="half-open"
+      />
+    )
+
+    expect(screen.getByText('right (exclusive): 4')).toBeVisible()
+    expect(screen.getByLabelText('Index 3: value 7, in range')).toBeVisible()
+    expect(
+      screen.getByLabelText('Index 4: value 9, out of range')
+    ).toBeVisible()
+  })
+
+  it('shows an empty range when half-open bounds converge', () => {
+    render(
+      <BinarySearchVisualizer
+        data={[1, 3, 5, 7, 9, 11]}
+        name="values"
+        indexState={{ left: 4, right: 4, mid: 3 }}
+        rangeMode="half-open"
+      />
+    )
+
+    expect(
+      screen.getByLabelText('Index 4: value 9, out of range')
+    ).toBeVisible()
+  })
+})

--- a/src/features/visualization/ui/binary-search-visualizer.tsx
+++ b/src/features/visualization/ui/binary-search-visualizer.tsx
@@ -1,5 +1,8 @@
 import { Card } from '@/shared/ui'
-import type { BinarySearchIndexState } from '../lib/binary-search-view'
+import type {
+  BinarySearchIndexState,
+  BinarySearchRangeMode,
+} from '../lib/binary-search-view'
 
 type BinarySearchVisualizerProps = {
   /** Numeric array being searched. */
@@ -8,13 +11,21 @@ type BinarySearchVisualizerProps = {
   name: string
   /** Current left/right/mid index state. */
   indexState: BinarySearchIndexState
+  /** Whether the right boundary is included in the active range. */
+  rangeMode: BinarySearchRangeMode
 }
 
-function getClampedRange(indexState: BinarySearchIndexState, length: number) {
-  if (indexState.left > indexState.right) return null
+function getClampedRange(
+  indexState: BinarySearchIndexState,
+  length: number,
+  rangeMode: BinarySearchRangeMode
+) {
+  const inclusiveRight =
+    rangeMode === 'half-open' ? indexState.right - 1 : indexState.right
+  if (indexState.left > inclusiveRight) return null
 
   const left = Math.max(0, Math.min(indexState.left, length - 1))
-  const right = Math.max(0, Math.min(indexState.right, length - 1))
+  const right = Math.max(0, Math.min(inclusiveRight, length - 1))
 
   return left <= right ? { left, right } : null
 }
@@ -23,8 +34,9 @@ export function BinarySearchVisualizer({
   data,
   name,
   indexState,
+  rangeMode,
 }: BinarySearchVisualizerProps) {
-  const activeRange = getClampedRange(indexState, data.length)
+  const activeRange = getClampedRange(indexState, data.length, rangeMode)
 
   return (
     <Card className="h-full border-0 shadow-none">
@@ -38,7 +50,8 @@ export function BinarySearchVisualizer({
               left: {indexState.left}
             </span>
             <span className="border border-primary px-2 py-1">
-              right: {indexState.right}
+              right{rangeMode === 'half-open' ? ' (exclusive)' : ''}:{' '}
+              {indexState.right}
             </span>
             <span className="border border-primary px-2 py-1">
               mid: {indexState.mid ?? '-'}
@@ -65,6 +78,7 @@ export function BinarySearchVisualizer({
               return (
                 <div key={index} className="flex flex-col items-center gap-2">
                   <div
+                    aria-label={`Index ${index}: value ${value}, ${isMid ? 'midpoint' : isInRange ? 'in range' : 'out of range'}`}
                     className={[
                       'flex h-14 w-full min-w-14 items-center justify-center border font-mono text-base font-bold transition-colors',
                       isMid

--- a/src/features/visualization/ui/binary-search-visualizer.tsx
+++ b/src/features/visualization/ui/binary-search-visualizer.tsx
@@ -11,6 +11,8 @@ type BinarySearchVisualizerProps = {
 }
 
 function getClampedRange(indexState: BinarySearchIndexState, length: number) {
+  if (indexState.left > indexState.right) return null
+
   const left = Math.max(0, Math.min(indexState.left, length - 1))
   const right = Math.max(0, Math.min(indexState.right, length - 1))
 

--- a/src/features/visualization/ui/capacity-search-visualizer.test.tsx
+++ b/src/features/visualization/ui/capacity-search-visualizer.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vite-plus/test'
+import { CapacitySearchVisualizer } from './capacity-search-visualizer'
+
+describe('CapacitySearchVisualizer', () => {
+  it('shows capacity bounds, total weight, and the current package index', () => {
+    render(
+      <CapacitySearchVisualizer
+        name="weights"
+        state={{
+          data: [1, 2, 3, 4, 5],
+          left: 10,
+          right: 10,
+          mid: 9,
+          capacity: 10,
+          isConverged: true,
+          totalWeight: 15,
+          targetDays: 2,
+          currentIndex: 3,
+          packages: [
+            { index: 0, weight: 1, day: 1, load: 1 },
+            { index: 1, weight: 2, day: 1, load: 3 },
+            { index: 2, weight: 3, day: 1, load: 6 },
+            { index: 3, weight: 4, day: 1, load: 10 },
+            { index: 4, weight: 5, day: 2, load: 5 },
+          ],
+          requiredDays: 1,
+          currentLoad: 10,
+          canShip: true,
+        }}
+      />
+    )
+
+    expect(screen.getByText('max weight → total weight (15)')).toBeVisible()
+    expect(screen.getByText('result · capacity')).toBeVisible()
+    expect(screen.queryByText('mid · capacity')).not.toBeInTheDocument()
+    expect(screen.getByText('10 / 10')).toBeVisible()
+    expect(screen.getByText('1 / 2')).toBeVisible()
+    expect(screen.getByText('fits')).toBeVisible()
+    expect(
+      screen.getByRole('listitem', { current: 'step' })
+    ).toHaveAccessibleName('Index 3: weight 4, day 1, current')
+    expect(screen.getByText('weights[3] = 4 · day 1 load = 10')).toBeVisible()
+  })
+})

--- a/src/features/visualization/ui/capacity-search-visualizer.test.tsx
+++ b/src/features/visualization/ui/capacity-search-visualizer.test.tsx
@@ -8,7 +8,6 @@ describe('CapacitySearchVisualizer', () => {
       <CapacitySearchVisualizer
         name="weights"
         state={{
-          data: [1, 2, 3, 4, 5],
           left: 10,
           right: 10,
           mid: 9,
@@ -17,6 +16,7 @@ describe('CapacitySearchVisualizer', () => {
           totalWeight: 15,
           targetDays: 2,
           currentIndex: 3,
+          currentWeight: 4,
           packages: [
             { index: 0, weight: 1, day: 1, load: 1 },
             { index: 1, weight: 2, day: 1, load: 3 },

--- a/src/features/visualization/ui/capacity-search-visualizer.test.tsx
+++ b/src/features/visualization/ui/capacity-search-visualizer.test.tsx
@@ -13,6 +13,7 @@ describe('CapacitySearchVisualizer', () => {
           mid: 9,
           capacity: 10,
           isConverged: true,
+          phase: 'complete',
           totalWeight: 15,
           targetDays: 2,
           currentIndex: 3,
@@ -41,5 +42,40 @@ describe('CapacitySearchVisualizer', () => {
       screen.getByRole('listitem', { current: 'step' })
     ).toHaveAccessibleName('Index 3: weight 4, day 1, current')
     expect(screen.getByText('weights[3] = 4 · day 1 load = 10')).toBeVisible()
+  })
+
+  it('shows a pending state before the first package iteration', () => {
+    render(
+      <CapacitySearchVisualizer
+        name="weights"
+        state={{
+          left: 10,
+          right: 55,
+          mid: 32,
+          capacity: 32,
+          isConverged: false,
+          phase: 'pending',
+          totalWeight: 55,
+          targetDays: 5,
+          packages: [
+            { index: 0, weight: 1, day: 1, load: 1 },
+            { index: 1, weight: 2, day: 1, load: 3 },
+          ],
+          requiredDays: 0,
+          currentLoad: 0,
+          canShip: true,
+        }}
+      />
+    )
+
+    expect(screen.getByText('0 / 32')).toBeVisible()
+    expect(screen.getByText('0 / 5')).toBeVisible()
+    expect(screen.getByText('pending')).toBeVisible()
+    expect(
+      screen.queryByRole('listitem', { current: 'step' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText('Waiting for the first package iteration')
+    ).toBeVisible()
   })
 })

--- a/src/features/visualization/ui/capacity-search-visualizer.tsx
+++ b/src/features/visualization/ui/capacity-search-visualizer.tsx
@@ -37,6 +37,37 @@ function Metric({
   )
 }
 
+function CapacityBound({
+  label,
+  value,
+  emphasized = false,
+}: {
+  label: string
+  value: number
+  emphasized?: boolean
+}) {
+  return (
+    <div
+      className={[
+        'rounded border px-2 py-2',
+        emphasized
+          ? 'border-primary bg-primary/10 font-bold text-primary'
+          : 'border-border bg-background',
+      ].join(' ')}
+    >
+      <span
+        className={[
+          'block text-[0.6875rem]',
+          emphasized ? '' : 'text-muted-foreground',
+        ].join(' ')}
+      >
+        {label}
+      </span>
+      {value}
+    </div>
+  )
+}
+
 function getPackageClass(
   packageState: CapacityPackageState,
   currentIndex: number
@@ -48,6 +79,45 @@ function getPackageClass(
     return 'border-primary/30 bg-primary/5 text-foreground'
   }
   return 'border-border bg-muted/30 text-muted-foreground'
+}
+
+function PackageProgressItem({
+  packageState,
+  previousDay,
+  currentIndex,
+}: {
+  packageState: CapacityPackageState
+  previousDay?: number
+  currentIndex: number
+}) {
+  const isCurrent = packageState.index === currentIndex
+  const startsDay = previousDay !== packageState.day
+
+  return (
+    <li
+      aria-current={isCurrent ? 'step' : undefined}
+      aria-label={`Index ${packageState.index}: weight ${packageState.weight}, day ${packageState.day}${isCurrent ? ', current' : ''}`}
+      className={[
+        'relative flex flex-col items-center gap-1',
+        startsDay ? 'ml-3 border-l border-dashed border-primary pl-3' : '',
+      ].join(' ')}
+    >
+      <span className="absolute -top-6 whitespace-nowrap font-mono text-[0.6875rem] font-semibold text-primary">
+        {startsDay ? `day ${packageState.day}` : ''}
+      </span>
+      <div
+        className={[
+          'flex h-14 w-14 items-center justify-center rounded-md border-2 font-mono text-base transition-colors',
+          getPackageClass(packageState, currentIndex),
+        ].join(' ')}
+      >
+        {packageState.weight}
+      </div>
+      <span className="font-mono text-xs text-muted-foreground">
+        {packageState.index}
+      </span>
+    </li>
+  )
 }
 
 export function CapacitySearchVisualizer({
@@ -72,24 +142,13 @@ export function CapacitySearchVisualizer({
             </span>
           </div>
           <div className="grid grid-cols-3 gap-2 text-center font-mono">
-            <div className="rounded border border-border bg-background px-2 py-2">
-              <span className="block text-[0.6875rem] text-muted-foreground">
-                left
-              </span>
-              {state.left}
-            </div>
-            <div className="rounded border border-primary bg-primary/10 px-2 py-2 font-bold text-primary">
-              <span className="block text-[0.6875rem]">
-                {state.isConverged ? 'result · capacity' : 'mid · capacity'}
-              </span>
-              {state.capacity}
-            </div>
-            <div className="rounded border border-border bg-background px-2 py-2">
-              <span className="block text-[0.6875rem] text-muted-foreground">
-                right
-              </span>
-              {state.right}
-            </div>
+            <CapacityBound label="left" value={state.left} />
+            <CapacityBound
+              label={state.isConverged ? 'result · capacity' : 'mid · capacity'}
+              value={state.capacity}
+              emphasized
+            />
+            <CapacityBound label="right" value={state.right} />
           </div>
         </div>
 
@@ -112,46 +171,19 @@ export function CapacitySearchVisualizer({
             aria-label={`${name} capacity progress`}
             className="flex min-w-max gap-2 pt-6"
           >
-            {state.packages.map((packageState) => {
-              const isCurrent = packageState.index === state.currentIndex
-              const startsDay =
-                packageState.index === 0 ||
-                state.packages[packageState.index - 1]?.day !== packageState.day
-
-              return (
-                <li
-                  key={packageState.index}
-                  aria-current={isCurrent ? 'step' : undefined}
-                  aria-label={`Index ${packageState.index}: weight ${packageState.weight}, day ${packageState.day}${isCurrent ? ', current' : ''}`}
-                  className={[
-                    'relative flex flex-col items-center gap-1',
-                    startsDay
-                      ? 'ml-3 border-l border-dashed border-primary pl-3'
-                      : '',
-                  ].join(' ')}
-                >
-                  <span className="absolute -top-6 whitespace-nowrap font-mono text-[0.6875rem] font-semibold text-primary">
-                    {startsDay ? `day ${packageState.day}` : ''}
-                  </span>
-                  <div
-                    className={[
-                      'flex h-14 w-14 items-center justify-center rounded-md border-2 font-mono text-base transition-colors',
-                      getPackageClass(packageState, state.currentIndex),
-                    ].join(' ')}
-                  >
-                    {packageState.weight}
-                  </div>
-                  <span className="font-mono text-xs text-muted-foreground">
-                    {packageState.index}
-                  </span>
-                </li>
-              )
-            })}
+            {state.packages.map((packageState) => (
+              <PackageProgressItem
+                key={packageState.index}
+                packageState={packageState}
+                previousDay={state.packages[packageState.index - 1]?.day}
+                currentIndex={state.currentIndex}
+              />
+            ))}
           </ol>
         </div>
 
         <div className="rounded-md bg-muted/40 px-3 py-2 font-mono text-xs text-muted-foreground">
-          {name}[{state.currentIndex}] = {state.data[state.currentIndex]} · day{' '}
+          {name}[{state.currentIndex}] = {state.currentWeight} · day{' '}
           {state.requiredDays} load = {state.currentLoad}
         </div>
       </div>

--- a/src/features/visualization/ui/capacity-search-visualizer.tsx
+++ b/src/features/visualization/ui/capacity-search-visualizer.tsx
@@ -1,0 +1,160 @@
+import { Card } from '@/shared/ui'
+import type {
+  CapacityPackageState,
+  CapacitySearchVisualizationState,
+} from '../lib/capacity-search-view'
+
+type CapacitySearchVisualizerProps = {
+  /** Package-array variable name. */
+  name: string
+  /** Current capacity-search state. */
+  state: CapacitySearchVisualizationState
+}
+
+function Metric({
+  label,
+  value,
+  emphasized = false,
+}: {
+  label: string
+  value: string
+  emphasized?: boolean
+}) {
+  return (
+    <div
+      className={[
+        'min-w-32 rounded-md border px-3 py-2',
+        emphasized
+          ? 'border-primary/50 bg-primary/10'
+          : 'border-border bg-muted/30',
+      ].join(' ')}
+    >
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <strong className="mt-1 block font-mono text-lg text-foreground">
+        {value}
+      </strong>
+    </div>
+  )
+}
+
+function getPackageClass(
+  packageState: CapacityPackageState,
+  currentIndex: number
+): string {
+  if (packageState.index === currentIndex) {
+    return 'border-primary bg-primary text-primary-foreground shadow-sm'
+  }
+  if (packageState.index < currentIndex) {
+    return 'border-primary/30 bg-primary/5 text-foreground'
+  }
+  return 'border-border bg-muted/30 text-muted-foreground'
+}
+
+export function CapacitySearchVisualizer({
+  name,
+  state,
+}: CapacitySearchVisualizerProps) {
+  const status = state.canShip ? 'fits' : 'needs more days'
+
+  return (
+    <Card className="w-full border-0 shadow-none">
+      <div className="flex flex-col gap-5 p-4">
+        <p className="text-xs text-muted-foreground">
+          Binary-search the ship capacity, then greedily load packages in their
+          original order.
+        </p>
+
+        <div className="rounded-md border border-border bg-muted/20 p-3">
+          <div className="mb-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+            <span>Capacity search range</span>
+            <span className="font-mono">
+              max weight → total weight ({state.totalWeight})
+            </span>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-center font-mono">
+            <div className="rounded border border-border bg-background px-2 py-2">
+              <span className="block text-[0.6875rem] text-muted-foreground">
+                left
+              </span>
+              {state.left}
+            </div>
+            <div className="rounded border border-primary bg-primary/10 px-2 py-2 font-bold text-primary">
+              <span className="block text-[0.6875rem]">
+                {state.isConverged ? 'result · capacity' : 'mid · capacity'}
+              </span>
+              {state.capacity}
+            </div>
+            <div className="rounded border border-border bg-background px-2 py-2">
+              <span className="block text-[0.6875rem] text-muted-foreground">
+                right
+              </span>
+              {state.right}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Metric label="Total weight" value={String(state.totalWeight)} />
+          <Metric
+            label="Current load"
+            value={`${state.currentLoad} / ${state.capacity}`}
+            emphasized
+          />
+          <Metric
+            label="Days used"
+            value={`${state.requiredDays} / ${state.targetDays}`}
+          />
+          <Metric label="Feasibility" value={status} />
+        </div>
+
+        <div className="min-w-0 overflow-x-auto pb-2">
+          <ol
+            aria-label={`${name} capacity progress`}
+            className="flex min-w-max gap-2 pt-6"
+          >
+            {state.packages.map((packageState) => {
+              const isCurrent = packageState.index === state.currentIndex
+              const startsDay =
+                packageState.index === 0 ||
+                state.packages[packageState.index - 1]?.day !== packageState.day
+
+              return (
+                <li
+                  key={packageState.index}
+                  aria-current={isCurrent ? 'step' : undefined}
+                  aria-label={`Index ${packageState.index}: weight ${packageState.weight}, day ${packageState.day}${isCurrent ? ', current' : ''}`}
+                  className={[
+                    'relative flex flex-col items-center gap-1',
+                    startsDay
+                      ? 'ml-3 border-l border-dashed border-primary pl-3'
+                      : '',
+                  ].join(' ')}
+                >
+                  <span className="absolute -top-6 whitespace-nowrap font-mono text-[0.6875rem] font-semibold text-primary">
+                    {startsDay ? `day ${packageState.day}` : ''}
+                  </span>
+                  <div
+                    className={[
+                      'flex h-14 w-14 items-center justify-center rounded-md border-2 font-mono text-base transition-colors',
+                      getPackageClass(packageState, state.currentIndex),
+                    ].join(' ')}
+                  >
+                    {packageState.weight}
+                  </div>
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {packageState.index}
+                  </span>
+                </li>
+              )
+            })}
+          </ol>
+        </div>
+
+        <div className="rounded-md bg-muted/40 px-3 py-2 font-mono text-xs text-muted-foreground">
+          {name}[{state.currentIndex}] = {state.data[state.currentIndex]} · day{' '}
+          {state.requiredDays} load = {state.currentLoad}
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/features/visualization/ui/capacity-search-visualizer.tsx
+++ b/src/features/visualization/ui/capacity-search-visualizer.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@/shared/ui'
+import { isUndefined } from '@/shared/lib/guards'
 import type {
   CapacityPackageState,
   CapacitySearchVisualizationState,
@@ -70,8 +71,11 @@ function CapacityBound({
 
 function getPackageClass(
   packageState: CapacityPackageState,
-  currentIndex: number
+  currentIndex?: number
 ): string {
+  if (isUndefined(currentIndex)) {
+    return 'border-border bg-muted/30 text-muted-foreground'
+  }
   if (packageState.index === currentIndex) {
     return 'border-primary bg-primary text-primary-foreground shadow-sm'
   }
@@ -88,9 +92,10 @@ function PackageProgressItem({
 }: {
   packageState: CapacityPackageState
   previousDay?: number
-  currentIndex: number
+  currentIndex?: number
 }) {
-  const isCurrent = packageState.index === currentIndex
+  const isCurrent =
+    !isUndefined(currentIndex) && packageState.index === currentIndex
   const startsDay = previousDay !== packageState.day
 
   return (
@@ -124,7 +129,12 @@ export function CapacitySearchVisualizer({
   name,
   state,
 }: CapacitySearchVisualizerProps) {
-  const status = state.canShip ? 'fits' : 'needs more days'
+  const status =
+    state.phase === 'pending'
+      ? 'pending'
+      : state.canShip
+        ? 'fits'
+        : 'needs more days'
 
   return (
     <Card className="w-full border-0 shadow-none">
@@ -183,8 +193,9 @@ export function CapacitySearchVisualizer({
         </div>
 
         <div className="rounded-md bg-muted/40 px-3 py-2 font-mono text-xs text-muted-foreground">
-          {name}[{state.currentIndex}] = {state.currentWeight} · day{' '}
-          {state.requiredDays} load = {state.currentLoad}
+          {state.phase === 'pending'
+            ? 'Waiting for the first package iteration'
+            : `${name}[${state.currentIndex}] = ${state.currentWeight} · day ${state.requiredDays} load = ${state.currentLoad}`}
         </div>
       </div>
     </Card>

--- a/src/features/visualization/ui/variables-card.tsx
+++ b/src/features/visualization/ui/variables-card.tsx
@@ -62,6 +62,10 @@ type VariablesCardProps = {
   primaryStockProfitArrayName?: string
   /** Step index where stock-profit state is available. */
   primaryStockProfitStepIndex?: number
+  /** Primary package-weight array detected for capacity-search visualization. */
+  primaryCapacitySearchArrayName?: string
+  /** Step index where package-capacity state is available. */
+  primaryCapacitySearchStepIndex?: number
   /** Primary numeric array detected for binary-search index visualization. */
   primaryBinarySearchArrayName?: string
   /** Step index where binary-search indexes are available. */
@@ -115,6 +119,8 @@ export function VariablesCard({
   primaryMaxSubarrayStepIndex,
   primaryStockProfitArrayName,
   primaryStockProfitStepIndex,
+  primaryCapacitySearchArrayName,
+  primaryCapacitySearchStepIndex,
   primaryBinarySearchArrayName,
   primaryBinarySearchStepIndex,
   primarySlidingWindowStringName,
@@ -279,6 +285,23 @@ export function VariablesCard({
             >
               <BarChart2 className="w-4 h-4" />
               Stock Profit View
+            </Button>
+          )}
+          {primaryCapacitySearchArrayName && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={() =>
+                onOpenVisualization(
+                  'capacity-search',
+                  primaryCapacitySearchArrayName,
+                  primaryCapacitySearchStepIndex
+                )
+              }
+            >
+              <Search className="w-4 h-4" />
+              Capacity View
             </Button>
           )}
           {primaryBinarySearchArrayName && (

--- a/src/features/visualization/ui/visualization-modal-content.tsx
+++ b/src/features/visualization/ui/visualization-modal-content.tsx
@@ -17,6 +17,7 @@ import {
 import { safeStringify } from '@/shared/lib/safe-stringify'
 import {
   getBinarySearchIndexState,
+  getBinarySearchRangeMode,
   isBinarySearchArrayCandidate,
 } from '../lib/binary-search-view'
 import { getAreaVisualizationState } from '../lib/area-view'
@@ -353,12 +354,14 @@ export function VisualizationModalContent({
       const indexState = getBinarySearchIndexState(
         binarySearchStep?.variables ?? {}
       )
+      const rangeMode = getBinarySearchRangeMode(executionState, targetVariable)
 
       return isNumericArray(data) && indexState ? (
         <BinarySearchVisualizer
           data={data.map((value) => Number(value))}
           name={targetVariable}
           indexState={indexState}
+          rangeMode={rangeMode}
         />
       ) : (
         <div>Binary search indexes are not available.</div>

--- a/src/features/visualization/ui/visualization-modal-content.tsx
+++ b/src/features/visualization/ui/visualization-modal-content.tsx
@@ -22,6 +22,7 @@ import {
 import { getAreaVisualizationState } from '../lib/area-view'
 import { getMaxSubarrayVisualizationState } from '../lib/max-subarray-view'
 import { getStockProfitVisualizationState } from '../lib/stock-profit-view'
+import { getCapacitySearchVisualizationState } from '../lib/capacity-search-view'
 import { getSlidingWindowVisualizationState } from '../lib/sliding-window-view'
 import { getRollingDpState, isRollingDpCandidate } from '../lib/rolling-dp-view'
 import { getGraphNodeAdjacencyRecord } from '../lib/graph-view'
@@ -38,6 +39,7 @@ import { BarChartVisualizer } from './bar-chart-visualizer'
 import { AreaVisualizer } from './area-visualizer'
 import { MaxSubarrayVisualizer } from './max-subarray-visualizer'
 import { StockProfitVisualizer } from './stock-profit-visualizer'
+import { CapacitySearchVisualizer } from './capacity-search-visualizer'
 import { BinarySearchVisualizer } from './binary-search-visualizer'
 import { SlidingWindowVisualizer } from './sliding-window-visualizer'
 import { DpVisualizer } from './dp-visualizer'
@@ -315,6 +317,22 @@ export function VisualizationModalContent({
         />
       ) : (
         <div>Stock-profit state is not available.</div>
+      )
+    }
+
+    case 'capacity-search': {
+      const visualizationState = getCapacitySearchVisualizationState({
+        executionState,
+        variableName: targetVariable,
+      })
+
+      return visualizationState ? (
+        <CapacitySearchVisualizer
+          name={targetVariable}
+          state={visualizationState}
+        />
+      ) : (
+        <div>Capacity-search state is not available.</div>
       )
     }
 

--- a/src/features/visualization/ui/visualization-modal-content.tsx
+++ b/src/features/visualization/ui/visualization-modal-content.tsx
@@ -338,23 +338,27 @@ export function VisualizationModalContent({
     }
 
     case 'binary-search': {
-      const fallbackStep =
-        executionState.steps[targetStepIndex ?? executionState.currentStep]
+      const fallbackStepIndex = targetStepIndex ?? executionState.currentStep
       const currentStepData = currentStep?.variables[targetVariable]
-      const binarySearchStep =
+      const binarySearchStepIndex =
         currentStep &&
         isBinarySearchArrayCandidate(
           targetVariable,
           currentStepData,
           currentStep.variables
         )
-          ? currentStep
-          : fallbackStep
+          ? executionState.currentStep
+          : fallbackStepIndex
+      const binarySearchStep = executionState.steps[binarySearchStepIndex]
       const data = binarySearchStep?.variables[targetVariable]
       const indexState = getBinarySearchIndexState(
         binarySearchStep?.variables ?? {}
       )
-      const rangeMode = getBinarySearchRangeMode(executionState, targetVariable)
+      const rangeMode = getBinarySearchRangeMode(
+        executionState,
+        targetVariable,
+        binarySearchStepIndex
+      )
 
       return isNumericArray(data) && indexState ? (
         <BinarySearchVisualizer

--- a/src/features/visualization/ui/visualization-modal.tsx
+++ b/src/features/visualization/ui/visualization-modal.tsx
@@ -98,6 +98,8 @@ function getVisualizationTitle({
       return `Maximum Subarray View: ${targetVariable}`
     case 'stock-profit':
       return `Stock Profit View: ${targetVariable}`
+    case 'capacity-search':
+      return `Capacity View: ${targetVariable}`
     case 'binary-search':
       return `Index View: ${targetVariable}`
     case 'sliding-window':
@@ -152,6 +154,8 @@ function getVisualizationDescription(
       return 'Follow the current position, best sum ending here, and best sum seen so far.'
     case 'stock-profit':
       return 'Follow prices, the current day, and the profit accumulated by the strategy.'
+    case 'capacity-search':
+      return 'Follow the candidate capacity, package loading, and shipping-day count.'
     case 'binary-search':
       return 'Visualize the current binary-search range and mid index.'
     case 'sliding-window':

--- a/src/features/visualization/ui/visualizer.test.tsx
+++ b/src/features/visualization/ui/visualizer.test.tsx
@@ -959,7 +959,7 @@ describe('Visualizer return value display', () => {
         description: 'const mid = Math.floor((left + right) / 2)',
         variables: {
           nums: [1, 3, 5, 7, 9, 11],
-          target: 9,
+          target: 8,
           left: 0,
           right: 5,
           mid: 2,
@@ -970,14 +970,29 @@ describe('Visualizer return value display', () => {
       {
         stepNumber: 1,
         type: 'assignment',
-        line: 6,
-        description: 'const mid = Math.floor((left + right) / 2)',
+        line: 10,
+        description: 'left = mid + 1',
         variables: {
           nums: [1, 3, 5, 7, 9, 11],
-          target: 9,
+          target: 8,
           left: 3,
           right: 5,
-          mid: 4,
+          mid: 2,
+        },
+        timestamp: Date.now(),
+        callStack: ['root', 'binarySearch'],
+      },
+      {
+        stepNumber: 2,
+        type: 'assignment',
+        line: 10,
+        description: 'left = mid + 1',
+        variables: {
+          nums: [1, 3, 5, 7, 9, 11],
+          target: 8,
+          left: 4,
+          right: 3,
+          mid: 3,
         },
         timestamp: Date.now(),
         callStack: ['root', 'binarySearch'],
@@ -1024,9 +1039,30 @@ describe('Visualizer return value display', () => {
 
     expect(screen.getByText('left: 3')).toBeInTheDocument()
     expect(screen.getByText('right: 5')).toBeInTheDocument()
-    expect(screen.getByText('mid: 4')).toBeInTheDocument()
+    expect(screen.getByText('mid: 2')).toBeInTheDocument()
     expect(screen.queryByText('left: 0')).not.toBeInTheDocument()
-    expect(screen.queryByText('mid: 2')).not.toBeInTheDocument()
+
+    rerender(
+      <Visualizer
+        executionState={{
+          ...createExecutionStateWithSteps(steps),
+          currentStep: 2,
+        }}
+        isRunning={false}
+        onPause={noop}
+        onRunAll={noop}
+        onReset={noop}
+        onStepForward={noop}
+        onStepBackward={noop}
+        onSkipToEnd={noop}
+        onJumpToStep={noop}
+      />
+    )
+
+    expect(screen.getByText('left: 4')).toBeInTheDocument()
+    expect(screen.getByText('right: 3')).toBeInTheDocument()
+    expect(screen.getByText('mid: 3')).toBeInTheDocument()
+    expect(screen.queryByText('left: 3')).not.toBeInTheDocument()
   })
 
   it('auto-opens sliding-window strings instead of stack visualization', async () => {

--- a/src/features/visualization/ui/visualizer.tsx
+++ b/src/features/visualization/ui/visualizer.tsx
@@ -80,6 +80,8 @@ export function Visualizer({
     primaryMaxSubarrayStepIndex,
     primaryStockProfitArrayName,
     primaryStockProfitStepIndex,
+    primaryCapacitySearchArrayName,
+    primaryCapacitySearchStepIndex,
     primaryBinarySearchArrayName,
     primaryBinarySearchStepIndex,
     primarySlidingWindowStringName,
@@ -252,6 +254,8 @@ export function Visualizer({
         primaryMaxSubarrayStepIndex={primaryMaxSubarrayStepIndex}
         primaryStockProfitArrayName={primaryStockProfitArrayName}
         primaryStockProfitStepIndex={primaryStockProfitStepIndex}
+        primaryCapacitySearchArrayName={primaryCapacitySearchArrayName}
+        primaryCapacitySearchStepIndex={primaryCapacitySearchStepIndex}
         primaryBinarySearchArrayName={primaryBinarySearchArrayName}
         primaryBinarySearchStepIndex={primaryBinarySearchStepIndex}
         primarySlidingWindowStringName={primarySlidingWindowStringName}


### PR DESCRIPTION
## Summary

Add capacity search view 🚀 

<!-- A brief summary of the changes -->

## Description

- add a dedicated Capacity View for shipping-capacity binary searches
- visualize capacity bounds, total weight, package index, daily load, and required days
- track `for...of` indexes by call frame, including duplicate weights

<!-- A detailed explanation of the changes, including why they are needed -->
