### PR TITLE
feat: add longest substring sliding window view

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -209,6 +209,34 @@ test('visualizes trapped rain water between height bars', async ({ page }) => {
   await expect(page.getByText('water=6')).toBeVisible()
 })
 
+test('tracks the longest substring with a half-open window', async ({ page }) => {
+  await page.goto('/')
+
+  await page.getByRole('combobox', { name: 'Example' }).click()
+  await page.getByLabel('Search examples').fill('longest substring')
+  await page
+    .getByRole('option', {
+      name: 'Longest Substring Without Repeating Characters',
+      exact: true,
+    })
+    .click()
+
+  await expect(page.getByText('Input Parameters')).toBeVisible()
+  await page.getByRole('button', { name: 'Run', exact: true }).click()
+  await expect(page.getByText('All execution steps')).toBeVisible()
+
+  const slidingWindowDialog = page.getByRole('dialog').filter({
+    has: page.getByRole('heading', { name: 'Sliding Window View: s' }),
+  })
+  await expect(slidingWindowDialog).toBeVisible()
+  await slidingWindowDialog.getByTitle('Skip to End').click()
+
+  await expect(slidingWindowDialog.getByText('range: [7, 8)')).toBeVisible()
+  await expect(slidingWindowDialog.getByText('set: {b}')).toBeVisible()
+  await expect(slidingWindowDialog.getByText('best: 3')).toBeVisible()
+  await expect(slidingWindowDialog.getByLabel('End boundary')).toHaveText('∅')
+})
+
 test('tracks maximum-subarray state at each array position', async ({
   page,
 }) => {

--- a/src/entities/algorithm-example/model/algorithm-example-sources.ts
+++ b/src/entities/algorithm-example/model/algorithm-example-sources.ts
@@ -303,6 +303,27 @@ export const ALGORITHM_EXAMPLE_SOURCES = {
 
   return answer
 }`,
+  'longest-substring-without-repeating-characters': `function lengthOfLongestSubstring(s: string): number {
+  const set = new Set<string>()
+  let left = 0
+  let right = 0
+  let best = 0
+
+  while (right < s.length) {
+    const char = s[right]
+
+    if (!set.has(char)) {
+      set.add(char)
+      right++
+      best = Math.max(best, right - left)
+    } else {
+      set.delete(s[left])
+      left++
+    }
+  }
+
+  return best
+}`,
   'trapping-rain-water': `function trap(height: number[]): number {
   let left = 0
   let right = height.length - 1

--- a/src/entities/algorithm-example/model/algorithm-example-sources.ts
+++ b/src/entities/algorithm-example/model/algorithm-example-sources.ts
@@ -304,20 +304,21 @@ export const ALGORITHM_EXAMPLE_SOURCES = {
   return answer
 }`,
   'longest-substring-without-repeating-characters': `function lengthOfLongestSubstring(s: string): number {
+  const chars = Array.from(s)
   const set = new Set<string>()
   let left = 0
   let right = 0
   let best = 0
 
-  while (right < s.length) {
-    const char = s[right]
+  while (right < chars.length) {
+    const char = chars[right]
 
     if (!set.has(char)) {
       set.add(char)
       right++
       best = Math.max(best, right - left)
     } else {
-      set.delete(s[left])
+      set.delete(chars[left])
       left++
     }
   }

--- a/src/entities/algorithm-example/model/algorithm-examples.test.ts
+++ b/src/entities/algorithm-example/model/algorithm-examples.test.ts
@@ -17,7 +17,7 @@ describe('algorithm examples', () => {
     }
   })
 
-  it('ships 40 examples', () => {
-    expect(ALGORITHM_EXAMPLES).toHaveLength(40)
+  it('ships 41 examples', () => {
+    expect(ALGORITHM_EXAMPLES).toHaveLength(41)
   })
 })

--- a/src/entities/algorithm-example/model/algorithm-examples.ts
+++ b/src/entities/algorithm-example/model/algorithm-examples.ts
@@ -19,6 +19,7 @@ const EXAMPLE_CATEGORY_BY_ID = new Map<AlgorithmExampleSourceId, string>([
   ['binary-search', 'Binary Search'],
   ['search-rotated-array', 'Binary Search'],
   ['product-except-self', 'Array'],
+  ['longest-substring-without-repeating-characters', 'Sliding Window'],
   ['bubble-sort', 'Sorting'],
   ['selection-sort', 'Sorting'],
   ['insertion-sort', 'Sorting'],
@@ -179,6 +180,17 @@ const ALGORITHM_EXAMPLE_DEFINITIONS: AlgorithmExampleDefinition[] = [
       nums: '[1, 2, 3, 4]',
     },
     sourceCode: ALGORITHM_EXAMPLE_SOURCES['product-except-self'],
+  },
+  {
+    id: 'longest-substring-without-repeating-characters',
+    label: 'Longest Substring Without Repeating Characters',
+    defaultInputValues: {
+      s: 'abcabcbb',
+    },
+    sourceCode:
+      ALGORITHM_EXAMPLE_SOURCES[
+        'longest-substring-without-repeating-characters'
+      ],
   },
   {
     id: 'trapping-rain-water',

--- a/src/features/code-execution/lib/longest-substring-visualization.integration.test.ts
+++ b/src/features/code-execution/lib/longest-substring-visualization.integration.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { ALGORITHM_EXAMPLES } from '@/entities/algorithm-example'
+import { getSlidingWindowVisualizationState } from '@/features/visualization/lib/sliding-window-view'
+import { getPrimaryVisualization } from '@/features/visualization/model/primary-visualization'
+import { detectVisualizationState } from '@/features/visualization/model/use-visualization-detection'
+
+import { executeCode } from './runner'
+
+const longestSubstringExample = ALGORITHM_EXAMPLES.find(
+  (example) =>
+    example.id === 'longest-substring-without-repeating-characters'
+)
+
+if (!longestSubstringExample) {
+  throw new Error('Longest Substring example is missing')
+}
+
+describe('Longest Substring visualization integration', () => {
+  it('tracks the half-open window, unique characters, and best length', () => {
+    const state = executeCode(
+      longestSubstringExample.sourceCode,
+      { s: 'abcabcbb' },
+      'lengthOfLongestSubstring'
+    )
+    const currentStep = state.steps.length - 1
+    const completedState = { ...state, currentStep }
+    const initialWindowStep = state.steps.findIndex(
+      (step) =>
+        step.variables.left === 0 &&
+        step.variables.right === 0 &&
+        step.variables.best === 0
+    )
+    const detection = detectVisualizationState(completedState)
+    const view = getSlidingWindowVisualizationState({
+      executionState: completedState,
+      variableName: 's',
+    })
+    const initialView = getSlidingWindowVisualizationState({
+      executionState: { ...state, currentStep: initialWindowStep },
+      variableName: 's',
+    })
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(3)
+    expect(initialWindowStep).toBeGreaterThan(-1)
+    expect(initialView?.windowState).toMatchObject({
+      left: 0,
+      right: 0,
+      rangeMode: 'half-open',
+      windowSize: 0,
+      setValues: [],
+      best: 0,
+    })
+    expect(view).toEqual({
+      data: 'abcabcbb',
+      windowState: {
+        left: 7,
+        right: 8,
+        rangeMode: 'half-open',
+        windowSize: 1,
+        pattern: undefined,
+        setValues: ['b'],
+        best: 3,
+      },
+    })
+    expect(detection).toMatchObject({
+      primarySlidingWindowStringName: 's',
+      primarySlidingWindowStepIndex: currentStep,
+    })
+    expect(getPrimaryVisualization(detection)).toEqual({
+      type: 'sliding-window',
+      targetVariable: 's',
+      targetStepIndex: currentStep,
+    })
+  })
+})

--- a/src/features/code-execution/lib/longest-substring-visualization.integration.test.ts
+++ b/src/features/code-execution/lib/longest-substring-visualization.integration.test.ts
@@ -74,4 +74,29 @@ describe('Longest Substring visualization integration', () => {
       targetStepIndex: currentStep,
     })
   })
+
+  it('keeps Unicode characters aligned with visualization cells', () => {
+    const state = executeCode(
+      longestSubstringExample.sourceCode,
+      { s: '😀😀' },
+      'lengthOfLongestSubstring'
+    )
+    const currentStep = state.steps.length - 1
+    const view = getSlidingWindowVisualizationState({
+      executionState: { ...state, currentStep },
+      variableName: 's',
+    })
+
+    expect(state.error).toBeUndefined()
+    expect(state.returnValue).toBe(1)
+    expect(Array.from(view?.data ?? '')).toHaveLength(2)
+    expect(view?.windowState).toMatchObject({
+      left: 1,
+      right: 2,
+      rangeMode: 'half-open',
+      windowSize: 1,
+      setValues: ['😀'],
+      best: 1,
+    })
+  })
 })

--- a/src/features/visualization/lib/sliding-window-view.test.ts
+++ b/src/features/visualization/lib/sliding-window-view.test.ts
@@ -78,4 +78,31 @@ describe('getSlidingWindowState', () => {
       best: 3,
     })
   })
+
+  it('validates boundaries using Unicode code points', () => {
+    expect(
+      getSlidingWindowState('😀😀', {
+        s: '😀😀',
+        set: new Set(['😀']),
+        left: 1,
+        right: 2,
+        best: 1,
+      })
+    ).toMatchObject({
+      left: 1,
+      right: 2,
+      rangeMode: 'half-open',
+      windowSize: 1,
+    })
+
+    expect(
+      getSlidingWindowState('😀😀', {
+        s: '😀😀',
+        set: new Set(['😀']),
+        left: 1,
+        right: 4,
+        best: 1,
+      })
+    ).toBeNull()
+  })
 })

--- a/src/features/visualization/lib/sliding-window-view.test.ts
+++ b/src/features/visualization/lib/sliding-window-view.test.ts
@@ -14,7 +14,68 @@ describe('getSlidingWindowState', () => {
     ).toEqual({
       left: 0,
       right: 5,
+      rangeMode: 'inclusive',
       pattern: 'ABC',
+    })
+  })
+
+  it('recognizes a half-open unique-character window', () => {
+    expect(
+      getSlidingWindowState('abba', {
+        s: 'abba',
+        set: new Set(['b', 'a']),
+        left: 2,
+        right: 4,
+        best: 2,
+      })
+    ).toEqual({
+      left: 2,
+      right: 4,
+      rangeMode: 'half-open',
+      windowSize: 2,
+      setValues: ['b', 'a'],
+      best: 2,
+    })
+  })
+
+  it('keeps array-length right bounds exclusive to Set-backed windows', () => {
+    expect(
+      getSlidingWindowState('abc', {
+        s: 'abc',
+        left: 0,
+        right: 3,
+      })
+    ).toBeNull()
+
+    expect(
+      getSlidingWindowState('abc', {
+        s: 'abc',
+        set: new Set(['a', 'b', 'c']),
+        left: 0,
+        right: 3,
+        best: 3,
+      })
+    ).toMatchObject({
+      right: 3,
+      rangeMode: 'half-open',
+    })
+  })
+
+  it('keeps Set-backed inclusive windows inclusive when their size matches', () => {
+    expect(
+      getSlidingWindowState('abc', {
+        s: 'abc',
+        set: new Set(['a', 'b', 'c']),
+        left: 0,
+        right: 2,
+        best: 3,
+      })
+    ).toMatchObject({
+      left: 0,
+      right: 2,
+      rangeMode: 'inclusive',
+      windowSize: 3,
+      best: 3,
     })
   })
 })

--- a/src/features/visualization/lib/sliding-window-view.ts
+++ b/src/features/visualization/lib/sliding-window-view.ts
@@ -71,14 +71,14 @@ function readUniqueCharacterSet(
 }
 
 function inferRangeMode(
-  value: string,
+  dataLength: number,
   left: number,
   right: number,
   setValues: readonly string[] | undefined
 ): SlidingWindowRangeMode {
   if (
     setValues !== undefined &&
-    (right === value.length || setValues.length === right - left)
+    (right === dataLength || setValues.length === right - left)
   ) {
     return 'half-open'
   }
@@ -106,7 +106,10 @@ function getTraceRangeMode(
       continue
     }
 
-    if (right === value.length || setValues.length === right - left) {
+    if (
+      right === Array.from(value).length ||
+      setValues.length === right - left
+    ) {
       return 'half-open'
     }
 
@@ -138,11 +141,12 @@ export function getSlidingWindowState(
     return null
   }
 
+  const dataLength = Array.from(value).length
   const rangeMode =
-    rangeModeOverride ?? inferRangeMode(value, left, right, setValues)
+    rangeModeOverride ?? inferRangeMode(dataLength, left, right, setValues)
 
   const maximumBoundary =
-    rangeMode === 'half-open' ? value.length : value.length - 1
+    rangeMode === 'half-open' ? dataLength : dataLength - 1
 
   if (
     left < 0 ||

--- a/src/features/visualization/lib/sliding-window-view.ts
+++ b/src/features/visualization/lib/sliding-window-view.ts
@@ -1,19 +1,32 @@
 import type { ExecutionState, ExecutionStep } from '@/entities/execution'
-import { isInteger, isNull, isString } from '@/shared/lib/guards'
+import {
+  isInteger,
+  isNull,
+  isSet,
+  isString,
+  isStringArray,
+} from '@/shared/lib/guards'
 
 const STRING_SOURCE_NAMES = new Set(['s', 'str', 'text'])
 const PATTERN_SOURCE_NAMES = ['p', 'pattern', 't', 'word'] as const
+type SlidingWindowRangeMode = 'inclusive' | 'half-open'
 
 /** Window boundaries and optional pattern metadata for one execution step. */
 export type SlidingWindowState = {
   /** Inclusive left boundary. */
   left: number
-  /** Inclusive right boundary. */
+  /** Inclusive right boundary, or exclusive boundary in half-open mode. */
   right: number
-  /** Optional algorithm-provided window size. */
+  /** Whether the window includes or excludes its right boundary. */
+  rangeMode: SlidingWindowRangeMode
+  /** Current window size when available. */
   windowSize?: number
   /** Optional pattern used by the window algorithm. */
   pattern?: string
+  /** Optional set of unique characters currently in the window. */
+  setValues?: readonly string[]
+  /** Best window length found so far. */
+  best?: number
 }
 
 /** Source string and boundaries required by the sliding-window visualization. */
@@ -44,6 +57,65 @@ function readPattern(
   return undefined
 }
 
+function readUniqueCharacterSet(
+  variables: ExecutionStep['variables']
+): readonly string[] | undefined {
+  const set = variables.set
+  const best = variables.best
+
+  if (!isSet(set) || !isInteger(best) || best < 0) return undefined
+
+  const values = Array.from(set)
+
+  return isStringArray(values) ? values : undefined
+}
+
+function inferRangeMode(
+  value: string,
+  left: number,
+  right: number,
+  setValues: readonly string[] | undefined
+): SlidingWindowRangeMode {
+  if (
+    setValues !== undefined &&
+    (right === value.length || setValues.length === right - left)
+  ) {
+    return 'half-open'
+  }
+
+  return 'inclusive'
+}
+
+function getTraceRangeMode(
+  executionState: ExecutionState,
+  variableName: string
+): SlidingWindowRangeMode | undefined {
+  for (let index = executionState.steps.length - 1; index >= 0; index--) {
+    const variables = executionState.steps[index]?.variables
+    const value = variables?.[variableName]
+    const left = variables?.left ?? variables?.l
+    const right = variables?.right ?? variables?.r
+    const setValues = variables && readUniqueCharacterSet(variables)
+
+    if (
+      !isString(value) ||
+      !isInteger(left) ||
+      !isInteger(right) ||
+      setValues === undefined
+    ) {
+      continue
+    }
+
+    if (right === value.length || setValues.length === right - left) {
+      return 'half-open'
+    }
+
+    if (setValues.length === right - left + 1) return 'inclusive'
+  }
+
+  return undefined
+}
+
 /**
  * Derives valid sliding-window boundaries from a value and execution variables.
  *
@@ -53,18 +125,31 @@ function readPattern(
  */
 export function getSlidingWindowState(
   value: unknown,
-  variables: ExecutionStep['variables']
+  variables: ExecutionStep['variables'],
+  rangeModeOverride?: SlidingWindowRangeMode
 ): SlidingWindowState | null {
   if (!isString(value) || value.length === 0) return null
 
   const left = variables.left ?? variables.l
   const right = variables.right ?? variables.r
+  const setValues = readUniqueCharacterSet(variables)
 
   if (!isInteger(left) || !isInteger(right)) {
     return null
   }
 
-  if (left < 0 || right < 0 || left >= value.length || right >= value.length) {
+  const rangeMode =
+    rangeModeOverride ?? inferRangeMode(value, left, right, setValues)
+
+  const maximumBoundary =
+    rangeMode === 'half-open' ? value.length : value.length - 1
+
+  if (
+    left < 0 ||
+    right < 0 ||
+    left > maximumBoundary ||
+    right > maximumBoundary
+  ) {
     return null
   }
 
@@ -75,8 +160,19 @@ export function getSlidingWindowState(
   return {
     left,
     right,
-    windowSize: readWindowSize(variables),
+    rangeMode,
+    windowSize:
+      rangeMode === 'half-open'
+        ? right - left
+        : setValues !== undefined
+          ? right - left + 1
+          : readWindowSize(variables),
     pattern: readPattern(variables),
+    setValues,
+    best:
+      setValues !== undefined && isInteger(variables.best)
+        ? variables.best
+        : undefined,
   }
 }
 
@@ -113,19 +209,22 @@ export function getSlidingWindowVisualizationState({
   variableName: string
   targetStepIndex?: number
 }): SlidingWindowVisualizationState | null {
+  const rangeMode = getTraceRangeMode(executionState, variableName)
   const currentStep = executionState.steps[executionState.currentStep]
   const fallbackStep =
     executionState.steps[targetStepIndex ?? executionState.currentStep]
   const currentValue = currentStep?.variables[variableName]
   const currentWindowState =
-    currentStep && getSlidingWindowState(currentValue, currentStep.variables)
+    currentStep &&
+    getSlidingWindowState(currentValue, currentStep.variables, rangeMode)
   const windowStep = currentWindowState ? currentStep : fallbackStep
   const data = windowStep?.variables[variableName]
 
   if (!isString(data) || !windowStep) return null
 
   const windowState =
-    currentWindowState ?? getSlidingWindowState(data, windowStep.variables)
+    currentWindowState ??
+    getSlidingWindowState(data, windowStep.variables, rangeMode)
 
   return isNull(windowState) ? null : { data, windowState }
 }

--- a/src/features/visualization/ui/sliding-window-visualizer.test.tsx
+++ b/src/features/visualization/ui/sliding-window-visualizer.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { SlidingWindowVisualizer } from './sliding-window-visualizer'
+
+describe('SlidingWindowVisualizer', () => {
+  it('shows half-open window state through the end boundary', () => {
+    render(
+      <SlidingWindowVisualizer
+        data="abc"
+        name="s"
+        windowState={{
+          left: 0,
+          right: 3,
+          rangeMode: 'half-open',
+          windowSize: 3,
+          setValues: ['a', 'b', 'c'],
+          best: 3,
+        }}
+      />
+    )
+
+    expect(screen.getByText('range: [0, 3)')).toBeInTheDocument()
+    expect(screen.getByText('size: 3')).toBeInTheDocument()
+    expect(screen.getByText('set: {a, b, c}')).toBeInTheDocument()
+    expect(screen.getByText('best: 3')).toBeInTheDocument()
+    expect(screen.getByLabelText('End boundary')).toHaveTextContent('∅')
+    expect(screen.getByText('R')).toBeInTheDocument()
+  })
+})

--- a/src/features/visualization/ui/sliding-window-visualizer.tsx
+++ b/src/features/visualization/ui/sliding-window-visualizer.tsx
@@ -26,6 +26,8 @@ export function SlidingWindowVisualizer({
   windowState,
 }: SlidingWindowVisualizerProps) {
   const chars = Array.from(data)
+  const isHalfOpen = windowState.rangeMode === 'half-open'
+  const cellCount = chars.length + (isHalfOpen ? 1 : 0)
 
   return (
     <Card className="h-full border-0 shadow-none">
@@ -38,6 +40,11 @@ export function SlidingWindowVisualizer({
             <span className="border border-primary px-2 py-1">
               right: {windowState.right}
             </span>
+            {isHalfOpen && (
+              <span className="border border-primary px-2 py-1">
+                range: [{windowState.left}, {windowState.right})
+              </span>
+            )}
             {windowState.windowSize !== undefined && (
               <span className="border border-primary px-2 py-1">
                 size: {windowState.windowSize}
@@ -48,6 +55,16 @@ export function SlidingWindowVisualizer({
                 pattern: {windowState.pattern}
               </span>
             )}
+            {windowState.setValues !== undefined && (
+              <span className="border border-primary px-2 py-1">
+                set: {'{'}{windowState.setValues.join(', ')}{'}'}
+              </span>
+            )}
+            {windowState.best !== undefined && (
+              <span className="border border-primary px-2 py-1">
+                best: {windowState.best}
+              </span>
+            )}
           </div>
         </div>
 
@@ -55,12 +72,15 @@ export function SlidingWindowVisualizer({
           <div
             className="mx-auto grid min-w-max gap-2 px-2"
             style={{
-              gridTemplateColumns: `repeat(${chars.length}, minmax(3rem, 1fr))`,
+              gridTemplateColumns: `repeat(${cellCount}, minmax(3rem, 1fr))`,
             }}
           >
             {chars.map((char, index) => {
               const isInWindow =
-                index >= windowState.left && index <= windowState.right
+                index >= windowState.left &&
+                (isHalfOpen
+                  ? index < windowState.right
+                  : index <= windowState.right)
               const isBoundary =
                 index === windowState.left || index === windowState.right
 
@@ -69,11 +89,13 @@ export function SlidingWindowVisualizer({
                   <div
                     className={[
                       'flex h-14 w-full min-w-12 items-center justify-center border font-mono text-base font-bold transition-colors',
-                      isBoundary
+                      isBoundary && isInWindow
                         ? 'border-primary bg-primary text-background'
-                        : isInWindow
-                          ? 'border-primary bg-primary/20 text-primary'
-                          : 'border-muted-foreground/40 bg-background text-muted-foreground/60',
+                        : isBoundary
+                          ? 'border-primary bg-background text-primary'
+                          : isInWindow
+                            ? 'border-primary bg-primary/20 text-primary'
+                            : 'border-muted-foreground/40 bg-background text-muted-foreground/60',
                     ].join(' ')}
                   >
                     {char}
@@ -87,6 +109,27 @@ export function SlidingWindowVisualizer({
                 </div>
               )
             })}
+            {isHalfOpen && (
+              <div className="flex flex-col items-center gap-2">
+                <div
+                  aria-label="End boundary"
+                  className={[
+                    'flex h-14 w-full min-w-12 items-center justify-center border font-mono text-base font-bold transition-colors',
+                    windowState.right === chars.length
+                      ? 'border-primary bg-background text-primary'
+                      : 'border-muted-foreground/40 bg-background text-muted-foreground/60',
+                  ].join(' ')}
+                >
+                  ∅
+                </div>
+                <div className="font-mono text-xs text-muted-foreground">
+                  {chars.length}
+                </div>
+                <div className="h-5 font-mono text-[0.6875rem] font-bold text-primary">
+                  {getMarkerLabel(chars.length, windowState)}
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Add longest substring sliding window view.

<!-- A brief summary of the changes -->

## Description

- add Longest Substring Without Repeating Characters as a built-in sample
- support half-open `[left, right)` ranges in Sliding Window View
- display the current Set, window size, and best length

<!-- A detailed explanation of the changes, including why they are needed -->
