### PR TITLE
fix: clarify empty stack handling in parentheses sample

### DIFF
--- a/src/entities/algorithm-example/model/algorithm-example-sources.ts
+++ b/src/entities/algorithm-example/model/algorithm-example-sources.ts
@@ -253,6 +253,8 @@ export const ALGORITHM_EXAMPLE_SOURCES = {
       continue
     }
 
+    if (stack.length === 0) return false
+
     if (stack.pop() !== pairs.get(char)) return false
   }
 

--- a/src/features/code-execution/external-algorithms-use-cases.test.tsx
+++ b/src/features/code-execution/external-algorithms-use-cases.test.tsx
@@ -105,12 +105,24 @@ function validAnagram(s: string, t: string): boolean {
 `,
   'stack/parentheses.ts': `
 function isValid(s: string): boolean {
-  const pairs: Record<string, string> = { ')': '(', ']': '[', '}': '{' }
+  const pairs = new Map<string, string>([
+    [')', '('],
+    [']', '['],
+    ['}', '{'],
+  ])
   const stack: string[] = []
+
   for (const char of s) {
-    if (char === '(' || char === '[' || char === '{') stack.push(char)
-    else if (stack.pop() !== pairs[char]) return false
+    if (char === '(' || char === '[' || char === '{') {
+      stack.push(char)
+      continue
+    }
+
+    if (stack.length === 0) return false
+
+    if (stack.pop() !== pairs.get(char)) return false
   }
+
   return stack.length === 0
 }
 `,

--- a/src/features/code-execution/lib/runner.parentheses.test.ts
+++ b/src/features/code-execution/lib/runner.parentheses.test.ts
@@ -1,28 +1,19 @@
 import { describe, it, expect } from 'vite-plus/test'
-import type { ExecutionState } from '@/entities/execution'
+import { ALGORITHM_EXAMPLES } from '@/entities/algorithm-example'
+import {
+  RETURN_VALUE_LABEL,
+  STEP_TYPES,
+  type ExecutionState,
+} from '@/entities/execution'
 import { executeCode } from './runner'
 
-const validParenthesesCode = `
-function isValid(s: string): boolean {
-  const pairs = new Map<string, string>([
-    [')', '('],
-    [']', '['],
-    ['}', '{'],
-  ])
-  const stack: string[] = []
+const validParenthesesCode = ALGORITHM_EXAMPLES.find(
+  (example) => example.id === 'valid-parentheses'
+)?.sourceCode
 
-  for (const char of s) {
-    if (char === '(' || char === '[' || char === '{') {
-      stack.push(char)
-      continue
-    }
-
-    if (stack.pop() !== pairs.get(char)) return false
-  }
-
-  return stack.length === 0
+if (!validParenthesesCode) {
+  throw new Error('Valid Parentheses example is missing')
 }
-`
 
 function getStackPopComparisonStep(state: ExecutionState) {
   return state.steps.find(
@@ -63,34 +54,55 @@ function isValid(s: string): boolean {
     expect(state.totalSteps).toBeGreaterThan(5) // The input is long enough to produce at least 5 steps.
   })
 
-  it.each([
-    {
-      input: '([)]',
-      actual: '[',
-      remainingStack: ['('],
-    },
-    {
-      input: ')',
-      actual: undefined,
-      remainingStack: [],
-    },
-  ])(
-    'captures inline stack.pop() operands for invalid input $input',
-    ({ input, actual, remainingStack }) => {
-      const state = executeCode(validParenthesesCode, { s: input }, 'isValid')
-      const comparisonStep = getStackPopComparisonStep(state)
+  it('captures inline stack.pop() operands for mismatched pairs', () => {
+    const state = executeCode(validParenthesesCode, { s: '([)]' }, 'isValid')
+    const comparisonStep = getStackPopComparisonStep(state)
 
-      expect(state.error).toBeUndefined()
-      expect(state.returnValue).toBe(false)
-      expect(comparisonStep?.metadata?.comparison).toEqual({
-        left: { expression: 'stack.pop()', value: actual },
-        operator: '!==',
-        right: { expression: 'pairs.get(char)', value: '(' },
-        result: true,
-      })
-      expect(comparisonStep?.variables.stack).toEqual(remainingStack)
-    }
-  )
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(false)
+    expect(comparisonStep?.metadata?.comparison).toEqual({
+      left: { expression: 'stack.pop()', value: '[' },
+      operator: '!==',
+      right: { expression: 'pairs.get(char)', value: '(' },
+      result: true,
+    })
+    expect(comparisonStep?.variables.stack).toEqual(['('])
+  })
+
+  it('records empty-stack rejection before attempting to pop', () => {
+    const state = executeCode(validParenthesesCode, { s: ')(' }, 'isValid')
+    const comparisonIndex = state.steps.findIndex(
+      (step) =>
+        step.metadata?.comparison?.left.expression === 'stack.length' &&
+        step.metadata.comparison.operator === '===' &&
+        step.metadata.comparison.right.expression === '0'
+    )
+    const returnIndex = state.steps.findIndex(
+      (step, index) =>
+        index > comparisonIndex &&
+        step.type === STEP_TYPES.RETURN &&
+        step.variables[RETURN_VALUE_LABEL] === false
+    )
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(false)
+    expect(comparisonIndex).toBeGreaterThan(-1)
+    expect(state.steps[comparisonIndex]?.metadata?.comparison).toEqual({
+      left: { expression: 'stack.length', value: 0 },
+      operator: '===',
+      right: { expression: '0', value: 0 },
+      result: true,
+    })
+    expect(returnIndex).toBeGreaterThan(comparisonIndex)
+    expect(getStackPopComparisonStep(state)).toBeUndefined()
+  })
+
+  it('rejects unbalanced opening brackets', () => {
+    const state = executeCode(validParenthesesCode, { s: '((' }, 'isValid')
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(false)
+  })
 
   it('keeps successful Valid Parentheses execution unchanged', () => {
     const state = executeCode(validParenthesesCode, { s: '([])' }, 'isValid')


### PR DESCRIPTION
Close https://github.com/nyaomaru/dsa-view-view/issues/68

## Summary

Clarify empty stack handling in parentheses sample.

<!-- A brief summary of the changes -->

## Description

- add an explicit empty-stack check before `stack.pop()` in the Valid Parentheses sample
- align the external-algorithm fixture with the built-in sample

<!-- A detailed explanation of the changes, including why they are needed -->
