### PR TITLE
feat: add runtime comparison view

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -272,8 +272,9 @@ test('visualizes array and rolling DP examples', async ({ page, isMobile }) => {
         name: `DP View: ${example.variable}`,
       }),
     })
-    if (await dpDialog.isVisible()) {
-      await dpDialog.getByTitle('Skip to End').click()
+    const openDialog = page.getByRole('dialog')
+    if (await openDialog.isVisible()) {
+      await openDialog.getByTitle('Skip to End').click()
     } else {
       await page.getByTitle('Skip to End').first().click()
     }
@@ -329,8 +330,9 @@ test('visualizes semantic Map updates', async ({ page }) => {
         name: `Map View: ${example.map}`,
       }),
     })
-    if (await mapDialog.isVisible()) {
-      await mapDialog.getByTitle('Skip to End').click()
+    const openDialog = page.getByRole('dialog')
+    if (await openDialog.isVisible()) {
+      await openDialog.getByTitle('Skip to End').click()
     } else {
       await page.getByTitle('Skip to End').first().click()
     }

--- a/src/entities/execution/index.ts
+++ b/src/entities/execution/index.ts
@@ -2,6 +2,7 @@ export {
   FUNCTION_ARGUMENTS_LABEL,
   FUNCTION_NAME_LABEL,
   CLASS_RECEIVER_LABEL,
+  RUNTIME_COMPARISON_OPERATORS,
   RETURN_LOCATION_LABEL,
   RETURN_VALUE_LABEL,
   YIELD_INPUT_LABEL,
@@ -17,6 +18,14 @@ export type {
   HeapSnapshot,
   HeapTraceSnapshot,
   InputValues,
+  RuntimeComparison,
+  RuntimeComparisonOperand,
+  RuntimeComparisonOperator,
 } from './model/types'
 export type { ExecutionStepType } from './model/constants'
-export { isExecutionState, isExecutionStep } from './model/guards'
+export {
+  isExecutionState,
+  isExecutionStep,
+  isRuntimeComparison,
+  isRuntimeComparisonOperator,
+} from './model/guards'

--- a/src/entities/execution/model/constants.ts
+++ b/src/entities/execution/model/constants.ts
@@ -6,6 +6,19 @@ export const YIELD_INPUT_LABEL = 'yield input'
 export const CLASS_RECEIVER_LABEL = '__algorithmVisualizerClassReceiver'
 export const FUNCTION_NAME_LABEL = '__algorithmVisualizerFunctionName'
 
+export const RUNTIME_COMPARISON_OPERATORS = [
+  '===',
+  '!==',
+  '==',
+  '!=',
+  '<',
+  '<=',
+  '>',
+  '>=',
+  'in',
+  'instanceof',
+] as const
+
 export const STEP_TYPES = {
   FUNCTION_CALL: 'function-call',
   FUNCTION_ENTRY: 'function-entry',

--- a/src/entities/execution/model/guards.test.ts
+++ b/src/entities/execution/model/guards.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { isRuntimeComparison } from './guards'
+
+const comparison = {
+  left: { expression: 'stack.pop()', value: undefined },
+  operator: '!==',
+  right: { expression: 'pairs[char]', value: '(' },
+  result: true,
+}
+
+describe('isRuntimeComparison', () => {
+  it('accepts an explicit undefined operand value', () => {
+    expect(isRuntimeComparison(comparison)).toBe(true)
+  })
+
+  it('rejects a missing operand value', () => {
+    expect(
+      isRuntimeComparison({
+        ...comparison,
+        left: { expression: 'stack.pop()' },
+      })
+    ).toBe(false)
+  })
+
+  it('rejects invalid comparison fields', () => {
+    expect(isRuntimeComparison({ ...comparison, operator: '=' })).toBe(false)
+    expect(isRuntimeComparison({ ...comparison, result: 'true' })).toBe(false)
+  })
+})

--- a/src/entities/execution/model/guards.ts
+++ b/src/entities/execution/model/guards.ts
@@ -3,12 +3,17 @@ import {
   hasKeys,
   isArray,
   isBoolean,
+  isFunction,
   isInteger,
   isNonArrayObject,
+  isObject,
+  isPrimitive,
   isString,
   isStringArray,
   isUndefined,
   oneOfValues,
+  or,
+  struct,
   type Guard,
 } from '@/shared/lib/guards'
 import type { ExecutionState, ExecutionStep } from './types'
@@ -19,8 +24,11 @@ const isExecutionStepType = oneOfValues(Object.values(STEP_TYPES))
 export const isRuntimeComparisonOperator = oneOfValues(
   ...RUNTIME_COMPARISON_OPERATORS
 )
-const hasRuntimeComparisonKeys = hasKeys('left', 'operator', 'right', 'result')
-const hasRuntimeComparisonOperandKeys = hasKeys('expression', 'value')
+const isRuntimeComparisonValue = or(isPrimitive, isObject, isFunction)
+const isRuntimeComparisonOperand = struct({
+  expression: isString,
+  value: isRuntimeComparisonValue,
+})
 const hasExecutionStepKeys = hasKeys(
   'stepNumber',
   'type',
@@ -36,28 +44,12 @@ const hasExecutionStateKeys = hasKeys(
   'isComplete'
 )
 
-export const isRuntimeComparison: Guard<RuntimeComparison> =
-  define<RuntimeComparison>((value) => {
-    if (!isNonArrayObject(value) || !hasRuntimeComparisonKeys(value)) {
-      return false
-    }
-
-    const { left, right } = value
-    if (
-      !isNonArrayObject(left) ||
-      !hasRuntimeComparisonOperandKeys(left) ||
-      !isString(left.expression) ||
-      !isNonArrayObject(right) ||
-      !hasRuntimeComparisonOperandKeys(right) ||
-      !isString(right.expression)
-    ) {
-      return false
-    }
-
-    return (
-      isRuntimeComparisonOperator(value.operator) && isBoolean(value.result)
-    )
-  })
+export const isRuntimeComparison: Guard<RuntimeComparison> = struct({
+  left: isRuntimeComparisonOperand,
+  operator: isRuntimeComparisonOperator,
+  right: isRuntimeComparisonOperand,
+  result: isBoolean,
+})
 
 export const isExecutionStep: Guard<ExecutionStep> = define<ExecutionStep>(
   (value) => {

--- a/src/entities/execution/model/guards.ts
+++ b/src/entities/execution/model/guards.ts
@@ -12,9 +12,15 @@ import {
   type Guard,
 } from '@/shared/lib/guards'
 import type { ExecutionState, ExecutionStep } from './types'
-import { STEP_TYPES } from './constants'
+import { RUNTIME_COMPARISON_OPERATORS, STEP_TYPES } from './constants'
+import type { RuntimeComparison } from './types'
 
 const isExecutionStepType = oneOfValues(Object.values(STEP_TYPES))
+export const isRuntimeComparisonOperator = oneOfValues(
+  ...RUNTIME_COMPARISON_OPERATORS
+)
+const hasRuntimeComparisonKeys = hasKeys('left', 'operator', 'right', 'result')
+const hasRuntimeComparisonOperandKeys = hasKeys('expression', 'value')
 const hasExecutionStepKeys = hasKeys(
   'stepNumber',
   'type',
@@ -29,6 +35,29 @@ const hasExecutionStateKeys = hasKeys(
   'steps',
   'isComplete'
 )
+
+export const isRuntimeComparison: Guard<RuntimeComparison> =
+  define<RuntimeComparison>((value) => {
+    if (!isNonArrayObject(value) || !hasRuntimeComparisonKeys(value)) {
+      return false
+    }
+
+    const { left, right } = value
+    if (
+      !isNonArrayObject(left) ||
+      !hasRuntimeComparisonOperandKeys(left) ||
+      !isString(left.expression) ||
+      !isNonArrayObject(right) ||
+      !hasRuntimeComparisonOperandKeys(right) ||
+      !isString(right.expression)
+    ) {
+      return false
+    }
+
+    return (
+      isRuntimeComparisonOperator(value.operator) && isBoolean(value.result)
+    )
+  })
 
 export const isExecutionStep: Guard<ExecutionStep> = define<ExecutionStep>(
   (value) => {

--- a/src/entities/execution/model/types.ts
+++ b/src/entities/execution/model/types.ts
@@ -1,4 +1,28 @@
 import type { ExecutionStepType } from './constants'
+import type { RUNTIME_COMPARISON_OPERATORS } from './constants'
+
+export type RuntimeComparisonOperator =
+  (typeof RUNTIME_COMPARISON_OPERATORS)[number]
+
+/** One evaluated side of a runtime comparison. */
+export type RuntimeComparisonOperand = {
+  /** Source expression evaluated for this operand. */
+  expression: string
+  /** Runtime value produced by the expression, including explicit undefined. */
+  value: unknown
+}
+
+/** Evaluated operands and outcome captured for one runtime comparison. */
+export type RuntimeComparison = {
+  /** Evaluated left-hand operand. */
+  left: RuntimeComparisonOperand
+  /** Comparison operator applied to both operands. */
+  operator: RuntimeComparisonOperator
+  /** Evaluated right-hand operand. */
+  right: RuntimeComparisonOperand
+  /** Boolean result produced by the comparison. */
+  result: boolean
+}
 
 export type HeapKind = 'min' | 'max'
 
@@ -72,6 +96,8 @@ export type ExecutionStep = {
     loopIteration?: number
     /** Condition expression result. */
     conditionResult?: boolean
+    /** Evaluated operands and result for a runtime comparison. */
+    comparison?: RuntimeComparison
     /** Related function name. */
     functionName?: string
     /** Normalized state for MinHeap and MaxHeap instances. */

--- a/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
@@ -100,6 +100,7 @@ function declareComparisonTemporary(
   path: NodePath<t.BinaryExpression>,
   identifier: t.Identifier
 ): void {
+  context.registerInternalBinding(identifier.name)
   path.scope.push({ id: identifier, kind: 'var' })
 
   const declaration = path.scope.getBinding(identifier.name)?.path.parentPath

--- a/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
@@ -117,15 +117,10 @@ export function createComparisonVisitor(context: InstrumentationContext) {
         const resultId = path.scope.generateUidIdentifier(
           'algorithmVisualizerComparisonResult'
         )
-        const description = t.templateLiteral(
-          [
-            t.templateElement({
-              raw: `Compare ${trace.source} -> `,
-              cooked: `Compare ${trace.source} -> `,
-            }),
-            t.templateElement({ raw: '', cooked: '' }, true),
-          ],
-          [resultId]
+        const description = t.binaryExpression(
+          '+',
+          t.stringLiteral(`Compare ${trace.source} -> `),
+          resultId
         )
         const comparisonMetadata = t.objectExpression([
           t.objectProperty(

--- a/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
@@ -39,7 +39,8 @@ function runsBeforeTrackedBindingsInitialize(
     if (
       (ancestor.isForInStatement() || ancestor.isForOfStatement()) &&
       t.isVariableDeclaration(ancestor.node.left) &&
-      containingNodes.has(ancestor.node.left)
+      (containingNodes.has(ancestor.node.left) ||
+        containingNodes.has(ancestor.node.right))
     ) {
       return true
     }

--- a/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
@@ -95,6 +95,19 @@ function createOperandMetadata(
   ])
 }
 
+function declareComparisonTemporary(
+  context: InstrumentationContext,
+  path: NodePath<t.BinaryExpression>,
+  identifier: t.Identifier
+): void {
+  path.scope.push({ id: identifier, kind: 'var' })
+
+  const declaration = path.scope.getBinding(identifier.name)?.path.parentPath
+  if (declaration?.isVariableDeclaration()) {
+    context.markInstrumented(declaration.node)
+  }
+}
+
 /** Records evaluated operands and outcomes for synchronous comparisons. */
 export function createComparisonVisitor(context: InstrumentationContext) {
   const comparisonTraces = new WeakMap<t.BinaryExpression, ComparisonTrace>()
@@ -137,6 +150,10 @@ export function createComparisonVisitor(context: InstrumentationContext) {
         const resultId = path.scope.generateUidIdentifier(
           'algorithmVisualizerComparisonResult'
         )
+        declareComparisonTemporary(context, path, leftId)
+        declareComparisonTemporary(context, path, rightId)
+        declareComparisonTemporary(context, path, resultId)
+
         const description = t.binaryExpression(
           '+',
           t.stringLiteral(`Compare ${trace.source} -> `),
@@ -162,36 +179,36 @@ export function createComparisonVisitor(context: InstrumentationContext) {
             ])
           ),
         ])
-        const wrapper = context.markInstrumented(
-          t.arrowFunctionExpression(
-            [],
-            t.blockStatement([
-              t.variableDeclaration('const', [
-                t.variableDeclarator(leftId, path.node.left),
-              ]),
-              t.variableDeclaration('const', [
-                t.variableDeclarator(rightId, path.node.right),
-              ]),
-              t.variableDeclaration('const', [
-                t.variableDeclarator(
-                  resultId,
-                  t.binaryExpression(path.node.operator, leftId, rightId)
-                ),
-              ]),
-              createRecordStepStatement(
-                STEP_TYPES.CONDITION,
-                getLineNumber(path.node),
-                description,
-                context.createScopeProperties(),
-                comparisonMetadata
-              ),
-              t.returnStatement(resultId),
-            ])
-          )
+        const comparisonResult = context.markInstrumented(
+          t.binaryExpression(path.node.operator, leftId, rightId)
+        )
+        const recordStep = createRecordStepStatement(
+          STEP_TYPES.CONDITION,
+          getLineNumber(path.node),
+          description,
+          context.createScopeProperties(),
+          comparisonMetadata
+        )
+        const leftAssignment = context.markInstrumented(
+          t.assignmentExpression('=', leftId, path.node.left)
+        )
+        const rightAssignment = context.markInstrumented(
+          t.assignmentExpression('=', rightId, path.node.right)
+        )
+        const resultAssignment = context.markInstrumented(
+          t.assignmentExpression('=', resultId, comparisonResult)
         )
 
         path.replaceWith(
-          context.markInstrumented(t.callExpression(wrapper, []))
+          context.markInstrumented(
+            t.sequenceExpression([
+              leftAssignment,
+              rightAssignment,
+              resultAssignment,
+              recordStep.expression,
+              resultId,
+            ])
+          )
         )
       },
     },

--- a/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
@@ -22,10 +22,11 @@ function runsBeforeTrackedBindingsInitialize(
   ])
 
   for (const ancestor of ancestry) {
-    if (ancestor.isFunction()) {
-      return ancestor.node.params.some((parameter) =>
-        containingNodes.has(parameter)
-      )
+    if (
+      ancestor.isFunction() &&
+      !containingNodes.has(ancestor.node.body)
+    ) {
+      return true
     }
 
     if (

--- a/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
@@ -70,6 +70,21 @@ function hasSuspendingOperand(path: NodePath<t.BinaryExpression>): boolean {
   return hasSuspendingOperand
 }
 
+function hasDirectEvalOperand(path: NodePath<t.BinaryExpression>): boolean {
+  let hasDirectEvalOperand = false
+
+  path.traverse({
+    CallExpression(callPath) {
+      if (!t.isIdentifier(callPath.node.callee, { name: 'eval' })) return
+
+      hasDirectEvalOperand = true
+      callPath.stop()
+    },
+  })
+
+  return hasDirectEvalOperand
+}
+
 function createOperandMetadata(
   expression: string,
   valueIdentifier: t.Identifier
@@ -102,7 +117,11 @@ export function createComparisonVisitor(context: InstrumentationContext) {
         })
       },
       exit(path: NodePath<t.BinaryExpression>) {
-        if (context.isInstrumented(path.node) || hasSuspendingOperand(path)) {
+        if (
+          context.isInstrumented(path.node) ||
+          hasSuspendingOperand(path) ||
+          hasDirectEvalOperand(path)
+        ) {
           return
         }
 

--- a/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
@@ -1,0 +1,146 @@
+import { type NodePath } from '@babel/traverse'
+import * as t from '@babel/types'
+
+import { isRuntimeComparisonOperator, STEP_TYPES } from '@/entities/execution'
+import { getLineNumber, safeGenerate } from './ast-utils'
+import { InstrumentationContext } from './context'
+import { createRecordStepStatement } from './step-factory'
+
+type ComparisonTrace = {
+  leftExpression: string
+  rightExpression: string
+  source: string
+}
+
+function hasSuspendingOperand(path: NodePath<t.BinaryExpression>): boolean {
+  let hasSuspendingOperand = false
+
+  path.traverse({
+    Function(functionPath) {
+      functionPath.skip()
+    },
+    AwaitExpression(awaitPath) {
+      hasSuspendingOperand = true
+      awaitPath.stop()
+    },
+    YieldExpression(yieldPath) {
+      hasSuspendingOperand = true
+      yieldPath.stop()
+    },
+  })
+
+  return hasSuspendingOperand
+}
+
+function createOperandMetadata(
+  expression: string,
+  valueIdentifier: t.Identifier
+): t.ObjectExpression {
+  return t.objectExpression([
+    t.objectProperty(t.identifier('expression'), t.stringLiteral(expression)),
+    t.objectProperty(t.identifier('value'), valueIdentifier),
+  ])
+}
+
+/** Records evaluated operands and outcomes for synchronous comparisons. */
+export function createComparisonVisitor(context: InstrumentationContext) {
+  const comparisonTraces = new WeakMap<t.BinaryExpression, ComparisonTrace>()
+
+  return {
+    BinaryExpression: {
+      enter(path: NodePath<t.BinaryExpression>) {
+        if (
+          context.isInstrumented(path.node) ||
+          !isRuntimeComparisonOperator(path.node.operator)
+        ) {
+          return
+        }
+
+        comparisonTraces.set(path.node, {
+          leftExpression: safeGenerate(path.node.left),
+          rightExpression: safeGenerate(path.node.right),
+          source: safeGenerate(path.node),
+        })
+      },
+      exit(path: NodePath<t.BinaryExpression>) {
+        if (context.isInstrumented(path.node) || hasSuspendingOperand(path)) {
+          return
+        }
+
+        const trace = comparisonTraces.get(path.node)
+        if (!trace || !t.isExpression(path.node.left)) return
+
+        const leftId = path.scope.generateUidIdentifier(
+          'algorithmVisualizerComparisonLeft'
+        )
+        const rightId = path.scope.generateUidIdentifier(
+          'algorithmVisualizerComparisonRight'
+        )
+        const resultId = path.scope.generateUidIdentifier(
+          'algorithmVisualizerComparisonResult'
+        )
+        const description = t.templateLiteral(
+          [
+            t.templateElement({
+              raw: `Compare ${trace.source} -> `,
+              cooked: `Compare ${trace.source} -> `,
+            }),
+            t.templateElement({ raw: '', cooked: '' }, true),
+          ],
+          [resultId]
+        )
+        const comparisonMetadata = t.objectExpression([
+          t.objectProperty(
+            t.identifier('comparison'),
+            t.objectExpression([
+              t.objectProperty(
+                t.identifier('left'),
+                createOperandMetadata(trace.leftExpression, leftId)
+              ),
+              t.objectProperty(
+                t.identifier('operator'),
+                t.stringLiteral(path.node.operator)
+              ),
+              t.objectProperty(
+                t.identifier('right'),
+                createOperandMetadata(trace.rightExpression, rightId)
+              ),
+              t.objectProperty(t.identifier('result'), resultId),
+            ])
+          ),
+        ])
+        const wrapper = context.markInstrumented(
+          t.arrowFunctionExpression(
+            [],
+            t.blockStatement([
+              t.variableDeclaration('const', [
+                t.variableDeclarator(leftId, path.node.left),
+              ]),
+              t.variableDeclaration('const', [
+                t.variableDeclarator(rightId, path.node.right),
+              ]),
+              t.variableDeclaration('const', [
+                t.variableDeclarator(
+                  resultId,
+                  t.binaryExpression(path.node.operator, leftId, rightId)
+                ),
+              ]),
+              createRecordStepStatement(
+                STEP_TYPES.CONDITION,
+                getLineNumber(path.node),
+                description,
+                context.createScopeProperties(),
+                comparisonMetadata
+              ),
+              t.returnStatement(resultId),
+            ])
+          )
+        )
+
+        path.replaceWith(
+          context.markInstrumented(t.callExpression(wrapper, []))
+        )
+      },
+    },
+  }
+}

--- a/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/comparison-visitor.ts
@@ -12,6 +12,42 @@ type ComparisonTrace = {
   source: string
 }
 
+function runsBeforeTrackedBindingsInitialize(
+  path: NodePath<t.BinaryExpression>
+): boolean {
+  const ancestry = path.getAncestry()
+  const containingNodes = new Set<t.Node>([
+    path.node,
+    ...ancestry.map((ancestor) => ancestor.node),
+  ])
+
+  for (const ancestor of ancestry) {
+    if (ancestor.isFunction()) {
+      return ancestor.node.params.some((parameter) =>
+        containingNodes.has(parameter)
+      )
+    }
+
+    if (
+      ancestor.isForStatement() &&
+      t.isVariableDeclaration(ancestor.node.init) &&
+      containingNodes.has(ancestor.node.init)
+    ) {
+      return true
+    }
+
+    if (
+      (ancestor.isForInStatement() || ancestor.isForOfStatement()) &&
+      t.isVariableDeclaration(ancestor.node.left) &&
+      containingNodes.has(ancestor.node.left)
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
+
 function hasSuspendingOperand(path: NodePath<t.BinaryExpression>): boolean {
   let hasSuspendingOperand = false
 
@@ -51,7 +87,8 @@ export function createComparisonVisitor(context: InstrumentationContext) {
       enter(path: NodePath<t.BinaryExpression>) {
         if (
           context.isInstrumented(path.node) ||
-          !isRuntimeComparisonOperator(path.node.operator)
+          !isRuntimeComparisonOperator(path.node.operator) ||
+          runsBeforeTrackedBindingsInitialize(path)
         ) {
           return
         }

--- a/src/features/code-execution/lib/instrumentation/context.ts
+++ b/src/features/code-execution/lib/instrumentation/context.ts
@@ -21,6 +21,7 @@ export class InstrumentationContext {
   > = []
   private readonly tracedGeneratorStack: boolean[] = []
   private readonly instrumentedNodes = new WeakSet<t.Node>()
+  private readonly internalBindingNames = new Set<string>()
   private readonly intrinsicsIdentifier: t.Identifier
 
   constructor(intrinsicsIdentifier: t.Identifier) {
@@ -34,6 +35,14 @@ export class InstrumentationContext {
   markInstrumented<T extends t.Node>(node: T): T {
     this.instrumentedNodes.add(node)
     return node
+  }
+
+  registerInternalBinding(name: string): void {
+    this.internalBindingNames.add(name)
+  }
+
+  isInternalBinding(name: string): boolean {
+    return this.internalBindingNames.has(name)
   }
 
   createIntrinsicReference(

--- a/src/features/code-execution/lib/instrumentation/mutation-visitors.ts
+++ b/src/features/code-execution/lib/instrumentation/mutation-visitors.ts
@@ -28,6 +28,20 @@ const shouldSkipVariableDeclarationStep = (
   ((path.parentPath.isForOfStatement() || path.parentPath.isForInStatement()) &&
     path.key === 'left')
 
+const isInternalVariableDeclaration = (
+  context: InstrumentationContext,
+  declaration: t.VariableDeclaration
+): boolean => {
+  const bindingNames = declaration.declarations.flatMap((declarator) =>
+    collectBindingNames(declarator.id)
+  )
+
+  return (
+    bindingNames.length > 0 &&
+    bindingNames.every((name) => context.isInternalBinding(name))
+  )
+}
+
 const getAssignmentTargetName = (
   target: t.AssignmentExpression['left']
 ): string => {
@@ -78,7 +92,12 @@ export const createMutationVisitors = (context: InstrumentationContext) => {
   return {
     VariableDeclaration: {
       enter(path: NodePath<t.VariableDeclaration>) {
-        if (context.isInstrumented(path.node)) return
+        if (
+          context.isInstrumented(path.node) ||
+          isInternalVariableDeclaration(context, path.node)
+        ) {
+          return
+        }
 
         const lastDeclaration = path.node.declarations.at(-1)
         if (lastDeclaration) {
@@ -91,6 +110,7 @@ export const createMutationVisitors = (context: InstrumentationContext) => {
       exit(path: NodePath<t.VariableDeclaration>) {
         if (
           context.isInstrumented(path.node) ||
+          isInternalVariableDeclaration(context, path.node) ||
           shouldSkipVariableDeclarationStep(path)
         ) {
           return

--- a/src/features/code-execution/lib/instrumentation/step-factory.ts
+++ b/src/features/code-execution/lib/instrumentation/step-factory.ts
@@ -5,21 +5,24 @@ export const createRecordStepCall = (
   stepType: string,
   line: number,
   description: string | t.Expression,
-  scopeProperties: t.ObjectProperty[]
+  scopeProperties: t.ObjectProperty[],
+  metadata?: t.Expression
 ): t.CallExpression =>
   t.callExpression(t.identifier('recordStep'), [
     t.stringLiteral(stepType),
     t.numericLiteral(line),
     isString(description) ? t.stringLiteral(description) : description,
     t.objectExpression(scopeProperties),
+    ...(metadata ? [metadata] : []),
   ])
 
 export const createRecordStepStatement = (
   stepType: string,
   line: number,
   description: string | t.Expression,
-  scopeProperties: t.ObjectProperty[]
+  scopeProperties: t.ObjectProperty[],
+  metadata?: t.Expression
 ): t.ExpressionStatement =>
   t.expressionStatement(
-    createRecordStepCall(stepType, line, description, scopeProperties)
+    createRecordStepCall(stepType, line, description, scopeProperties, metadata)
   )

--- a/src/features/code-execution/lib/instrumentation/visitor.ts
+++ b/src/features/code-execution/lib/instrumentation/visitor.ts
@@ -5,6 +5,7 @@ import { createLoopVisitors } from './loop-visitors'
 import { createMutationVisitors } from './mutation-visitors'
 import { createReturnVisitor } from './return-visitor'
 import { createYieldVisitor } from './yield-visitor'
+import { createComparisonVisitor } from './comparison-visitor'
 
 export const createInstrumentationVisitor = (
   context: InstrumentationContext
@@ -15,4 +16,5 @@ export const createInstrumentationVisitor = (
   ...createMutationVisitors(context),
   ...createLoopVisitors(context),
   ...createReturnVisitor(context),
+  ...createComparisonVisitor(context),
 })

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -104,6 +104,29 @@ function compare(): number {
     expect(state.steps.some((step) => step.metadata?.comparison)).toBe(false)
   })
 
+  it('preserves the caller of comparison operand calls', () => {
+    const state = executeCode(
+      `
+function inspect(): string | undefined {
+  return inspect.caller?.name
+}
+
+function compare(): boolean {
+  return inspect() === 'compare'
+}
+`,
+      {},
+      'compare'
+    )
+    const comparison = state.steps.find(
+      (step) => step.metadata?.comparison?.left.expression === 'inspect()'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(true)
+    expect(comparison?.metadata?.comparison?.result).toBe(true)
+  })
+
   it('does not read a for-loop binding from its own initializer', () => {
     const state = executeCode(
       `

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -34,6 +34,33 @@ function compare(): { calls: number; first: boolean; second: boolean } {
     })
   })
 
+  it('records comparisons containing template literals', () => {
+    const state = executeCode(
+      `
+function compare(status: string): boolean {
+  return \`ready\` === status
+}
+`,
+      { status: 'ready' },
+      'compare'
+    )
+    const comparison = state.steps.find((step) => step.metadata?.comparison)
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(true)
+    expect(comparison).toMatchObject({
+      description: 'Compare `ready` === status -> true',
+      metadata: {
+        comparison: {
+          left: { expression: '`ready`', value: 'ready' },
+          operator: '===',
+          right: { expression: 'status', value: 'ready' },
+          result: true,
+        },
+      },
+    })
+  })
+
   it('does not read a for-loop binding from its own initializer', () => {
     const state = executeCode(
       `

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -79,4 +79,55 @@ function choose(n = 1, start = n > 0 ? 0 : 1): number {
       )
     ).toBe(false)
   })
+
+  it.each([
+    {
+      loop: 'for...of',
+      code: `
+function collect(s: string): string[] {
+  const values: string[] = []
+
+  for (const char of s.length > 0 ? s : '') {
+    values.push(char)
+  }
+
+  return values
+}
+`,
+      inputs: { s: 'ab' },
+      expected: ['a', 'b'],
+      leftExpression: 's.length',
+    },
+    {
+      loop: 'for...in',
+      code: `
+function collect(items: Record<string, number>): string[] {
+  const keys: string[] = []
+
+  for (const key in Object.keys(items).length > 0 ? items : {}) {
+    keys.push(key)
+  }
+
+  return keys
+}
+`,
+      inputs: { items: { first: 1 } },
+      expected: ['first'],
+      leftExpression: 'Object.keys(items).length',
+    },
+  ])(
+    'does not read a $loop binding while evaluating its right-hand expression',
+    ({ code, inputs, expected, leftExpression }) => {
+      const state = executeCode(code, inputs, 'collect')
+
+      expect(state.error).toBeUndefined()
+      expect(state.returnValue).toEqual(expected)
+      expect(
+        state.steps.some(
+          (step) =>
+            step.metadata?.comparison?.left.expression === leftExpression
+        )
+      ).toBe(false)
+    }
+  )
 })

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { executeCode } from './runner'
+
+describe('runner - runtime comparisons', () => {
+  it('evaluates operands once and preserves logical short-circuiting', () => {
+    const state = executeCode(
+      `
+function compare(): { calls: number; first: boolean; second: boolean } {
+  let calls = 0
+  const next = () => calls++
+  const first = next() < next()
+  const second = true || next() > 0
+
+  return { calls, first, second }
+}
+`,
+      {},
+      'compare'
+    )
+    const comparisons = state.steps.filter((step) => step.metadata?.comparison)
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual({ calls: 2, first: true, second: true })
+    expect(comparisons).toHaveLength(1)
+    expect(comparisons[0]?.metadata).toMatchObject({
+      conditionResult: true,
+      comparison: {
+        left: { expression: 'next()', value: 0 },
+        operator: '<',
+        right: { expression: 'next()', value: 1 },
+        result: true,
+      },
+    })
+  })
+})

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -125,6 +125,45 @@ function compare(): boolean {
     expect(state.error).toBeUndefined()
     expect(state.returnValue).toBe(true)
     expect(comparison?.metadata?.comparison?.result).toBe(true)
+    expect(
+      state.steps.some((step) =>
+        Object.keys(step.variables).some((name) =>
+          name.includes('algorithmVisualizerComparison')
+        )
+      )
+    ).toBe(false)
+  })
+
+  it('does not expose comparison temporaries in loop snapshots', () => {
+    const state = executeCode(
+      `
+function coinChange(coins: number[], amount: number): number {
+  const dp = Array(amount + 1).fill(amount + 1)
+  dp[0] = 0
+
+  for (const coin of coins) {
+    for (let x = coin; x <= amount; x++) {
+      dp[x] = Math.min(dp[x], dp[x - coin] + 1)
+    }
+  }
+
+  return dp[amount] > amount ? -1 : dp[amount]
+}
+`,
+      { coins: [1, 2, 5], amount: 11 },
+      'coinChange'
+    )
+    const internalNames = new Set(
+      state.steps.flatMap((step) =>
+        Object.keys(step.variables).filter((name) =>
+          name.includes('algorithmVisualizerComparison')
+        )
+      )
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(3)
+    expect([...internalNames]).toEqual([])
   })
 
   it('does not read a for-loop binding from its own initializer', () => {

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -33,4 +33,50 @@ function compare(): { calls: number; first: boolean; second: boolean } {
       },
     })
   })
+
+  it('does not read a for-loop binding from its own initializer', () => {
+    const state = executeCode(
+      `
+function collect(n: number): number[] {
+  const values: number[] = []
+
+  for (let i = n > 0 ? 0 : 1; i < 1; i += 1) {
+    values.push(i)
+  }
+
+  return values
+}
+`,
+      { n: 1 },
+      'collect'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual([0])
+    expect(
+      state.steps.some(
+        (step) => step.metadata?.comparison?.left.expression === 'n'
+      )
+    ).toBe(false)
+  })
+
+  it('does not read parameters or frame bindings from a default parameter', () => {
+    const state = executeCode(
+      `
+function choose(n = 1, start = n > 0 ? 0 : 1): number {
+  return start
+}
+`,
+      { n: undefined, start: undefined },
+      'choose'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(0)
+    expect(
+      state.steps.some(
+        (step) => step.metadata?.comparison?.left.expression === 'n'
+      )
+    ).toBe(false)
+  })
 })

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -86,6 +86,32 @@ function compare(): { calls: number; matched: boolean } {
     expect(comparison?.metadata?.comparison?.left.value).toBe('[Object]')
   })
 
+  it('does not invoke getters from comparison scope snapshots', () => {
+    const state = executeCode(
+      `
+function compare(): number {
+  let calls = 0
+  const obj: Record<string, unknown> = {}
+  Object.defineProperty(obj, 'x', {
+    enumerable: true,
+    get() {
+      calls += 1
+      return 1
+    },
+  })
+
+  1 === 1
+  return calls
+}
+`,
+      {},
+      'compare'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(0)
+  })
+
   it('preserves the variable environment of direct eval operands', () => {
     const state = executeCode(
       `

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -61,6 +61,31 @@ function compare(status: string): boolean {
     })
   })
 
+  it('does not invoke getters while capturing comparison operands', () => {
+    const state = executeCode(
+      `
+function compare(): { calls: number; matched: boolean } {
+  let calls = 0
+  const matched = ({
+    get x() {
+      calls += 1
+      return 1
+    },
+  }) === null
+
+  return { calls, matched }
+}
+`,
+      {},
+      'compare'
+    )
+    const comparison = state.steps.find((step) => step.metadata?.comparison)
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toEqual({ calls: 0, matched: false })
+    expect(comparison?.metadata?.comparison?.left.value).toBe('[Object]')
+  })
+
   it('preserves the variable environment of direct eval operands', () => {
     const state = executeCode(
       `

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -109,6 +109,52 @@ function choose(n = 1, start = n > 0 ? 0 : 1): number {
 
   it.each([
     {
+      method: 'object',
+      code: `
+function choose(flag: boolean): string {
+  const methods = {
+    [flag === true ? 'a' : 'b'](value: string): string {
+      return value
+    },
+  }
+
+  return methods.a('object')
+}
+`,
+      expected: 'object',
+    },
+    {
+      method: 'class',
+      code: `
+function choose(flag: boolean): string {
+  class Methods {
+    [flag === true ? 'a' : 'b'](value: string): string {
+      return value
+    }
+  }
+
+  return new Methods().a('class')
+}
+`,
+      expected: 'class',
+    },
+  ])(
+    'does not read $method method bindings from its computed key',
+    ({ code, expected }) => {
+      const state = executeCode(code, { flag: true }, 'choose')
+
+      expect(state.error).toBeUndefined()
+      expect(state.returnValue).toBe(expected)
+      expect(
+        state.steps.some(
+          (step) => step.metadata?.comparison?.left.expression === 'flag'
+        )
+      ).toBe(false)
+    }
+  )
+
+  it.each([
+    {
       loop: 'for...of',
       code: `
 function collect(s: string): string[] {

--- a/src/features/code-execution/lib/runner.comparison.test.ts
+++ b/src/features/code-execution/lib/runner.comparison.test.ts
@@ -61,6 +61,24 @@ function compare(status: string): boolean {
     })
   })
 
+  it('preserves the variable environment of direct eval operands', () => {
+    const state = executeCode(
+      `
+function compare(): number {
+  eval('var observed = 1; 0') === 0
+
+  return observed
+}
+`,
+      {},
+      'compare'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(1)
+    expect(state.steps.some((step) => step.metadata?.comparison)).toBe(false)
+  })
+
   it('does not read a for-loop binding from its own initializer', () => {
     const state = executeCode(
       `

--- a/src/features/code-execution/lib/runner.parentheses.test.ts
+++ b/src/features/code-execution/lib/runner.parentheses.test.ts
@@ -1,5 +1,36 @@
 import { describe, it, expect } from 'vite-plus/test'
+import type { ExecutionState } from '@/entities/execution'
 import { executeCode } from './runner'
+
+const validParenthesesCode = `
+function isValid(s: string): boolean {
+  const pairs = new Map<string, string>([
+    [')', '('],
+    [']', '['],
+    ['}', '{'],
+  ])
+  const stack: string[] = []
+
+  for (const char of s) {
+    if (char === '(' || char === '[' || char === '{') {
+      stack.push(char)
+      continue
+    }
+
+    if (stack.pop() !== pairs.get(char)) return false
+  }
+
+  return stack.length === 0
+}
+`
+
+function getStackPopComparisonStep(state: ExecutionState) {
+  return state.steps.find(
+    (step) =>
+      step.metadata?.comparison?.left.expression === 'stack.pop()' &&
+      step.metadata.comparison.operator === '!=='
+  )
+}
 
 describe('runner - parentheses validation', () => {
   it('should generate steps for each iteration of for-of loop', () => {
@@ -30,5 +61,48 @@ function isValid(s: string): boolean {
 
     expect(state.error).toBeUndefined()
     expect(state.totalSteps).toBeGreaterThan(5) // The input is long enough to produce at least 5 steps.
+  })
+
+  it.each([
+    {
+      input: '([)]',
+      actual: '[',
+      remainingStack: ['('],
+    },
+    {
+      input: ')',
+      actual: undefined,
+      remainingStack: [],
+    },
+  ])(
+    'captures inline stack.pop() operands for invalid input $input',
+    ({ input, actual, remainingStack }) => {
+      const state = executeCode(validParenthesesCode, { s: input }, 'isValid')
+      const comparisonStep = getStackPopComparisonStep(state)
+
+      expect(state.error).toBeUndefined()
+      expect(state.returnValue).toBe(false)
+      expect(comparisonStep?.metadata?.comparison).toEqual({
+        left: { expression: 'stack.pop()', value: actual },
+        operator: '!==',
+        right: { expression: 'pairs.get(char)', value: '(' },
+        result: true,
+      })
+      expect(comparisonStep?.variables.stack).toEqual(remainingStack)
+    }
+  )
+
+  it('keeps successful Valid Parentheses execution unchanged', () => {
+    const state = executeCode(validParenthesesCode, { s: '([])' }, 'isValid')
+    const comparisons = state.steps.filter(
+      (step) => step.metadata?.comparison?.left.expression === 'stack.pop()'
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(true)
+    expect(comparisons).toHaveLength(2)
+    expect(
+      comparisons.every((step) => step.metadata?.comparison?.result === false)
+    ).toBe(true)
   })
 })

--- a/src/features/code-execution/lib/step-recorder.ts
+++ b/src/features/code-execution/lib/step-recorder.ts
@@ -1,6 +1,7 @@
 import {
   CLASS_RECEIVER_LABEL,
   FUNCTION_NAME_LABEL,
+  isRuntimeComparison,
   STEP_TYPES,
   type CallFrameStepMetadata,
   type ExecutionStep,
@@ -244,7 +245,8 @@ export function recordExecutionStep(
   type: ExecutionStep['type'],
   line: number,
   description: string,
-  stepVariables: Record<string, unknown>
+  stepVariables: Record<string, unknown>,
+  instrumentationMetadata?: ExecutionStep['metadata']
 ): ExecutionStep {
   if (context.stepNumber >= MAX_STEPS) {
     throw new StepLimitError(MAX_STEPS)
@@ -266,6 +268,9 @@ export function recordExecutionStep(
     frameId,
     visibleVariableNames: Object.keys(visibleStepVariables),
   })
+  const comparison = isRuntimeComparison(instrumentationMetadata?.comparison)
+    ? deepClone(instrumentationMetadata.comparison)
+    : undefined
 
   Object.assign(context.variables, visibleStepVariables)
   const variablesForStep =
@@ -295,10 +300,16 @@ export function recordExecutionStep(
       timestamp: Date.now(),
       callStack: getFrameCallStack(context, callStackFrameId),
       metadata:
-        heapTrace || callFrame
+        heapTrace || callFrame || comparison
           ? {
               ...(heapTrace ? { heapTrace: deepClone(heapTrace) } : {}),
               ...(callFrame ? { callFrame } : {}),
+              ...(comparison
+                ? {
+                    comparison,
+                    conditionResult: comparison.result,
+                  }
+                : {}),
             }
           : undefined,
     },

--- a/src/features/code-execution/lib/step-recorder.ts
+++ b/src/features/code-execution/lib/step-recorder.ts
@@ -263,6 +263,17 @@ function captureComparison(comparison: RuntimeComparison): RuntimeComparison {
   }
 }
 
+/** Keeps comparison snapshots from traversing scoped user references. */
+function captureComparisonScopeVariables(
+  variables: Record<string, unknown>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(variables).filter(
+      ([, value]) => !isObject(value) && !isFunction(value)
+    )
+  )
+}
+
 export function recordExecutionStep(
   context: ExecutionContext,
   type: ExecutionStep['type'],
@@ -296,8 +307,11 @@ export function recordExecutionStep(
     : undefined
 
   Object.assign(context.variables, visibleStepVariables)
-  const variablesForStep =
+  const changedVariables =
     context.stepNumber === 0 ? context.variables : visibleStepVariables
+  const variablesForStep = comparison
+    ? captureComparisonScopeVariables(changedVariables)
+    : changedVariables
   const variableDelta = deepClone(variablesForStep)
 
   updateActiveFrame(context, type, callFrame)

--- a/src/features/code-execution/lib/step-recorder.ts
+++ b/src/features/code-execution/lib/step-recorder.ts
@@ -6,9 +6,10 @@ import {
   type CallFrameStepMetadata,
   type ExecutionStep,
   type InputValues,
+  type RuntimeComparison,
 } from '@/entities/execution'
 import { deepClone } from '@/shared/lib/deep-clone'
-import { isInteger, isString } from '@/shared/lib/guards'
+import { isFunction, isInteger, isObject, isString } from '@/shared/lib/guards'
 import { MAX_STEPS, StepLimitError } from './execution-errors'
 import { CALL_FRAME_ID_LABEL } from './frame-identity'
 import { createHeapTraceCollector, type HeapTraceCollector } from './heap-trace'
@@ -240,6 +241,28 @@ function createStepWithLazyVariables(
   return step
 }
 
+/** Captures references without reading user-defined properties or traps. */
+function captureComparisonValue(value: unknown): unknown {
+  if (isFunction(value)) return '[Function]'
+  if (isObject(value)) return '[Object]'
+  return value
+}
+
+function captureComparison(comparison: RuntimeComparison): RuntimeComparison {
+  return {
+    left: {
+      expression: comparison.left.expression,
+      value: captureComparisonValue(comparison.left.value),
+    },
+    operator: comparison.operator,
+    right: {
+      expression: comparison.right.expression,
+      value: captureComparisonValue(comparison.right.value),
+    },
+    result: comparison.result,
+  }
+}
+
 export function recordExecutionStep(
   context: ExecutionContext,
   type: ExecutionStep['type'],
@@ -269,7 +292,7 @@ export function recordExecutionStep(
     visibleVariableNames: Object.keys(visibleStepVariables),
   })
   const comparison = isRuntimeComparison(instrumentationMetadata?.comparison)
-    ? deepClone(instrumentationMetadata.comparison)
+    ? captureComparison(instrumentationMetadata.comparison)
     : undefined
 
   Object.assign(context.variables, visibleStepVariables)

--- a/src/features/code-execution/lib/typescript-runner.ts
+++ b/src/features/code-execution/lib/typescript-runner.ts
@@ -104,9 +104,17 @@ export function* createTypeScriptExecutionRunner(
     type: ExecutionStep['type'],
     line: number,
     description: string,
-    stepVariables: Record<string, unknown>
+    stepVariables: Record<string, unknown>,
+    metadata?: ExecutionStep['metadata']
   ): ExecutionStep =>
-    recordExecutionStep(context, type, line, description, stepVariables)
+    recordExecutionStep(
+      context,
+      type,
+      line,
+      description,
+      stepVariables,
+      metadata
+    )
   attachInstrumentationIntrinsics(recordStep)
 
   try {
@@ -179,9 +187,17 @@ export async function* createAsyncTypeScriptExecutionRunner(
     type: ExecutionStep['type'],
     line: number,
     description: string,
-    stepVariables: Record<string, unknown>
+    stepVariables: Record<string, unknown>,
+    metadata?: ExecutionStep['metadata']
   ): ExecutionStep =>
-    recordExecutionStep(context, type, line, description, stepVariables)
+    recordExecutionStep(
+      context,
+      type,
+      line,
+      description,
+      stepVariables,
+      metadata
+    )
   attachInstrumentationIntrinsics(recordStep)
 
   try {

--- a/src/features/visualization/lib/runtime-comparison.ts
+++ b/src/features/visualization/lib/runtime-comparison.ts
@@ -1,0 +1,13 @@
+import type { ExecutionState, RuntimeComparison } from '@/entities/execution'
+
+/** Returns the latest comparison evaluated at or before the playback step. */
+export function getLatestRuntimeComparison(
+  executionState: ExecutionState
+): RuntimeComparison | undefined {
+  for (let index = executionState.currentStep; index >= 0; index -= 1) {
+    const comparison = executionState.steps[index]?.metadata?.comparison
+    if (comparison) return comparison
+  }
+
+  return undefined
+}

--- a/src/features/visualization/model/visualization-detection/array-candidates.ts
+++ b/src/features/visualization/model/visualization-detection/array-candidates.ts
@@ -56,8 +56,9 @@ export function getPrimaryStackName(
     return (
       (isResultLikeName(name) || hasStackSemantics) &&
       isArray(value) &&
-      value.length > 0 &&
-      (!isNumericArray(value) ||
+      (value.length > 0 || hasStackSemantics) &&
+      (hasStackSemantics ||
+        !isNumericArray(value) ||
         (options.includeNumericResultArrays &&
           options.mutatedNumericArrayNames?.has(name)))
     )

--- a/src/features/visualization/model/visualization-detection/detect-visualization-state.test.ts
+++ b/src/features/visualization/model/visualization-detection/detect-visualization-state.test.ts
@@ -131,6 +131,16 @@ describe('detectVisualizationState', () => {
     expect(detection.primaryStackName).toBe('stack')
   })
 
+  it('keeps an empty named stack available for runtime comparisons', () => {
+    const state = createExecutionState([
+      createStep(0, 'Compare stack.pop() !== pairs.get(char) -> true', {
+        stack: [],
+      }),
+    ])
+
+    expect(detectVisualizationState(state).primaryStackName).toBe('stack')
+  })
+
   it('selects a mutated numeric array only for sorting traces', () => {
     const sortingState = createExecutionState([
       createStep(0, 'Initial values', { nums: [2, 1] }),

--- a/src/features/visualization/ui/index.ts
+++ b/src/features/visualization/ui/index.ts
@@ -1,6 +1,7 @@
 export * from './visualizer'
 export * from './visualization-modal'
 export * from './stack-visualizer'
+export * from './runtime-comparison-view'
 export * from './recursion-tree-visualizer'
 export * from './bar-chart-visualizer'
 export * from './area-visualizer'

--- a/src/features/visualization/ui/runtime-comparison-view.test.tsx
+++ b/src/features/visualization/ui/runtime-comparison-view.test.tsx
@@ -4,6 +4,17 @@ import { describe, expect, it } from 'vite-plus/test'
 import { RuntimeComparisonView } from './runtime-comparison-view'
 
 describe('RuntimeComparisonView', () => {
+  it('keeps a stable placeholder before the first comparison', () => {
+    render(<RuntimeComparisonView />)
+
+    const view = screen.getByLabelText('Runtime comparison')
+
+    expect(within(view).getByText('Waiting')).toBeInTheDocument()
+    expect(
+      within(view).getByText('No comparison evaluated yet.')
+    ).toBeInTheDocument()
+  })
+
   it('renders explicit undefined operands and a true result', () => {
     render(
       <RuntimeComparisonView

--- a/src/features/visualization/ui/runtime-comparison-view.test.tsx
+++ b/src/features/visualization/ui/runtime-comparison-view.test.tsx
@@ -35,7 +35,7 @@ describe('RuntimeComparisonView', () => {
     expect(within(left).getByText('undefined')).toBeInTheDocument()
     expect(within(view).getByText('!==')).toBeInTheDocument()
     expect(within(right).getByText('pairs.get(char)')).toBeInTheDocument()
-    expect(within(right).getByText('(')).toBeInTheDocument()
+    expect(within(right).getByText('"("')).toBeInTheDocument()
     expect(within(view).getByText('true')).toBeInTheDocument()
   })
 })

--- a/src/features/visualization/ui/runtime-comparison-view.test.tsx
+++ b/src/features/visualization/ui/runtime-comparison-view.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { RuntimeComparisonView } from './runtime-comparison-view'
+
+describe('RuntimeComparisonView', () => {
+  it('renders explicit undefined operands and a true result', () => {
+    render(
+      <RuntimeComparisonView
+        comparison={{
+          left: { expression: 'stack.pop()', value: undefined },
+          operator: '!==',
+          right: { expression: 'pairs.get(char)', value: '(' },
+          result: true,
+        }}
+      />
+    )
+
+    const view = screen.getByLabelText('Runtime comparison')
+    const left = within(view).getByLabelText('Left comparison operand')
+    const right = within(view).getByLabelText('Right comparison operand')
+
+    expect(within(left).getByText('stack.pop()')).toBeInTheDocument()
+    expect(within(left).getByText('undefined')).toBeInTheDocument()
+    expect(within(view).getByText('!==')).toBeInTheDocument()
+    expect(within(right).getByText('pairs.get(char)')).toBeInTheDocument()
+    expect(within(right).getByText('(')).toBeInTheDocument()
+    expect(within(view).getByText('true')).toBeInTheDocument()
+  })
+})

--- a/src/features/visualization/ui/runtime-comparison-view.tsx
+++ b/src/features/visualization/ui/runtime-comparison-view.tsx
@@ -1,0 +1,70 @@
+import type { RuntimeComparison } from '@/entities/execution'
+import { cn } from '@/shared/lib/class-names'
+import { Badge, Card } from '@/shared/ui'
+import { formatDisplayValue } from '../lib/display-value'
+
+type RuntimeComparisonViewProps = {
+  /** Evaluated comparison to explain at the current execution step. */
+  comparison: RuntimeComparison
+  /** Optional layout classes supplied by the containing visualizer. */
+  className?: string
+}
+
+function formatOperand(value: unknown): string {
+  return formatDisplayValue(value, {
+    nullLabel: 'null',
+    undefinedLabel: 'undefined',
+  })
+}
+
+/** Displays both evaluated comparison operands and their runtime outcome. */
+export function RuntimeComparisonView({
+  comparison,
+  className,
+}: RuntimeComparisonViewProps) {
+  const resultLabel = String(comparison.result)
+
+  return (
+    <Card
+      className={cn('w-full max-w-lg p-4', className)}
+      aria-label="Runtime comparison"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold">Runtime comparison</h3>
+        <Badge variant={comparison.result ? 'secondary' : 'destructive'}>
+          {resultLabel}
+        </Badge>
+      </div>
+
+      <div className="mt-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-stretch gap-2">
+        <div
+          className="min-w-0 rounded-md bg-muted/30 p-3"
+          aria-label="Left comparison operand"
+        >
+          <p className="truncate text-xs text-muted-foreground">
+            Actual · <code>{comparison.left.expression}</code>
+          </p>
+          <code className="mt-1 block break-all text-base font-semibold">
+            {formatOperand(comparison.left.value)}
+          </code>
+        </div>
+
+        <code className="flex items-center px-1 text-sm font-semibold text-muted-foreground">
+          {comparison.operator}
+        </code>
+
+        <div
+          className="min-w-0 rounded-md bg-muted/30 p-3"
+          aria-label="Right comparison operand"
+        >
+          <p className="truncate text-xs text-muted-foreground">
+            Expected · <code>{comparison.right.expression}</code>
+          </p>
+          <code className="mt-1 block break-all text-base font-semibold">
+            {formatOperand(comparison.right.value)}
+          </code>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/features/visualization/ui/runtime-comparison-view.tsx
+++ b/src/features/visualization/ui/runtime-comparison-view.tsx
@@ -5,7 +5,7 @@ import { formatDisplayValue } from '../lib/display-value'
 
 type RuntimeComparisonViewProps = {
   /** Evaluated comparison to explain at the current execution step. */
-  comparison: RuntimeComparison
+  comparison?: RuntimeComparison
   /** Optional layout classes supplied by the containing visualizer. */
   className?: string
 }
@@ -22,49 +22,57 @@ export function RuntimeComparisonView({
   comparison,
   className,
 }: RuntimeComparisonViewProps) {
-  const resultLabel = String(comparison.result)
-
   return (
     <Card
-      className={cn('w-full max-w-lg p-4', className)}
+      className={cn('min-h-36 w-full max-w-lg p-4', className)}
       aria-label="Runtime comparison"
     >
       <div className="flex items-center justify-between gap-3">
         <h3 className="text-sm font-semibold">Runtime comparison</h3>
-        <Badge variant={comparison.result ? 'secondary' : 'destructive'}>
-          {resultLabel}
-        </Badge>
+        {comparison ? (
+          <Badge variant={comparison.result ? 'secondary' : 'destructive'}>
+            {String(comparison.result)}
+          </Badge>
+        ) : (
+          <Badge variant="outline">Waiting</Badge>
+        )}
       </div>
 
-      <div className="mt-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-stretch gap-2">
-        <div
-          className="min-w-0 rounded-md bg-muted/30 p-3"
-          aria-label="Left comparison operand"
-        >
-          <p className="truncate text-xs text-muted-foreground">
-            Actual · <code>{comparison.left.expression}</code>
-          </p>
-          <code className="mt-1 block break-all text-base font-semibold">
-            {formatOperand(comparison.left.value)}
-          </code>
-        </div>
+      {comparison ? (
+        <div className="mt-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-stretch gap-2">
+          <div
+            className="min-w-0 rounded-md bg-muted/30 p-3"
+            aria-label="Left comparison operand"
+          >
+            <p className="truncate text-xs text-muted-foreground">
+              Actual · <code>{comparison.left.expression}</code>
+            </p>
+            <code className="mt-1 block break-all text-base font-semibold">
+              {formatOperand(comparison.left.value)}
+            </code>
+          </div>
 
-        <code className="flex items-center px-1 text-sm font-semibold text-muted-foreground">
-          {comparison.operator}
-        </code>
-
-        <div
-          className="min-w-0 rounded-md bg-muted/30 p-3"
-          aria-label="Right comparison operand"
-        >
-          <p className="truncate text-xs text-muted-foreground">
-            Expected · <code>{comparison.right.expression}</code>
-          </p>
-          <code className="mt-1 block break-all text-base font-semibold">
-            {formatOperand(comparison.right.value)}
+          <code className="flex items-center px-1 text-sm font-semibold text-muted-foreground">
+            {comparison.operator}
           </code>
+
+          <div
+            className="min-w-0 rounded-md bg-muted/30 p-3"
+            aria-label="Right comparison operand"
+          >
+            <p className="truncate text-xs text-muted-foreground">
+              Expected · <code>{comparison.right.expression}</code>
+            </p>
+            <code className="mt-1 block break-all text-base font-semibold">
+              {formatOperand(comparison.right.value)}
+            </code>
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="mt-3 flex min-h-16 items-center justify-center rounded-md bg-muted/20 px-3 text-center text-sm text-muted-foreground">
+          No comparison evaluated yet.
+        </div>
+      )}
     </Card>
   )
 }

--- a/src/features/visualization/ui/runtime-comparison-view.tsx
+++ b/src/features/visualization/ui/runtime-comparison-view.tsx
@@ -14,6 +14,7 @@ function formatOperand(value: unknown): string {
   return formatDisplayValue(value, {
     nullLabel: 'null',
     undefinedLabel: 'undefined',
+    quoteStrings: true,
   })
 }
 

--- a/src/features/visualization/ui/stack-visualizer.test.tsx
+++ b/src/features/visualization/ui/stack-visualizer.test.tsx
@@ -5,14 +5,14 @@ import type { ExecutionState } from '@/entities/execution'
 import { VisualizationModalContent } from './visualization-modal-content'
 
 describe('StackVisualizer', () => {
-  it('shows the active runtime comparison alongside an empty stack', () => {
+  it('keeps the latest runtime comparison visible on following steps', () => {
     const comparison = {
       left: { expression: 'stack.pop()', value: undefined },
       operator: '!==',
       right: { expression: 'pairs.get(char)', value: '(' },
       result: true,
     } as const
-    const currentStep: ExecutionState['steps'][number] = {
+    const comparisonStep: ExecutionState['steps'][number] = {
       stepNumber: 0,
       type: 'condition',
       line: 1,
@@ -21,10 +21,18 @@ describe('StackVisualizer', () => {
       timestamp: 0,
       metadata: { comparison },
     }
+    const currentStep: ExecutionState['steps'][number] = {
+      stepNumber: 1,
+      type: 'array-mutation',
+      line: 2,
+      description: 'stack.pop()',
+      variables: { stack: [] },
+      timestamp: 1,
+    }
     const executionState: ExecutionState = {
-      currentStep: 0,
-      totalSteps: 1,
-      steps: [currentStep],
+      currentStep: 1,
+      totalSteps: 2,
+      steps: [comparisonStep, currentStep],
       isComplete: false,
     }
 

--- a/src/features/visualization/ui/stack-visualizer.test.tsx
+++ b/src/features/visualization/ui/stack-visualizer.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vite-plus/test'
+import type { ExecutionState } from '@/entities/execution'
+
+import { VisualizationModalContent } from './visualization-modal-content'
+
+describe('StackVisualizer', () => {
+  it('shows the active runtime comparison alongside an empty stack', () => {
+    const comparison = {
+      left: { expression: 'stack.pop()', value: undefined },
+      operator: '!==',
+      right: { expression: 'pairs.get(char)', value: '(' },
+      result: true,
+    } as const
+    const currentStep: ExecutionState['steps'][number] = {
+      stepNumber: 0,
+      type: 'condition',
+      line: 1,
+      description: 'Compare stack.pop() !== pairs.get(char) -> true',
+      variables: { stack: [] },
+      timestamp: 0,
+      metadata: { comparison },
+    }
+    const executionState: ExecutionState = {
+      currentStep: 0,
+      totalSteps: 1,
+      steps: [currentStep],
+      isComplete: false,
+    }
+
+    render(
+      <VisualizationModalContent
+        type="stack"
+        targetVariable="stack"
+        executionState={executionState}
+        currentStep={currentStep}
+      />
+    )
+
+    expect(screen.getByText('Empty Stack')).toBeInTheDocument()
+    expect(screen.getByLabelText('Runtime comparison')).toBeInTheDocument()
+    expect(screen.getByText('undefined')).toBeInTheDocument()
+  })
+})

--- a/src/features/visualization/ui/stack-visualizer.tsx
+++ b/src/features/visualization/ui/stack-visualizer.tsx
@@ -94,9 +94,7 @@ export function StackVisualizer({
           Bottom
         </span>
       </div>
-      {comparison && (
-        <RuntimeComparisonView comparison={comparison} className="mt-5" />
-      )}
+      <RuntimeComparisonView comparison={comparison} className="mt-5" />
     </div>
   )
 }

--- a/src/features/visualization/ui/stack-visualizer.tsx
+++ b/src/features/visualization/ui/stack-visualizer.tsx
@@ -1,6 +1,8 @@
 import { motion, AnimatePresence } from 'framer-motion'
+import type { RuntimeComparison } from '@/entities/execution'
 import { Card, Badge } from '@/shared/ui'
 import { isArray } from '@/shared/lib/guards'
+import { RuntimeComparisonView } from './runtime-comparison-view'
 
 const STACK_CONTAINER_MIN_HEIGHT_CLASS = 'min-h-[18.75rem]'
 const STACK_ITEM_ENTER_Y_OFFSET = -50
@@ -18,9 +20,15 @@ type StackVisualizerProps = {
   data: unknown
   /** Optional variable name shown above the stack. */
   name?: string
+  /** Runtime comparison evaluated at the current playback step. */
+  comparison?: RuntimeComparison
 }
 
-export function StackVisualizer({ data, name }: StackVisualizerProps) {
+export function StackVisualizer({
+  data,
+  name,
+  comparison,
+}: StackVisualizerProps) {
   // Ensure data is an array
   const stackData = isArray(data) ? data : []
 
@@ -86,6 +94,9 @@ export function StackVisualizer({ data, name }: StackVisualizerProps) {
           Bottom
         </span>
       </div>
+      {comparison && (
+        <RuntimeComparisonView comparison={comparison} className="mt-5" />
+      )}
     </div>
   )
 }

--- a/src/features/visualization/ui/visualization-modal-content.tsx
+++ b/src/features/visualization/ui/visualization-modal-content.tsx
@@ -244,7 +244,11 @@ export function VisualizationModalContent({
       })?.variables[targetVariable]
 
       return isArray(data) ? (
-        <StackVisualizer data={data} name={targetVariable} />
+        <StackVisualizer
+          data={data}
+          name={targetVariable}
+          comparison={currentStep?.metadata?.comparison}
+        />
       ) : (
         <div>Variable is not an array</div>
       )

--- a/src/features/visualization/ui/visualization-modal-content.tsx
+++ b/src/features/visualization/ui/visualization-modal-content.tsx
@@ -32,6 +32,7 @@ import { getExecutionStepSearchOrder } from '../lib/execution-step-search'
 import { getHeapVisualizationState } from '../lib/heap-view'
 import { getWordLadderVisualizationState } from '../lib/word-ladder-view'
 import { getExpressionVisualizationState } from '../lib/expression-view'
+import { getLatestRuntimeComparison } from '../lib/runtime-comparison'
 import { hasCallFrameMetadata } from '../lib/call-frame-inspector'
 import type { VisualizationType } from '../model/types'
 import { StackVisualizer } from './stack-visualizer'
@@ -247,7 +248,7 @@ export function VisualizationModalContent({
         <StackVisualizer
           data={data}
           name={targetVariable}
-          comparison={currentStep?.metadata?.comparison}
+          comparison={getLatestRuntimeComparison(executionState)}
         />
       ) : (
         <div>Variable is not an array</div>

--- a/src/shared/lib/deep-clone.test.ts
+++ b/src/shared/lib/deep-clone.test.ts
@@ -70,4 +70,27 @@ describe('deepClone', () => {
     expect(calls).toBe(0)
     expect(clone).toEqual({ result: '[Getter]' })
   })
+
+  it('does not call overridden Map or Set forEach methods', () => {
+    let calls = 0
+    const map = new Map([[1, { count: 2 }]])
+    const set = new Set(['a'])
+
+    Object.defineProperty(map, 'forEach', {
+      value: () => {
+        calls += 1
+      },
+    })
+    Object.defineProperty(set, 'forEach', {
+      value: () => {
+        calls += 1
+      },
+    })
+
+    const clone = deepClone({ fn: () => null, map, set })
+
+    expect(calls).toBe(0)
+    expect(clone.map.get(1)).toEqual({ count: 2 })
+    expect([...clone.set]).toEqual(['a'])
+  })
 })

--- a/src/shared/lib/deep-clone.test.ts
+++ b/src/shared/lib/deep-clone.test.ts
@@ -55,4 +55,19 @@ describe('deepClone', () => {
     expect(clone.items[0]).toBe(clone.items[1])
     expect(clone.items[2]).toBe(clone.items)
   })
+
+  it('does not invoke enumerable getters', () => {
+    let calls = 0
+    const value = {
+      get result() {
+        calls += 1
+        return 1
+      },
+    }
+
+    const clone = deepClone(value)
+
+    expect(calls).toBe(0)
+    expect(clone).toEqual({ result: '[Getter]' })
+  })
 })

--- a/src/shared/lib/deep-clone.ts
+++ b/src/shared/lib/deep-clone.ts
@@ -12,6 +12,13 @@ import {
 const isIntlCollator = isInstanceOf(
   Intl.Collator as unknown as abstract new (...args: unknown[]) => Intl.Collator
 )
+const mapForEach = Reflect.get(Map.prototype, 'forEach') as Map<
+  unknown,
+  unknown
+>['forEach']
+const setForEach = Reflect.get(Set.prototype, 'forEach') as Set<
+  unknown
+>['forEach']
 
 function hasEnumerableAccessor(
   value: unknown,
@@ -24,7 +31,7 @@ function hasEnumerableAccessor(
 
   if (isMap(value)) {
     let found = false
-    value.forEach((item, key) => {
+    mapForEach.call(value, (item, key) => {
       found ||=
         hasEnumerableAccessor(key, seen) ||
         hasEnumerableAccessor(item, seen)
@@ -34,7 +41,7 @@ function hasEnumerableAccessor(
 
   if (isSet(value)) {
     let found = false
-    value.forEach((item) => {
+    setForEach.call(value, (item) => {
       found ||= hasEnumerableAccessor(item, seen)
     })
     return found
@@ -98,7 +105,7 @@ function cloneWithoutStructuredClone<T>(
   if (isMap(value)) {
     const clone = new Map<unknown, unknown>()
     seen.set(value, clone)
-    value.forEach((item, key) => {
+    mapForEach.call(value, (item, key) => {
       clone.set(
         cloneWithoutStructuredClone(key, seen),
         cloneWithoutStructuredClone(item, seen)
@@ -110,7 +117,9 @@ function cloneWithoutStructuredClone<T>(
   if (isSet(value)) {
     const clone = new Set<unknown>()
     seen.set(value, clone)
-    value.forEach((item) => clone.add(cloneWithoutStructuredClone(item, seen)))
+    setForEach.call(value, (item) =>
+      clone.add(cloneWithoutStructuredClone(item, seen))
+    )
     return clone as T
   }
 

--- a/src/shared/lib/deep-clone.ts
+++ b/src/shared/lib/deep-clone.ts
@@ -13,6 +13,58 @@ const isIntlCollator = isInstanceOf(
   Intl.Collator as unknown as abstract new (...args: unknown[]) => Intl.Collator
 )
 
+function hasEnumerableAccessor(
+  value: unknown,
+  seen = new WeakSet<object>()
+): boolean {
+  if (!isObject(value) || seen.has(value)) return false
+  if (isDate(value) || isRegExp(value) || isIntlCollator(value)) return false
+
+  seen.add(value)
+
+  if (isMap(value)) {
+    let found = false
+    value.forEach((item, key) => {
+      found ||=
+        hasEnumerableAccessor(key, seen) ||
+        hasEnumerableAccessor(item, seen)
+    })
+    return found
+  }
+
+  if (isSet(value)) {
+    let found = false
+    value.forEach((item) => {
+      found ||= hasEnumerableAccessor(item, seen)
+    })
+    return found
+  }
+
+  return Object.values(Object.getOwnPropertyDescriptors(value)).some(
+    (descriptor) =>
+      descriptor.enumerable &&
+      (!('value' in descriptor) ||
+        hasEnumerableAccessor(descriptor.value, seen))
+  )
+}
+
+function cloneEnumerableProperties(
+  value: object,
+  clone: Record<string, unknown>,
+  seen: WeakMap<object, unknown>
+): void {
+  Object.entries(Object.getOwnPropertyDescriptors(value)).forEach(
+    ([key, descriptor]) => {
+      if (!descriptor.enumerable) return
+
+      clone[key] =
+        'value' in descriptor
+          ? cloneWithoutStructuredClone(descriptor.value, seen)
+          : '[Getter]'
+    }
+  )
+}
+
 function cloneWithoutStructuredClone<T>(
   value: T,
   seen = new WeakMap<object, unknown>()
@@ -32,9 +84,11 @@ function cloneWithoutStructuredClone<T>(
 
     const clone: unknown[] = []
     seen.set(value, clone)
-    value.forEach((item, index) => {
-      clone[index] = cloneWithoutStructuredClone(item, seen)
-    })
+    cloneEnumerableProperties(
+      value,
+      clone as unknown as Record<string, unknown>,
+      seen
+    )
     return clone as T
   }
 
@@ -62,9 +116,7 @@ function cloneWithoutStructuredClone<T>(
 
   const clone: Record<string, unknown> = {}
   seen.set(value, clone)
-  Object.entries(value).forEach(([key, item]) => {
-    clone[key] = cloneWithoutStructuredClone(item, seen)
-  })
+  cloneEnumerableProperties(value, clone, seen)
 
   return clone as T
 }
@@ -79,7 +131,10 @@ export function deepClone<T>(value: T): T {
   if (!isObject(value)) return value
   if (isIntlCollator(value)) return value
 
-  if (isFunction(globalThis.structuredClone)) {
+  if (
+    isFunction(globalThis.structuredClone) &&
+    !hasEnumerableAccessor(value)
+  ) {
     try {
       return structuredClone(value)
     } catch {

--- a/src/shared/lib/guards.ts
+++ b/src/shared/lib/guards.ts
@@ -48,6 +48,7 @@ export {
   lazy,
   recordOf,
   safeJsonParse,
+  struct,
 } from 'is-kit'
 
 export type { Guard } from 'is-kit'


### PR DESCRIPTION
Close #67 

## Summary

Add runtime comparison view.

<!-- A brief summary of the changes -->

## Description

- capture evaluated operands, operators, and results for runtime comparisons
- preserve inline expression values such as `stack.pop()`, including `undefined`
- add a reusable Runtime Comparison view
- integrate comparison details into Stack View

<!-- A detailed explanation of the changes, including why they are needed -->
